### PR TITLE
Fixed MD indentations and code format

### DIFF
--- a/docs/spfx/set-up-your-developer-tenant.md
+++ b/docs/spfx/set-up-your-developer-tenant.md
@@ -14,62 +14,62 @@ If you don't have one, sign up for the [Office Developer Program](https://profil
 ## Create app catalog site
 You will need an app catalog to upload and deploy web parts. If you've already set up an app catalog, see [create a new Developer Site collection](#create-a-new-developer-site-collection).  
 
-1. Go to the **SharePoint Admin Center** by entering the following URL in your browser. Replace **yourtenantprefix** with your Office 365 Developer Tenant prefix.
+Go to the **SharePoint Admin Center** by entering the following URL in your browser. Replace **yourtenantprefix** with your Office 365 Developer Tenant prefix.
 	
-	```
-	https://yourtenantprefix-admin.sharepoint.com
-	```
+```
+https://yourtenantprefix-admin.sharepoint.com
+```
 	
-2. In the left sidebar, choose the **apps** menu item and then choose **App Catalog**.
+In the left sidebar, choose the **apps** menu item and then choose **App Catalog**.
 
-3. Choose **OK** to create a new app catalog site.
+Choose **OK** to create a new app catalog site.
 
-3. In the next page, enter the following details:
-   * **Title**: Enter **App Catalog**.
-   * **Web Site Address _suffix_**: Enter your preferred suffix for app catalog; for example: **apps**.
-   * **Administrator**: Enter your username and choose the **resolve** button to resolve the username.
+In the next page, enter the following details:
+* **Title**: Enter **App Catalog**.
+* **Web Site Address _suffix_**: Enter your preferred suffix for app catalog; for example: **apps**.
+* **Administrator**: Enter your username and choose the **resolve** button to resolve the username.
 
-4. Choose **OK** to create the app catalog site.
+Choose **OK** to create the app catalog site.
 
 SharePoint will create the app catalog site and you will be able to see its progress in the SharePoint admin center.
 
 ## Create a new Developer Site collection
 You also need a Developer Site. If you already have a Developer Site collection, see [Set up a document library](#set-up-a-document-library).
 
-1. Go to the **SharePoint Admin Center** by entering the following URL in your browser. Replace **yourtenantprefix** with your Office 365 Developer Tenant prefix.
+ Go to the **SharePoint Admin Center** by entering the following URL in your browser. Replace **yourtenantprefix** with your Office 365 Developer Tenant prefix.
 	
-	```
-	https://yourtenantprefix-admin.sharepoint.com
-	```
+```
+https://yourtenantprefix-admin.sharepoint.com
+```
 	
-2. In the SharePoint ribbon, choose **New** -> **Private Site Collection**.
+In the SharePoint ribbon, choose **New** -> **Private Site Collection**.
 
-3. In the dialog box, enter the following details:
-   * **Title**: Enter a title for your developer site collection; for example: **Developer Site**.
-   * **Web Site Address _suffix_**: Enter a suffix for your developer site collection; for example: **dev**.
-   * **Template Selection**: Select **Developer Site** as the site collection template.
-   * **Administrator**: Enter your username and choose the **resolve** button to resolve the username.
+In the dialog box, enter the following details:
+* **Title**: Enter a title for your developer site collection; for example: **Developer Site**.
+* **Web Site Address _suffix_**: Enter a suffix for your developer site collection; for example: **dev**.
+* **Template Selection**: Select **Developer Site** as the site collection template.
+* **Administrator**: Enter your username and choose the **resolve** button to resolve the username.
 
-4. Choose **OK** to create the site collection.
+Choose **OK** to create the site collection.
 
 SharePoint will create the developer site and you will be able to see its progress in the SharePoint admin center. After the site is created, you can browse to your developer site collection.
 
 ## Set up a document library
 In order to use the preview features, you will need to set up a document library with a new column and upload SharePoint workbench. This procedure uses the default document library in your developer site collection. This will be called **Documents** in the left navigation.
 
-1. Choose the gears icon on the top right and then choose **Site settings** to open the settings page.
-2. Choose **Site libraries and lists** under the **Site Administration** category.
-3. Choose **Customize Documents**
-4. Choose **Create column** under **Columns**
-5. Enter **ClientSideApplicationId** as the column name and leave the other fields at their current values.
-6. Choose **OK** to create the column.
+* Choose the gears icon on the top right and then choose **Site settings** to open the settings page.
+* Choose **Site libraries and lists** under the **Site Administration** category.
+* Choose **Customize Documents**
+* Choose **Create column** under **Columns**
+* Enter **ClientSideApplicationId** as the column name and leave the other fields at their current values.
+* Choose **OK** to create the column.
 
 ## Upload the SharePoint workbench
 You need to upload the SharePoint workbench to test your web parts on SharePoint. 
 
-1. Download the [workbench.aspx](https://github.com/SharePoint/sp-dev-docs/blob/master/workbench.aspx) file to your local computer. To do this:
+* Download the [workbench.aspx](https://github.com/SharePoint/sp-dev-docs/blob/master/workbench.aspx) file to your local computer. To do this:
 	- Open the context menu (right-click) on the "raw" link in the middle of the page and choose **Save Target As** or **Save Link As** (depending on your browser) to save the file as **workbench.aspx** to your local computer. 
-2. Upload the file to the **Documents** library in the dev site collection.
+* Upload the file to the **Documents** library in the dev site collection.
 
 ##Troubleshooting
 If you get the following exception when moving to the workbench.aspx page: 

--- a/docs/spfx/set-up-your-development-environment.md
+++ b/docs/spfx/set-up-your-development-environment.md
@@ -6,32 +6,45 @@ You can use Visual Studio, or your own custom development environment to build S
 
 ## Install developer tools
 
-* Install [Node.js](https://nodejs.org/en/) Long Term Support (LTS) version. If you already installed Node.js please check that you have the latest version using `node -v`. It should return the current [LTS version](https://nodejs.org/en/download/). 
+### NodeJS
+Install [NodeJS](https://nodejs.org/en/) Long Term Support (LTS) version.
+* If you have NodeJS already installed please check you have the latest version using `node -v`. It should return the current [LTS version](https://nodejs.org/en/download/). 
+* If you are using a Mac, it is recommended you use [homebrew](http://brew.sh/) to install and manage NodeJS. 
 
->**Note:** If you are using a Mac, it is recommended you use [homebrew](http://brew.sh/) to install and manage Node.js. 
+After installing node, make sure you are running V3 or higher of npm by running the following command:
 	
-* Install a code editor. The steps and examples in this documentation use [Visual Studio Code](https://code.visualstudio.com/), but you can use any editor of your choice. 
+```
+npm -g install npm@next
+```
 
-* Make sure you are running V3 of npm by running the following command:
-	
-```npm -g install npm@next```
+### Code Editors
+Install a code editor. You can use any code editor or IDE that supports client-side development to build your web part, such as:
+* [Visual Studio Code](https://code.visualstudio.com/)
+* [Sublime](https://www.sublimetext.com/)
+* [Atom](https://atom.io)
+* [Webstorm](https://www.jetbrains.com/webstorm) 
+
+The steps and examples in this documentation use [Visual Studio Code](https://code.visualstudio.com/), but you can use any editor of your choice. 
 
 ### If you're using a PC
 
-* You need to install Python. Run the following command:
+You need to install *windows-build-tools*. windows-build-tools will install Visual C++ Build Tools 2015, provided free of charge by Microsoft. These tools are required to compile popular native modules. It will also install Python 2.7, configuring your computer and npm appropriately. 
+
+Run the following command:
 	
-```npm install --global --production windows-build-tools```
-	
-windows-build-tools will install Visual C++ Build Tools 2015, provided free of charge by Microsoft. These tools are required to compile popular native modules. It will also install Python 2.7, configuring your computer and npm appropriately. 
-	
-* If you want to use Visual Studio as your development environment, install the following required tools and updates:
-    * [Visual Studio 2015](https://go.microsoft.com/fwlink/?LinkId=691978&clcid=0x409)
-    * [Visual Studio Update 3](https://www.visualstudio.com/en-us/news/releasenotes/vs2015-update3-vs) or later
-    * [Node.js Tools for Visual Studio](https://aka.ms/getntvs)
+```
+npm install --global --production windows-build-tools
+```
+
+#### If you are using Visual Studio	
+If you want to use Visual Studio as your development environment, install the following required tools and updates:
+* [Visual Studio 2015](https://go.microsoft.com/fwlink/?LinkId=691978&clcid=0x409)
+* [Visual Studio Update 3](https://www.visualstudio.com/en-us/news/releasenotes/vs2015-update3-vs) or later
+* [Node.js Tools for Visual Studio](https://aka.ms/getntvs)
 
 ### If you are using Ubuntu
 
-* You need to install compiler tools using the following command:
+You need to install compiler tools using the following command:
 	
 ```
 sudo apt-get build-essential
@@ -39,26 +52,17 @@ sudo apt-get build-essential
 
 ### If you are using fedora
 
-* You need to install compiler tools using the following command:
+You need to install compiler tools using the following command:
 	
 ```
 sudo yum install make automake gcc gcc-c++ kernel-devel
 ```
 
-### Optional tools
-
-Here are some tools that might come in handy as well:
-* [Fiddler](http://www.telerik.com/fiddler)
-* [Postman plugin for Chrome](https://www.getpostman.com/docs/introduction)
-* [Cmder for Windows](http://cmder.net/)
-* [Oh My Zsh for Mac](http://ohmyz.sh/)
-* [Git source control tools](https://git-scm.com/)
-
 ## Install Yeoman and gulp
 
 [Yeoman](http://yeoman.io/) helps you kick-start new projects, and prescribes best practices and tools to help you stay productive. SharePoint client-side development tools include a Yeoman generator for creating new web parts. The generator provides common build tools, common boilerplate code, and a common playground web site to host web parts for testing.
 
-* Enter the following command to install Yeoman and gulp:
+Enter the following command to install Yeoman and gulp:
 	
 ```
 npm i -g yo gulp
@@ -73,6 +77,15 @@ The Yeoman SharePoint web part generator helps you quickly create a SharePoint c
 ```
 npm i -g @microsoft/generator-sharepoint 
 ```
+
+## Optional tools
+
+Here are some tools that might come in handy as well:
+* [Fiddler](http://www.telerik.com/fiddler)
+* [Postman plugin for Chrome](https://www.getpostman.com/docs/introduction)
+* [Cmder for Windows](http://cmder.net/)
+* [Oh My Zsh for Mac](http://ohmyz.sh/)
+* [Git source control tools](https://git-scm.com/)
 
 ## Next steps
 

--- a/docs/spfx/set-up-your-development-environment.md
+++ b/docs/spfx/set-up-your-development-environment.md
@@ -72,7 +72,7 @@ npm i -g yo gulp
 
 The Yeoman SharePoint web part generator helps you quickly create a SharePoint client-side solution project with the right toolchain and project structure.
 
-* Enter the following command to install the Yeoman SharePoint generator:
+Enter the following command to install the Yeoman SharePoint generator:
 	
 ```
 npm i -g @microsoft/generator-sharepoint 

--- a/docs/spfx/set-up-your-development-environment.md
+++ b/docs/spfx/set-up-your-development-environment.md
@@ -6,48 +6,48 @@ You can use Visual Studio, or your own custom development environment to build S
 
 ## Install developer tools
 
-1. Install [Node.js](https://nodejs.org/en/) Long Term Support (LTS) version. If you already installed Node.js please check that you have the latest version using `node -v`. It should return the current [LTS version](https://nodejs.org/en/download/). 
-	>**Note:** If you are using a Mac, it is recommended you use [homebrew](http://brew.sh/) to install and manage Node.js. 
-	
-2. Install a code editor. The steps and examples in this documentation use [Visual Studio Code](https://code.visualstudio.com/), but you can use any editor of your choice. 
+* Install [Node.js](https://nodejs.org/en/) Long Term Support (LTS) version. If you already installed Node.js please check that you have the latest version using `node -v`. It should return the current [LTS version](https://nodejs.org/en/download/). 
 
-3. Make sure you are running V3 of npm by running the following command:
+>**Note:** If you are using a Mac, it is recommended you use [homebrew](http://brew.sh/) to install and manage Node.js. 
 	
-	```npm -g install npm@next```
+* Install a code editor. The steps and examples in this documentation use [Visual Studio Code](https://code.visualstudio.com/), but you can use any editor of your choice. 
+
+* Make sure you are running V3 of npm by running the following command:
+	
+```npm -g install npm@next```
 
 ### If you're using a PC
 
-1. You need to install Python. Run the following command:
+* You need to install Python. Run the following command:
 	
-	```npm install --global --production windows-build-tools```
+```npm install --global --production windows-build-tools```
 	
-	windows-build-tools will install Visual C++ Build Tools 2015, provided free of charge by Microsoft. These tools are required to compile popular native modules. It will also install Python 2.7, configuring your computer and npm appropriately. 
+windows-build-tools will install Visual C++ Build Tools 2015, provided free of charge by Microsoft. These tools are required to compile popular native modules. It will also install Python 2.7, configuring your computer and npm appropriately. 
 	
-2. If you want to use Visual Studio as your development environment, install the following required tools and updates:
-	* [Visual Studio 2015](https://go.microsoft.com/fwlink/?LinkId=691978&clcid=0x409)
-	* [Visual Studio Update 3](https://www.visualstudio.com/en-us/news/releasenotes/vs2015-update3-vs) or later
-	* [Node.js Tools for Visual Studio](https://aka.ms/getntvs)
+* If you want to use Visual Studio as your development environment, install the following required tools and updates:
+    * [Visual Studio 2015](https://go.microsoft.com/fwlink/?LinkId=691978&clcid=0x409)
+    * [Visual Studio Update 3](https://www.visualstudio.com/en-us/news/releasenotes/vs2015-update3-vs) or later
+    * [Node.js Tools for Visual Studio](https://aka.ms/getntvs)
 
 ### If you are using Ubuntu
 
 * You need to install compiler tools using the following command:
 	
-	```
-	sudo apt-get build-essential
-	```
+```
+sudo apt-get build-essential
+```
 
 ### If you are using fedora
 
 * You need to install compiler tools using the following command:
 	
-	```
-	sudo yum install make automake gcc gcc-c++ kernel-devel
-	```
+```
+sudo yum install make automake gcc gcc-c++ kernel-devel
+```
 
 ### Optional tools
 
-Here are some tools that might come in handy as well.
-
+Here are some tools that might come in handy as well:
 * [Fiddler](http://www.telerik.com/fiddler)
 * [Postman plugin for Chrome](https://www.getpostman.com/docs/introduction)
 * [Cmder for Windows](http://cmder.net/)
@@ -60,9 +60,9 @@ Here are some tools that might come in handy as well.
 
 * Enter the following command to install Yeoman and gulp:
 	
-	```
-	npm i -g yo gulp
-	```
+```
+npm i -g yo gulp
+```
 
 ## Install Yeoman SharePoint generator
 
@@ -70,9 +70,9 @@ The Yeoman SharePoint web part generator helps you quickly create a SharePoint c
 
 * Enter the following command to install the Yeoman SharePoint generator:
 	
-	```
-	npm i -g @microsoft/generator-sharepoint 
-	```
+```
+npm i -g @microsoft/generator-sharepoint 
+```
 
 ## Next steps
 

--- a/docs/spfx/web-parts/get-started/add-jqueryui-accordion-to-web-part.md
+++ b/docs/spfx/web-parts/get-started/add-jqueryui-accordion-to-web-part.md
@@ -20,28 +20,27 @@ The developer toolchain uses Webpack, SystemJS and CommonJS to bundle your web p
 
 ## Create a new web part project
 
-1. Create a new project directory in your favorite location:
+Create a new project directory in your favorite location:
 
-	```
-	md jquery-webpart
-	```
+```
+md jquery-webpart
+```
     
 	> **Warning:** Make sure to create this directory in a new folder, not as a subdirectory of `helloworld-webpart`.
 
-2. Go to the project directory:
+Go to the project directory:
 
-	```
-	cd jquery-webpart
-	```
+```
+cd jquery-webpart
+```
     
-3. Create a new jQuery web part by running the Yeoman SharePoint Generator:
+Create a new jQuery web part by running the Yeoman SharePoint Generator:
 
-	```
-	yo @microsoft/sharepoint
-	```
+```
+yo @microsoft/sharepoint
+```
 
 When prompted:
-
 * Accept the default **jquery-webpart** as your solution name and choose **Enter**.
 * Select **Use the current folder** as the location for the files.
 
@@ -53,25 +52,25 @@ The next set of prompts will ask for specific information about your web part:
 
 At this point, Yeoman will install the required dependencies and scaffold the solution files. This might take a few minutes. Yeoman will scaffold the project to include your **jQueryWebPart** web part as well.
 
-4. In the console, type the following to open the web part project in Visual Studio Code:
+In the console, type the following to open the web part project in Visual Studio Code:
 
-	```
-	code .
-	```
+```
+code .
+```
 
 ## Install jQuery and jQuery UI NPM Packages
 
-1. In the console, type the following to install jQuery npm package:
+In the console, type the following to install jQuery npm package:
 
-	```
-	npm i --save jquery
-	```
+```
+npm i --save jquery
+```
 
-2. Now type the following to install jQueryUI npm package:
+ Now type the following to install jQueryUI npm package:
 
-	```
-	npm i --save jqueryui
-	```
+```
+npm i --save jqueryui
+```
 
 TypeScript Definition Manager (TSD) allows you to search and install type definitions for your project. Use TSD to install the type definitions for jQuery and jQuery UI.
 
@@ -258,7 +257,6 @@ public constructor(context: IWebPartContext){
 ```
 
 This code does the following:
-
 * Calls the parent constructor with the context to initialize the web part.
 * Loads the accordion styles from a CDN asynchronously.
 

--- a/docs/spfx/web-parts/get-started/build-a-hello-world-web-part.md
+++ b/docs/spfx/web-parts/get-started/build-a-hello-world-web-part.md
@@ -31,12 +31,10 @@ yo @microsoft/sharepoint
 ```
     
 When prompted:
-
 * Accept the default **helloworld-webpart** as your solution name and choose **Enter**.
 * Select **Use the current folder** for where to place the files.
 
 The next set of prompts will ask for specific information about your web part:
-
 * Accept the default **HelloWorld** as your web part name and choose **Enter**.
 * Accept the default **HelloWorld description** as your web part description and choose **Enter**.
 * Accept the default **No javascript web framework** as the framework you would like to use and choose **Enter**.
@@ -67,7 +65,7 @@ Currently, support for SharePoint client-side projects in Visual Studio is avail
 ## Preview the web part
 To preview your web part, build and run it on a local web server. 
 
-* Switch to your console, make sure you are still in the **helloworld-webpart** directory and enter the following command to build and preview your web part:
+Switch to your console, make sure you are still in the **helloworld-webpart** directory and enter the following command to build and preview your web part:
 
 ```
 gulp serve

--- a/docs/spfx/web-parts/get-started/build-a-hello-world-web-part.md
+++ b/docs/spfx/web-parts/get-started/build-a-hello-world-web-part.md
@@ -12,34 +12,34 @@ Client-side web parts support:
 >**Note:** Before following the steps in this article, be sure to [Set up your development environment](../../set-up-your-development-environment).
     
 ## Create a new web part project
-1. Create a new project directory in your favorite location.
+Create a new project directory in your favorite location.
 	
-	   ```
-	   md helloworld-webpart
-	   ```
+```
+md helloworld-webpart
+```
 
-2. Go to the project directory.
+Go to the project directory.
 
-	   ```
-	   cd helloworld-webpart
-	   ```
+```
+cd helloworld-webpart
+```
 
-3. Create a new HelloWorld web part by running the Yeoman SharePoint Generator.
+Create a new HelloWorld web part by running the Yeoman SharePoint Generator.
 
-	   ```
-	   yo @microsoft/sharepoint
-	   ```
+```
+yo @microsoft/sharepoint
+```
     
 When prompted:
 
-4. Accept the default **helloworld-webpart** as your solution name and choose **Enter**.
-5. Select **Use the current folder** for where to place the files.
+* Accept the default **helloworld-webpart** as your solution name and choose **Enter**.
+* Select **Use the current folder** for where to place the files.
 
 The next set of prompts will ask for specific information about your web part:
 
-6.  Accept the default **HelloWorld** as your web part name and choose **Enter**.
-7.  Accept the default **HelloWorld description** as your web part description and choose **Enter**.
-8.  Accept the default **No javascript web framework** as the framework you would like to use and choose **Enter**.
+* Accept the default **HelloWorld** as your web part name and choose **Enter**.
+* Accept the default **HelloWorld description** as your web part description and choose **Enter**.
+* Accept the default **No javascript web framework** as the framework you would like to use and choose **Enter**.
 
 ![Yeoman SharePoint generator prompts to create a web part client-side solution](../../../../images/yeoman-sp-prompts.png)
 
@@ -80,7 +80,6 @@ This command will execute a series of gulp tasks to create a local, Node-based H
 >**Note:** If you get the error **cannot find module es6-promise**, run the following command in the project folder to install the es-promise npm module: `npm i es6-promise` and then run `gulp serve` again.
 
 SharePoint client-side development tools use [gulp](http://gulpjs.com/) as the task runner to handle build process tasks such as:
-
 * Bundle and minify JavaScript and CSS files.
 * Run tools to call the bundling and minification tasks before each build.
 * Compile SASS files to CSS.
@@ -95,41 +94,41 @@ SharePoint workbench is a developer design surface that enables you to quickly p
 
 ![SharePoint workbench running locally](../../../../images/sp-workbench.png)
 
-1. To add the HelloWorld web part, choose the **add** button. The add button opens the toolbox where you can see a list of web parts available for you to add. The list will include the **HelloWorld** web part as well other web parts available locally in your development environment.
+To add the HelloWorld web part, choose the **add** button. The add button opens the toolbox where you can see a list of web parts available for you to add. The list will include the **HelloWorld** web part as well other web parts available locally in your development environment.
    
-   ![SharePoint workbench toolbox in localhost](../../../../images/sp-workbench-toolbox.png)
+![SharePoint workbench toolbox in localhost](../../../../images/sp-workbench-toolbox.png)
    
-2. Choose **HelloWorld** to add the web part to the page:
+Choose **HelloWorld** to add the web part to the page:
    
-   ![HelloWorld web part in SharePoint workbench](../../../../images/sp-workbench-helloworld-wp.png)
-   
-   Congratulations! You have just added your first client-side web part to a client-side page.
-   
-3. Now, choose the pencil icon on the far left of the web part to reveal the web part property pane.
-   
-   ![HelloWorld web part property pane](../../../../images/sp-workbench-helloworld-pp.png)
-   
-   The property pane is where you can define properties to customize your web part. The property pane is client-side driven and provides a consistent design across SharePoint. 
-   
-4. Modify the text in the **Description** text box to **Client-side web parts are awesome!**
+![HelloWorld web part in SharePoint workbench](../../../../images/sp-workbench-helloworld-wp.png)
 
-   Notice how the text in the web part also changes as you type. 
+Congratulations! You have just added your first client-side web part to a client-side page.
+   
+Now, choose the pencil icon on the far left of the web part to reveal the web part property pane.
+   
+![HelloWorld web part property pane](../../../../images/sp-workbench-helloworld-pp.png)
+
+The property pane is where you can define properties to customize your web part. The property pane is client-side driven and provides a consistent design across SharePoint. 
+   
+Modify the text in the **Description** text box to **Client-side web parts are awesome!**
+
+Notice how the text in the web part also changes as you type. 
 
 One of the new capabilities available to the property pane is to configure its update behavior, which can be set to reactive or non-reactive. By default the update behavior is reactive and enables you to see the changes as you edit the properties. The changes are saved instantly as when the behavior is reactive.  
 
 ## Web part project structure
 You can use Visual Studio Code to explore the web part project structure. 
 
-1. In the console, go to the **src\webparts\helloWorld** directory. 
-2. Enter the following command to open the web part project in Visual Studio Code (or use your favorite editor):
+* In the console, go to the **src\webparts\helloWorld** directory. 
+* Enter the following command to open the web part project in Visual Studio Code (or use your favorite editor):
 
-   ```
-   code .
-   ```
+```
+code .
+```
 
-   ![HelloWorld project structure](../../../../images/helloworld-wp-vscode-project-structure.png)
+![HelloWorld project structure](../../../../images/helloworld-wp-vscode-project-structure.png)
 
-   If you get an error, you might need to [install the code command in PATH](https://code.visualstudio.com/docs/editor/setup).
+If you get an error, you might need to [install the code command in PATH](https://code.visualstudio.com/docs/editor/setup).
 
 TypeScript is the primary language for building SharePoint client-side web parts. TypeScript is a typed superset of JavaScript that compiles to plain JavaScript. SharePoint client-side development tools are built using TypeScript classes, modules, and interfaces to help developers build robust client-side web parts. 
 
@@ -203,115 +202,115 @@ When the properties are defined, you can access them in your web part using `thi
 
 Read the [Integrating property pane with a web part](../basics/integrate-with-property-pane) article to learn more about how to work with the property pane and property pane field types.
 
-1. Replace the **propertyPaneSettings** method with the code below which shows how to add property types other than TextField. 
+Replace the **propertyPaneSettings** method with the code below which shows how to add property types other than TextField. 
 
-   ```ts
-   protected get propertyPaneSettings(): IPropertyPaneSettings {
-     return {
-       pages: [
-         {
-           header: {
-             description: strings.PropertyPaneDescription
-           },
-           groups: [
-             {
-               groupName: strings.BasicGroupName,
-               groupFields: [
-               PropertyPaneTextField('description', {
-                 label: 'Description'
-               }),
-               PropertyPaneTextField('test', {
-                 label: 'Multi-line Text Field',
-                 multiline: true
-               }),
-               PropertyPaneCheckbox('test1', {
-                 text: 'Checkbox'
-               }),
-               PropertyPaneDropdown('test2', {
-                 label: 'Dropdown',
-                 options: [
-                   { key: '1', text: 'One' },
-                   { key: '2', text: 'Two' },
-                   { key: '3', text: 'Three' },
-                   { key: '4', text: 'Four' }
-                 ]}),
-               PropertyPaneToggle('test3', {
-                 label: 'Toggle',
-                 onText: 'On',
-                 offText: 'Off'
-               })
-             ]
-             }
-           ]
-         }
-       ]
-     };
-   }
-   ```
+```ts
+protected get propertyPaneSettings(): IPropertyPaneSettings {
+  return {
+    pages: [
+      {
+        header: {
+          description: strings.PropertyPaneDescription
+        },
+        groups: [
+          {
+            groupName: strings.BasicGroupName,
+            groupFields: [
+            PropertyPaneTextField('description', {
+              label: 'Description'
+            }),
+            PropertyPaneTextField('test', {
+              label: 'Multi-line Text Field',
+              multiline: true
+            }),
+            PropertyPaneCheckbox('test1', {
+              text: 'Checkbox'
+            }),
+            PropertyPaneDropdown('test2', {
+              label: 'Dropdown',
+              options: [
+                { key: '1', text: 'One' },
+                { key: '2', text: 'Two' },
+                { key: '3', text: 'Three' },
+                { key: '4', text: 'Four' }
+              ]}),
+            PropertyPaneToggle('test3', {
+              label: 'Toggle',
+              onText: 'On',
+              offText: 'Off'
+            })
+          ]
+          }
+        ]
+      }
+    ]
+  };
+}
+```
 
-   Since we added new property fields, let's import those from the framework.
+Since we added new property fields, let's import those from the framework.
 
-2. Scroll to the top of the file and add the following to the import section from `@microsoft/sp-client-preview`:
+Scroll to the top of the file and add the following to the import section from `@microsoft/sp-client-preview`:
 
-   ```
-   PropertyPaneCheckbox,
-   PropertyPaneDropdown,
-   PropertyPaneToggle
-   ```
+```ts
+PropertyPaneCheckbox,
+PropertyPaneDropdown,
+PropertyPaneToggle
+```
 
-   The complete import section will look like the following:
+The complete import section will look like the following:
 
-   ```
-   import {
-     BaseClientSideWebPart,
-     IPropertyPaneSettings,
-     IWebPartContext,
-     PropertyPaneTextField,
-     PropertyPaneCheckbox,
-     PropertyPaneDropdown,
-     PropertyPaneToggle
-   } from '@microsoft/sp-client-preview';
-   ```
+```ts
+import {
+  BaseClientSideWebPart,
+  IPropertyPaneSettings,
+  IWebPartContext,
+  PropertyPaneTextField,
+  PropertyPaneCheckbox,
+  PropertyPaneDropdown,
+  PropertyPaneToggle
+} from '@microsoft/sp-client-preview';
+```
 
-3. Save the file.
+Save the file.
 
-   Now add these properties to the **IHelloWorldWebPartProps** interface that map to our fields we just added.
+Now add these properties to the **IHelloWorldWebPartProps** interface that map to our fields we just added.
 
-4. Open **IHelloWorldWebPartProps.ts** and replace the existing code with the following code:
+Open **IHelloWorldWebPartProps.ts** and replace the existing code with the following code:
 
-   ```ts
-   export interface IHelloWorldWebPartProps {
-       description: string;
-       test: string;
-       test1: boolean;
-       test2: string;
-       test3: boolean;
-   }
-   ```
+```ts
+export interface IHelloWorldWebPartProps {
+    description: string;
+    test: string;
+    test1: boolean;
+    test2: string;
+    test3: boolean;
+}
+```
 
-5. Save the file.
-6. Switch back to the **HelloWorldWebPart.ts** file.
+Save the file.
 
-   After you add your properties to the web part properties, you can access the property in the same way you accessed the **description** property earlier:
+Switch back to the **HelloWorldWebPart.ts** file.
 
-   ```ts
-   <p class="ms-font-l ms-fontColor-white">${this.properties.test2}</p>
-   ```
+After you add your properties to the web part properties, you can access the property in the same way you accessed the **description** property earlier:
 
-   To set the default value for the property, you will need to update the web part manifest's **properties** property bag:
+```ts
+<p class="ms-font-l ms-fontColor-white">${this.properties.test2}</p>
+```
 
-7. Open `HelloWorldWebPart.manifest.json`
-8. Modify the `properties` to:
+To set the default value for the property, you will need to update the web part manifest's **properties** property bag:
 
-   ```ts
-   "properties": {
-     "description": "HelloWorld",
-     "test": "Multi-line text field",
-     "test1": true,
-     "test2": "2",
-     "test3": true
-   }
-   ```
+Open `HelloWorldWebPart.manifest.json` and modify the `properties` to:
+
+```ts
+"properties": {
+  "description": "HelloWorld",
+  "test": "Multi-line text field",
+  "test1": true,
+  "test2": "2",
+  "test3": true
+}
+```
 
 ### Web part manifest
 The **HelloWorldWebPart.manifest.json** file defines the web part metadata such as version, id, display name, icon, and description. Every web part should contain this manifest.
@@ -351,29 +350,29 @@ The **HelloWorldWebPart.manifest.json** file defines the web part metadata such 
 
 SharePoint workbench is also hosted in SharePoint to preview and test your local web parts in development. The key advantage is that now you are running in SharePoint context and that you will be able to interact with SharePoint data.
 
-1. Go to the following URL: 'https://your-sharepoint-site/Shared%20Documents/workbench.aspx'
+Go to the following URL: 'https://your-sharepoint-site/Shared%20Documents/workbench.aspx'
 
-   By default, your browser is configured not to load scripts from localhost. Workbench will notify you if that is the case.
+By default, your browser is configured not to load scripts from localhost. Workbench will notify you if that is the case.
 
-   ![Load unsafe scripts to run scripts from localhost](../../../../images/sp-workbench-o365-unsface-scripts.png) 
+![Load unsafe scripts to run scripts from localhost](../../../../images/sp-workbench-o365-unsface-scripts.png) 
 
-2. In order to execute local scripts, you will need to configure the browser to load scripts from unauthenticated sources. This is due to loading scripts over HTTP while connected to a page via HTTPS. Depending on the browser you use, the options to enable this may vary. For example, in the Chrome browser, you can choose the grey shield in the right side of the address bar to load unsafe scripts. 
+In order to execute local scripts, you will need to configure the browser to load scripts from unauthenticated sources. This is due to loading scripts over HTTP while connected to a page via HTTPS. Depending on the browser you use, the options to enable this may vary. For example, in the Chrome browser, you can choose the grey shield in the right side of the address bar to load unsafe scripts. 
 
-   ![Allow browser to load unsafe scripts to run scripts from localhost](../../../../images/chrome-load-unsafe-scripts.png)
+![Allow browser to load unsafe scripts to run scripts from localhost](../../../../images/chrome-load-unsafe-scripts.png)
 
-   After you enable loading scripts, you should see the workbench load. Add the hello world web part to the canvas:
+After you enable loading scripts, you should see the workbench load. Add the hello world web part to the canvas:
 
-   ![SharePoint Workbench running in a SharePoint Online site](../../../../images/sp-workbench-o365.png)
+![SharePoint Workbench running in a SharePoint Online site](../../../../images/sp-workbench-o365.png)
 
-   Notice that the SharePoint workbench now has the Office 365 Suite navigation bar.
+Notice that the SharePoint workbench now has the Office 365 Suite navigation bar.
 
-3. Choose **add icon** in the canvas to reveal the toolbox. The toolbox now shows the web parts available on the site where the SharePoint workbench is hosted along with your **HelloWorldWebPart**.
+Choose **add icon** in the canvas to reveal the toolbox. The toolbox now shows the web parts available on the site where the SharePoint workbench is hosted along with your **HelloWorldWebPart**.
 
-   ![Toolbox in SharePoint Workbench running in SharePoint Online site](../../../../images/sp-workbench-o365-toolbox.png)
+![Toolbox in SharePoint Workbench running in SharePoint Online site](../../../../images/sp-workbench-o365-toolbox.png)
 
-4. Add **HelloWorldWebPart** from the toolbox. Now you're running your web part in a page hosted in SharePoint!
+Add **HelloWorldWebPart** from the toolbox. Now you're running your web part in a page hosted in SharePoint!
 
-   ![HelloWorld web part running in SharePoint Workbench running in a SharePoint Online site](../../../../images/sp-workbench-o365-helloworld-wp.png)
+![HelloWorld web part running in SharePoint Workbench running in a SharePoint Online site](../../../../images/sp-workbench-o365-helloworld-wp.png)
 
 Because you are still developing and testing your web part, there is no need to package and deploy your web part to SharePoint. 
 

--- a/docs/spfx/web-parts/get-started/connect-to-sharepoint.md
+++ b/docs/spfx/web-parts/get-started/connect-to-sharepoint.md
@@ -30,9 +30,9 @@ You can get access to the page context using the following variable in your web 
 this.context.pageContext
 ```
 
-1. Switch to Visual Studio code (or your preferred IDE) and open **src\webparts\helloWorld\HelloWorldWebPart.ts**.
+Switch to Visual Studio code (or your preferred IDE) and open **src\webparts\helloWorld\HelloWorldWebPart.ts**.
 
-2. Inside the **render** method, replace the **innerHTML** code block with the following code:
+Inside the **render** method, replace the **innerHTML** code block with the following code:
 
 ```ts
 	this.domElement.innerHTML = `
@@ -55,25 +55,25 @@ this.context.pageContext
 
 Notice how `${ }` is used to output the variable's value in the HTML block. An extra HTML `p` is used to display `this.context.pageContext.web.title`. Since this web part loads from the local environment, the title will be **Local Workbench**.
 
-3. Save the file. The `gulp serve` running in your console will detect this save operation and:
-	* Build and bundle the updated code automatically.
-	* Refresh your local workbench page (as the web part code needs to be reloaded).
+Save the file. The `gulp serve` running in your console will detect this save operation and:
+* Build and bundle the updated code automatically.
+* Refresh your local workbench page (as the web part code needs to be reloaded).
 
 >**Note:** Keep the console window and VS Code side by side to see gulp automatically compile as you save changes in VS Code.
 
-4. In your browser, go to **workbench.html** locally. If you have already closed the tab, the URL is http://localhost:4321/temp/workbench.html.
+In your browser, go to **workbench.html** locally. If you have already closed the tab, the URL is http://localhost:4321/temp/workbench.html.
 
 You should see the following in the web part:
 
 ![SharePoint page context in localhost](../../../../images/sp-mock-localhost-wp.png)
 
-5. Go to **workbench.aspx** hosted in SharePoint. The full URL is https://your-sharepoint-site-url/Shared%20Documents/workbench.aspx.
+Go to **workbench.aspx** hosted in SharePoint. The full URL is https://your-sharepoint-site-url/Shared%20Documents/workbench.aspx.
 
 By default, your browser is configured not to load scripts from localhost. Workbench will notify you if that is the case as shown in the following image. This is due to loading scripts over HTTP while connected to a page via HTTPS.
 
 ![Load unsafe scripts to run scripts from localhost](../../../../images/sp-workbench-o365-unsface-scripts.png) 
 
-6. To execute local scripts, in the Chrome browser, click the grey shield in the right side of the address bar to load unsafe scripts. 
+To execute local scripts, in the Chrome browser, click the grey shield in the right side of the address bar to load unsafe scripts. 
 
 ![Allow browser to load unsafe scripts to run scripts from localhost](../../../../images/chrome-load-unsafe-scripts.png)
 
@@ -84,9 +84,9 @@ You should now see your SharePoint site URL in the web part now that page contex
 ## Define list model
 You need a list model to start working with SharePoint list data. Two models As we will retrieve the lists, we need two models. 
 
-1. Switch to Visual Studio Code and go to **src\webparts\helloWorld\HelloWorldWebPart.ts**.
+Switch to Visual Studio Code and go to **src\webparts\helloWorld\HelloWorldWebPart.ts**.
 
-2. Define the following `interface` models just above the **HelloWorldWebPart** class:
+Define the following `interface` models just above the **HelloWorldWebPart** class:
 
 ```ts
 export interface ISPLists {
@@ -105,9 +105,9 @@ The **ISPList** interface holds the SharePoint list information we are connectin
 
 To test in the local workbench you will need a mock store that returns mock data.
 
-1. Create a new file inside the **src\webparts\helloWorld** folder named **MockHttpClient.ts**.
+Create a new file inside the **src\webparts\helloWorld** folder named **MockHttpClient.ts**.
 
-2. Copy the following code into **MockHttpClient.ts**.
+Copy the following code into **MockHttpClient.ts**:
 
 ```ts
 import { ISPList } from './HelloWorldWebPart';
@@ -130,19 +130,19 @@ Things to note about the code:
 * It exports the **MockHttpClient** class as a default module so that it can be imported in other files.
 * It builds the initial `ISPList` mock array and returns.
 
-3. Save the file.
+Save the file.
 
 You can now use the **MockHttpClient** class in the **HelloWorldWebPart** class. You first need to import the **MockHttpClient** module.
 
-4. Open the **HelloWorldWebPart.ts** file.
+Open the **HelloWorldWebPart.ts** file.
 
-5. Copy and paste the following code to just below `import { IHelloWorldWebPartProps } from './IHelloWorldWebPartProps';`.
+Copy and paste the following code to just below `import { IHelloWorldWebPartProps } from './IHelloWorldWebPartProps';`.
 
 ```ts
 import MockHttpClient from './MockHttpClient';
 ```
  
-6. Add the following private method that mocks the list retrieval inside the **HelloWorldWebPart** class.
+Add the following private method that mocks the list retrieval inside the **HelloWorldWebPart** class.
 
 ```ts
 private _getMockListData(): Promise<ISPLists> {
@@ -161,13 +161,13 @@ private _getMockListData(): Promise<ISPLists> {
 }
 ```
 
-7. Save the file.
+Save the file.
 
 ## Retrieve lists from SharePoint site
 
 Next you need to retrieve lists from the current site. You will use SharePoint REST APIs to retrieve the lists from the site, which are located at https://yourtenantprefix.sharepoint.com/_api/web/lists.
 
-1. Add the following private method to retrieve lists from SharePoint inside the **HelloWorldWebPart** class.
+Add the following private method to retrieve lists from SharePoint inside the **HelloWorldWebPart** class.
 
 ```ts
 private _getListData(): Promise<ISPLists> {
@@ -180,19 +180,19 @@ return this.context.httpClient.get(this.context.pageContext.web.absoluteUrl + `/
 
 The previous method uses a helper class **httpClient** that is available in the SharePoint client-side platform to execute the REST API. It uses the **ISPLists** model and also applies a filter to not retrieve hidden lists.
 
-2. Save the file. 
+Save the file. 
 
-3. Switch to the console window that is running `gulp serve` and check if there are any errors. If there are errors, gulp reports them in the console and you will need to fix them before proceeding.
+Switch to the console window that is running `gulp serve` and check if there are any errors. If there are errors, gulp reports them in the console and you will need to fix them before proceeding.
 
 ## Add new styles
 
 The SharePoint Framework uses [Sass](http://sass-lang.com/) as the CSS pre-processor and specifically uses the [SCSS syntax](http://sass-lang.com/documentation/file.SCSS_FOR_SASS_USERS.html) which is fully complaint with normal CSS syntax. Sass extends the CSS language and allows you to use features like variables, nested rules, and inline imports to organize and create efficient style sheets for your web parts. The SharePoint Framework already comes with a SCSS compiler that converts your Sass files to normal CSS files and also provides a typed version to use it in during development.
 
-1. To add new styles, open **HelloWorld.module.scss**. This is the SCSS file where you will define your styles.
+To add new styles, open **HelloWorld.module.scss**. This is the SCSS file where you will define your styles.
 
 By default, the styles are scoped to your web part. You can see that as the styles are defined under **.helloWorld**.
 
-2. Add the following styles after the `.button` style:
+Add the following styles after the `.button` style:
 
 ```css
 .list {
@@ -224,7 +224,7 @@ By default, the styles are scoped to your web part. You can see that as the styl
 }
 ``` 
 
-3. Save the file.
+Save the file.
 
 gulp rebuilds the code in the console as soon as you save the file. This will generate the corresponding typings in the **HelloWorld.module.scss.ts** file. Once compiled to typescript, you can then import and reference these styles in your web part code.
 
@@ -236,17 +236,17 @@ You can see that in the **render** method of the web part:
 
 ## Method to render lists information
 
-1. Open the **HelloWorldWebPart** class.
+Open the **HelloWorldWebPart** class.
 
-	SharePoint workbench gives you the flexibility to test web parts in your local environment and from a SharePoint site. SharePoint Framework aids this capability by helping you understand which environment your web part is running from by using the **EnvironmentType** module. 
+SharePoint workbench gives you the flexibility to test web parts in your local environment and from a SharePoint site. SharePoint Framework aids this capability by helping you understand which environment your web part is running from by using the **EnvironmentType** module. 
 
-2. To use the module, you first need to import **EnvironmentType** module from the **@microsoft/sp-client-base** bundle. Add it to the **import** section at the top as shown in the following code:
+To use the module, you first need to import **EnvironmentType** module from the **@microsoft/sp-client-base** bundle. Add it to the **import** section at the top as shown in the following code:
 
 ```ts
 import { EnvironmentType } from '@microsoft/sp-client-base';
 ```
 
-3. Add the following private method inside the **HelloWorldWebPart** class to call the respective methods to retrieve list data:
+Add the following private method inside the **HelloWorldWebPart** class to call the respective methods to retrieve list data:
 
 ```ts
 private _renderListAsync(): void {
@@ -268,11 +268,11 @@ Things to note about hostType in the **_renderListAsync** method:
 * The `this.context.environment.type` property will help you check if you are in a local or SharePoint environment.
 * The correct method is called depending on where your workbench is hosted.
 
-4. Save the file.
+Save the file.
 
 Now you need to render the list data with the value fetched from the REST API.
 
-5. Add the following private method inside the **HelloWorldWebPart** class:
+Add the following private method inside the **HelloWorldWebPart** class:
 
 ```ts
 private _renderList(items: ISPList[]): void {
@@ -293,11 +293,11 @@ private _renderList(items: ISPList[]): void {
 
 The previous method references the new CSS styles added earlier by using the **styles** variable. 
 
-6. Save the file.
+Save the file.
 
 ## Retrieve list data
 
-1. Navigate to the **render** method and replace the code inside the method with the following code:
+Navigate to the **render** method and replace the code inside the method with the following code:
 
 ```ts
 this.domElement.innerHTML = `
@@ -322,23 +322,23 @@ this.domElement.innerHTML = `
 this._renderListAsync();
 ```
 
-2. Save the file.
+Save the file.
 
 Notice in the `gulp serve` console window that it rebuilds the code. Make sure you don't see any errors.
 
-3. Switch to your local workbench and add the HelloWorld web part.
+Switch to your local workbench and add the HelloWorld web part.
 
 You should see the mock data returned.
 
 ![Render lists data from localhost](../../../../images/sp-lists-render-localhost.png)
 
-4. Switch to the workbench hosted in SharePoint. Refresh the page and add the HelloWorld web part.
+Switch to the workbench hosted in SharePoint. Refresh the page and add the HelloWorld web part.
 
 You should see lists returned from the current site.
 
 ![Render lists data from SharePoint](../../../../images/sp-lists-render-spsite.png)
 
-5. Now you can stop the server from running. Switch to the console and stop `gulp serve`. Choose `Ctrl+C` to terminate the gulp task.
+Now you can stop the server from running. Switch to the console and stop `gulp serve`. Choose `Ctrl+C` to terminate the gulp task.
 
 ## Next steps
 

--- a/docs/spfx/web-parts/get-started/connect-to-sharepoint.md
+++ b/docs/spfx/web-parts/get-started/connect-to-sharepoint.md
@@ -34,52 +34,52 @@ this.context.pageContext
 
 2. Inside the **render** method, replace the **innerHTML** code block with the following code:
 
-	```ts
-		 this.domElement.innerHTML = `
-			<div class='${styles.helloWorld}'>
-			  <div class='${styles.container}'>
-				 <div class='ms-Grid-row ms-bgColor-themeDark ms-fontColor-white ${styles.row}'>
-					<div class='ms-Grid-col ms-u-lg10 ms-u-xl8 ms-u-xlPush2 ms-u-lgPush1'>
-					  <span class='ms-font-xl ms-fontColor-white'>Welcome to SharePoint!</span>
-					  <p class='ms-font-l ms-fontColor-white'>Customize SharePoint experiences using Web Parts.</p>
-					  <p class='ms-font-l ms-fontColor-white'>${this.properties.description}</p>
-					  <p class='ms-font-l ms-fontColor-white'>Loading from ${this.context.pageContext.web.title}</p>
-					  <a href='https://github.com/SharePoint/sp-dev-docs/wiki' class='ms-Button ${styles.button}'>
-						 <span class='ms-Button-label'>Learn more</span>
-					  </a>
-					</div>
-				 </div>
+```ts
+	this.domElement.innerHTML = `
+	<div class='${styles.helloWorld}'>
+		<div class='${styles.container}'>
+			<div class='ms-Grid-row ms-bgColor-themeDark ms-fontColor-white ${styles.row}'>
+			<div class='ms-Grid-col ms-u-lg10 ms-u-xl8 ms-u-xlPush2 ms-u-lgPush1'>
+				<span class='ms-font-xl ms-fontColor-white'>Welcome to SharePoint!</span>
+				<p class='ms-font-l ms-fontColor-white'>Customize SharePoint experiences using Web Parts.</p>
+				<p class='ms-font-l ms-fontColor-white'>${this.properties.description}</p>
+				<p class='ms-font-l ms-fontColor-white'>Loading from ${this.context.pageContext.web.title}</p>
+				<a href='https://github.com/SharePoint/sp-dev-docs/wiki' class='ms-Button ${styles.button}'>
+					<span class='ms-Button-label'>Learn more</span>
+				</a>
 			</div>
-		 </div>`;
-	```
+			</div>
+	</div>
+	</div>`;
+```
 
-	Notice how `${ }` is used to output the variable's value in the HTML block. An extra HTML `p` is used to display `this.context.pageContext.web.title`. Since this web part loads from the local environment, the title will be **Local Workbench**.
+Notice how `${ }` is used to output the variable's value in the HTML block. An extra HTML `p` is used to display `this.context.pageContext.web.title`. Since this web part loads from the local environment, the title will be **Local Workbench**.
 
 3. Save the file. The `gulp serve` running in your console will detect this save operation and:
 	* Build and bundle the updated code automatically.
 	* Refresh your local workbench page (as the web part code needs to be reloaded).
 
-	>**Note:** Keep the console window and VS Code side by side to see gulp automatically compile as you save changes in VS Code.
+>**Note:** Keep the console window and VS Code side by side to see gulp automatically compile as you save changes in VS Code.
 
 4. In your browser, go to **workbench.html** locally. If you have already closed the tab, the URL is http://localhost:4321/temp/workbench.html.
 
-	You should see the following in the web part:
+You should see the following in the web part:
 
-	![SharePoint page context in localhost](../../../../images/sp-mock-localhost-wp.png)
+![SharePoint page context in localhost](../../../../images/sp-mock-localhost-wp.png)
 
 5. Go to **workbench.aspx** hosted in SharePoint. The full URL is https://your-sharepoint-site-url/Shared%20Documents/workbench.aspx.
 
-	By default, your browser is configured not to load scripts from localhost. Workbench will notify you if that is the case as shown in the following image. This is due to loading scripts over HTTP while connected to a page via HTTPS.
+By default, your browser is configured not to load scripts from localhost. Workbench will notify you if that is the case as shown in the following image. This is due to loading scripts over HTTP while connected to a page via HTTPS.
 
-	![Load unsafe scripts to run scripts from localhost](../../../../images/sp-workbench-o365-unsface-scripts.png) 
+![Load unsafe scripts to run scripts from localhost](../../../../images/sp-workbench-o365-unsface-scripts.png) 
 
 6. To execute local scripts, in the Chrome browser, click the grey shield in the right side of the address bar to load unsafe scripts. 
 
-	![Allow browser to load unsafe scripts to run scripts from localhost](../../../../images/chrome-load-unsafe-scripts.png)
+![Allow browser to load unsafe scripts to run scripts from localhost](../../../../images/chrome-load-unsafe-scripts.png)
 
-	You should now see your SharePoint site URL in the web part now that page context is available to the web part.
+You should now see your SharePoint site URL in the web part now that page context is available to the web part.
 
-	![SharePoint page context in SharePoint site](../../../../images/sp-lists-spsiteurl-wp.png)
+![SharePoint page context in SharePoint site](../../../../images/sp-lists-spsiteurl-wp.png)
 
 ## Define list model
 You need a list model to start working with SharePoint list data. Two models As we will retrieve the lists, we need two models. 
@@ -88,78 +88,78 @@ You need a list model to start working with SharePoint list data. Two models As 
 
 2. Define the following `interface` models just above the **HelloWorldWebPart** class:
 
-	```ts
-	export interface ISPLists {
-	  value: ISPList[];
-	}
+```ts
+export interface ISPLists {
+	value: ISPList[];
+}
 
-	export interface ISPList {
-	  Title: string;
-	  Id: string;
-	}
-	```
+export interface ISPList {
+	Title: string;
+	Id: string;
+}
+```
 
 The **ISPList** interface holds the SharePoint list information we are connecting to. 
 
 ## Retrieve lists from mock store
 
-to test in the local workbench you will need a mock store that returns mock data.
+To test in the local workbench you will need a mock store that returns mock data.
 
 1. Create a new file inside the **src\webparts\helloWorld** folder named **MockHttpClient.ts**.
 
 2. Copy the following code into **MockHttpClient.ts**.
 
-	```ts
-	import { ISPList } from './HelloWorldWebPart';
+```ts
+import { ISPList } from './HelloWorldWebPart';
 
-	export default class MockHttpClient {
+export default class MockHttpClient {
 
-		 private static _items: ISPList[] = [{ Title: 'Mock List', Id: '1' }];
+		private static _items: ISPList[] = [{ Title: 'Mock List', Id: '1' }];
 
-		 public static get(restUrl: string, options?: any): Promise<ISPList[]> {
-			return new Promise<ISPList[]>((resolve) => {
-					resolve(MockHttpClient._items);
-			  });
-		 }
-	}
-	```
+		public static get(restUrl: string, options?: any): Promise<ISPList[]> {
+		return new Promise<ISPList[]>((resolve) => {
+				resolve(MockHttpClient._items);
+			});
+		}
+}
+```
 
-	Things to note about the code:
-	* Because there are multiple exports in **HelloWorldWebPart.ts** the specific one to import is specified using `{ }`. In this case, only the data model `ISPList` is required.
-	* You do not need to type the file extension when importing from the default module which in this case is **HelloWorldWebPart**. 
-	* It exports the **MockHttpClient** class as a default module so that it can be imported in other files.
-	* It builds the initial `ISPList` mock array and returns.
+Things to note about the code:
+* Because there are multiple exports in **HelloWorldWebPart.ts** the specific one to import is specified using `{ }`. In this case, only the data model `ISPList` is required.
+* You do not need to type the file extension when importing from the default module which in this case is **HelloWorldWebPart**. 
+* It exports the **MockHttpClient** class as a default module so that it can be imported in other files.
+* It builds the initial `ISPList` mock array and returns.
 
 3. Save the file.
 
-	You can now use the **MockHttpClient** class in the **HelloWorldWebPart** class. You first need to import the **MockHttpClient** module.
+You can now use the **MockHttpClient** class in the **HelloWorldWebPart** class. You first need to import the **MockHttpClient** module.
 
 4. Open the **HelloWorldWebPart.ts** file.
 
 5. Copy and paste the following code to just below `import { IHelloWorldWebPartProps } from './IHelloWorldWebPartProps';`.
 
-	```ts
-	import MockHttpClient from './MockHttpClient';
-	```
+```ts
+import MockHttpClient from './MockHttpClient';
+```
  
 6. Add the following private method that mocks the list retrieval inside the **HelloWorldWebPart** class.
 
-	```ts
-	private _getMockListData(): Promise<ISPLists> {
-		 return MockHttpClient.get(this.context.pageContext.web.absoluteUrl).then(() => {
-			  const listData: ISPLists = {
-					value:
-					[
-						 { Title: 'Mock List One', Id: '1' },
-						 { Title: 'Mock List Two', Id: '2' },
-						 { Title: 'Mock List Three', Id: '3' }
-					]
-					};
+```ts
+private _getMockListData(): Promise<ISPLists> {
+		return MockHttpClient.get(this.context.pageContext.web.absoluteUrl).then(() => {
+			const listData: ISPLists = {
+				value:
+				[
+						{ Title: 'Mock List One', Id: '1' },
+						{ Title: 'Mock List Two', Id: '2' },
+						{ Title: 'Mock List Three', Id: '3' }
+				]
+				};
 
-			  return listData;
-		 }) as Promise<ISPLists>;
-	}
-	```
+			return listData;
+		}) as Promise<ISPLists>;
+}
+```
 
 7. Save the file.
 
@@ -169,16 +169,16 @@ Next you need to retrieve lists from the current site. You will use SharePoint R
 
 1. Add the following private method to retrieve lists from SharePoint inside the **HelloWorldWebPart** class.
 
-	```ts
-	private _getListData(): Promise<ISPLists> {
-	return this.context.httpClient.get(this.context.pageContext.web.absoluteUrl + `/_api/web/lists?$filter=Hidden eq false`)
-		 .then((response: Response) => {
-		 return response.json();
-		 });
-	}
-	```
+```ts
+private _getListData(): Promise<ISPLists> {
+return this.context.httpClient.get(this.context.pageContext.web.absoluteUrl + `/_api/web/lists?$filter=Hidden eq false`)
+		.then((response: Response) => {
+		return response.json();
+		});
+}
+```
 
-	The previous method uses a helper class **httpClient** that is available in the SharePoint client-side platform to execute the REST API. It uses the **ISPLists** model and also applies a filter to not retrieve hidden lists.
+The previous method uses a helper class **httpClient** that is available in the SharePoint client-side platform to execute the REST API. It uses the **ISPLists** model and also applies a filter to not retrieve hidden lists.
 
 2. Save the file. 
 
@@ -190,39 +190,39 @@ The SharePoint Framework uses [Sass](http://sass-lang.com/) as the CSS pre-proce
 
 1. To add new styles, open **HelloWorld.module.scss**. This is the SCSS file where you will define your styles.
 
-	By default, the styles are scoped to your web part. You can see that as the styles are defined under **.helloWorld**.
+By default, the styles are scoped to your web part. You can see that as the styles are defined under **.helloWorld**.
 
 2. Add the following styles after the `.button` style:
 
-	```css
-	.list {
-	  color: #333333;
-	  font-family: 'Segoe UI Regular WestEuropean', 'Segoe UI', Tahoma, Arial, sans-serif;
-	  font-size: 14px;
-	  font-weight: normal;
-	  box-sizing: border-box;
-	  margin: 10;
-	  padding: 10;
-	  line-height: 50px;
-	  list-style-type: none;
-	  box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.2), 0 25px 50px 0 rgba(0, 0, 0, 0.1);
-	}
+```css
+.list {
+	color: #333333;
+	font-family: 'Segoe UI Regular WestEuropean', 'Segoe UI', Tahoma, Arial, sans-serif;
+	font-size: 14px;
+	font-weight: normal;
+	box-sizing: border-box;
+	margin: 10;
+	padding: 10;
+	line-height: 50px;
+	list-style-type: none;
+	box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.2), 0 25px 50px 0 rgba(0, 0, 0, 0.1);
+}
 
-	.listItem {
-	  color: #333333;
-	  vertical-align: center;
-	  font-family: 'Segoe UI Regular WestEuropean', 'Segoe UI', Tahoma, Arial, sans-serif;
-	  font-size: 14px;
-	  font-weight: normal;
-	  box-sizing: border-box;
-	  margin: 0;
-	  padding: 0;
-	  box-shadow: none;
-	  *zoom: 1;
-	  padding: 9px 28px 3px;
-	  position: relative;
-	}
-	``` 
+.listItem {
+	color: #333333;
+	vertical-align: center;
+	font-family: 'Segoe UI Regular WestEuropean', 'Segoe UI', Tahoma, Arial, sans-serif;
+	font-size: 14px;
+	font-weight: normal;
+	box-sizing: border-box;
+	margin: 0;
+	padding: 0;
+	box-shadow: none;
+	*zoom: 1;
+	padding: 9px 28px 3px;
+	position: relative;
+}
+``` 
 
 3. Save the file.
 
@@ -242,56 +242,56 @@ You can see that in the **render** method of the web part:
 
 2. To use the module, you first need to import **EnvironmentType** module from the **@microsoft/sp-client-base** bundle. Add it to the **import** section at the top as shown in the following code:
 
-	```ts
-	import { EnvironmentType } from '@microsoft/sp-client-base';
-	```
+```ts
+import { EnvironmentType } from '@microsoft/sp-client-base';
+```
 
 3. Add the following private method inside the **HelloWorldWebPart** class to call the respective methods to retrieve list data:
 
-	```ts
-	private _renderListAsync(): void {
-	  // Local environment
-	  if (this.context.environment.type === EnvironmentType.Local) {
-		 this._getMockListData().then((response) => {
+```ts
+private _renderListAsync(): void {
+	// Local environment
+	if (this.context.environment.type === EnvironmentType.Local) {
+		this._getMockListData().then((response) => {
+		this._renderList(response.value);
+		}); }
+		else {
+		this._getListData()
+		.then((response) => {
 			this._renderList(response.value);
-		 }); }
-		 else {
-		 this._getListData()
-			.then((response) => {
-			  this._renderList(response.value);
-			});
-	  }
+		});
 	}
-	```
+}
+```
 
-	Things to note about hostType in the **_renderListAsync** method:
-	* The `this.context.environment.type` property will help you check if you are in a local or SharePoint environment.
-	* The correct method is called depending on where your workbench is hosted.
+Things to note about hostType in the **_renderListAsync** method:
+* The `this.context.environment.type` property will help you check if you are in a local or SharePoint environment.
+* The correct method is called depending on where your workbench is hosted.
 
 4. Save the file.
 
-	Now you need to render the list data with the value fetched from the REST API.
+Now you need to render the list data with the value fetched from the REST API.
 
 5. Add the following private method inside the **HelloWorldWebPart** class:
 
-	```ts
-	private _renderList(items: ISPList[]): void {
-	  let html: string = '';
-	  items.forEach((item: ISPList) => {
-		 html += `
-		 <ul class="${styles.list}">
-			  <li class="${styles.listItem}">
-					<span class="ms-font-l">${item.Title}</span>
-			  </li>
-		 </ul>`;
-	  });
-	
-	  const listContainer: Element = this.domElement.querySelector('#spListContainer');
-	  listContainer.innerHTML = html;
-	}
-	```
+```ts
+private _renderList(items: ISPList[]): void {
+	let html: string = '';
+	items.forEach((item: ISPList) => {
+		html += `
+		<ul class="${styles.list}">
+			<li class="${styles.listItem}">
+				<span class="ms-font-l">${item.Title}</span>
+			</li>
+		</ul>`;
+	});
 
-	The previous method references the new CSS styles added earlier by using the **styles** variable. 
+	const listContainer: Element = this.domElement.querySelector('#spListContainer');
+	listContainer.innerHTML = html;
+}
+```
+
+The previous method references the new CSS styles added earlier by using the **styles** variable. 
 
 6. Save the file.
 
@@ -299,44 +299,44 @@ You can see that in the **render** method of the web part:
 
 1. Navigate to the **render** method and replace the code inside the method with the following code:
 
-	```ts
-	this.domElement.innerHTML = `
-	<div class="${styles.helloWorld}">
-		<div class="${styles.container}">
-			<div class="ms-Grid-row ms-bgColor-themeDark ms-fontColor-white ${styles.row}">
-				<div class="ms-Grid-col ms-u-lg10 ms-u-xl8 ms-u-xlPush2 ms-u-lgPush1">
-					<span class="ms-font-xl ms-fontColor-white">Welcome to SharePoint!</span>
-					<p class="ms-font-l ms-fontColor-white">Customize SharePoint experiences using Web Parts.</p>
-					<p class="ms-font-l ms-fontColor-white">${this.properties.description}</p>
-					<p class="ms-font-l ms-fontColor-white">${this.properties.test2}</p>
-					<p class='ms-font-l ms-fontColor-white'>Loading from ${this.context.pageContext.web.title}</p>
-					<a href="https://github.com/SharePoint/sp-dev-docs/wiki" class="ms-Button ${styles.button}">
-						<span class="ms-Button-label">Learn more</span>
-					</a>
-				</div>
+```ts
+this.domElement.innerHTML = `
+<div class="${styles.helloWorld}">
+	<div class="${styles.container}">
+		<div class="ms-Grid-row ms-bgColor-themeDark ms-fontColor-white ${styles.row}">
+			<div class="ms-Grid-col ms-u-lg10 ms-u-xl8 ms-u-xlPush2 ms-u-lgPush1">
+				<span class="ms-font-xl ms-fontColor-white">Welcome to SharePoint!</span>
+				<p class="ms-font-l ms-fontColor-white">Customize SharePoint experiences using Web Parts.</p>
+				<p class="ms-font-l ms-fontColor-white">${this.properties.description}</p>
+				<p class="ms-font-l ms-fontColor-white">${this.properties.test2}</p>
+				<p class='ms-font-l ms-fontColor-white'>Loading from ${this.context.pageContext.web.title}</p>
+				<a href="https://github.com/SharePoint/sp-dev-docs/wiki" class="ms-Button ${styles.button}">
+					<span class="ms-Button-label">Learn more</span>
+				</a>
 			</div>
-		<div id="spListContainer" />
 		</div>
-	</div>`;
-	
-	this._renderListAsync();
-	```
+	<div id="spListContainer" />
+	</div>
+</div>`;
+
+this._renderListAsync();
+```
 
 2. Save the file.
 
-	Notice in the `gulp serve` console window that it rebuilds the code. Make sure you don't see any errors.
+Notice in the `gulp serve` console window that it rebuilds the code. Make sure you don't see any errors.
 
 3. Switch to your local workbench and add the HelloWorld web part.
 
-	You should see the mock data returned.
+You should see the mock data returned.
 
-	![Render lists data from localhost](../../../../images/sp-lists-render-localhost.png)
+![Render lists data from localhost](../../../../images/sp-lists-render-localhost.png)
 
 4. Switch to the workbench hosted in SharePoint. Refresh the page and add the HelloWorld web part.
 
-	You should see lists returned from the current site.
+You should see lists returned from the current site.
 
-	![Render lists data from SharePoint](../../../../images/sp-lists-render-spsite.png)
+![Render lists data from SharePoint](../../../../images/sp-lists-render-spsite.png)
 
 5. Now you can stop the server from running. Switch to the console and stop `gulp serve`. Choose `Ctrl+C` to terminate the gulp task.
 

--- a/docs/spfx/web-parts/get-started/deploy-web-part-to-cdn.md
+++ b/docs/spfx/web-parts/get-started/deploy-web-part-to-cdn.md
@@ -34,9 +34,9 @@ This will create a new storage account endpoint **spfxsamples.blob.core.windows.
 
 ### BLOB container name
 
-1. Create a new Blob service container. This will be available in your storage account dashboard.
+Create a new Blob service container. This will be available in your storage account dashboard.
 
-2. Select the **+ Container** and create a new container with the following:
+Select the **+ Container** and create a new container with the following:
 
 * Name: **helloworld-webpart**
 * Access type: Container
@@ -45,7 +45,7 @@ This will create a new storage account endpoint **spfxsamples.blob.core.windows.
 
 ### Storage account access key
 
-3. In the storage account dashboard, choose **Access Key** in the dashboard and copy one of the access keys.
+In the storage account dashboard, choose **Access Key** in the dashboard and copy one of the access keys.
 
 ![Image that shows the storage account access key](../../../../images/deploy-storage-account-accesskey.png)
 
@@ -53,14 +53,13 @@ This will create a new storage account endpoint **spfxsamples.blob.core.windows.
 
 Create a new CDN profile and associate the CDN endpoint wit this BLOB container.
 
-4. Create a new CDN profile as described in [Step 2: Create a new CDN profile](https://azure.microsoft.com/en-us/documentation/articles/cdn-create-a-storage-account-with-cdn/#step-2-create-a-new-cdn-profile).
+Create a new CDN profile as described in [Step 2: Create a new CDN profile](https://azure.microsoft.com/en-us/documentation/articles/cdn-create-a-storage-account-with-cdn/#step-2-create-a-new-cdn-profile).
 
 For example, in the following screenshot, **spfxwebparts** is the CDN profile name.
 
-
 ![Screenshot of create a new CDN profile](../../../../images/deploy-create-cdn-profile.png)
 
-5. Create a CDN endpoint as described in [Step 3: Create a new CDN endpoint](https://azure.microsoft.com/en-us/documentation/articles/cdn-create-a-storage-account-with-cdn/#step-3-create-a-new-cdn-endpoint).
+Create a CDN endpoint as described in [Step 3: Create a new CDN endpoint](https://azure.microsoft.com/en-us/documentation/articles/cdn-create-a-storage-account-with-cdn/#step-3-create-a-new-cdn-endpoint).
 
 For example, in the following screenshot, **spfxsamples** is the endpoint name, **Storage** is the origin type, and **spfxsamples.blob.core.windows.net** is the storage account.
 
@@ -74,7 +73,7 @@ Note, however that you have not yet deployed the files.
 
 ## Project directory
 
-1. Switch to console and make sure you are still in the project directory you used to set up your web part project.
+Switch to console and make sure you are still in the project directory you used to set up your web part project.
 2. End the **gulp serve** task by choosing **Ctrl+C** and go to your project directory:
 
 ```
@@ -83,9 +82,9 @@ cd helloworld-webpart
 
 ## Configure Azure Storage account details
 
-1. Switch to Visual Studio Code and go to your **HelloWorld** web part project.
+Switch to Visual Studio Code and go to your **HelloWorld** web part project.
 
-2. Open **deploy-azure-storage.json** in the **config** folder.
+Open **deploy-azure-storage.json** in the **config** folder.
 
 This is the file that contains your Azure Storage account details.
 
@@ -98,7 +97,7 @@ This is the file that contains your Azure Storage account details.
 }
 ```
 
-3. Replace the **account**, **container**, **accessKey** with your storage account name, BLOB container and storage account access key respectively.
+Replace the **account**, **container**, **accessKey** with your storage account name, BLOB container and storage account access key respectively.
 
 **workingDir** is the directory where the web part assets will be located.
 
@@ -113,13 +112,13 @@ In this example, with the storage account created earlier, this file will look l
 }
 ```
 
-4. Save the file.
+Save the file.
 
 ## Prepare web part assets to deploy
 
 Before uploading the assets to CDN, you need to build them.
 
-1. Switch to the console and execute the following `gulp` task:
+Switch to the console and execute the following `gulp` task:
 
 ```
 gulp --ship
@@ -138,9 +137,9 @@ The minified assets can be found under the `temp\deploy` directory.
 
 ## Deploy assets to Azure Storage
 
-1. Switch to the console of the **HelloWorld** project directory.
+Switch to the console of the **HelloWorld** project directory.
 
-2. Enter the gulp task to deploy the assets to your storage account:
+Enter the gulp task to deploy the assets to your storage account:
 
 ```
 gulp deploy-azure-storage
@@ -152,9 +151,9 @@ This will deploy the web part bundle along with other assets like JavaScript and
 
 In order for the web part to load from your CDN, you will need to tell it your CDN path.
 
-1. Switch to Visual Studio Code and open the **write-manifests.json** from the **config** folder.
+Switch to Visual Studio Code and open the **write-manifests.json** from the **config** folder.
 
-2. Enter your CDN base path for the **cdnBasePath** property.
+Enter your CDN base path for the **cdnBasePath** property.
 
 ```json
 {
@@ -172,7 +171,7 @@ In this example, with the CDN profile created earlier, this file will look like:
 
 >**Note:** The CDN base path is the CDN endpoint with the BLOB container.
 
-3. Save the file.
+Save the file.
 
 ## Deploy the updated package
 
@@ -180,9 +179,9 @@ In this example, with the CDN profile created earlier, this file will look like:
 
 Because you changed the web part bundle, you will need to re-deploy the package to the App Catalog. You used **--ship** to generate minified assets for distribution.
 
-1. Switch to the console of the **HelloWorld** project directory.
+Switch to the console of the **HelloWorld** project directory.
 
-2. Enter the gulp task to package the client-side solution, this time with the `--ship` flag set. This forces the task to pick up the CDN base path configured in the previous step:
+Enter the gulp task to package the client-side solution, this time with the `--ship` flag set. This forces the task to pick up the CDN base path configured in the previous step:
 
 ```
 gulp bundle --ship
@@ -195,13 +194,13 @@ This will create the updated client-side solution package in the **sharepoint\so
 
 ### Upload to your App Catalog
 
-1. Upload or drag & drop the client-side solution package to the App Catalog.
+Upload or drag & drop the client-side solution package to the App Catalog.
 
 Because you already  deployed the package, you will be prompted as to whether to replace the existing package.
 
 ![Screenshot of replace client-side solution package prompt](../../../../images/sp-app-replace-pkg.png)
 
-2. Choose **Replace It**.
+Choose **Replace It**.
 
 The App Catalog will now have the latest client-side solution package where the web part bundle is loaded from the CDN.
 

--- a/docs/spfx/web-parts/get-started/deploy-web-part-to-cdn.md
+++ b/docs/spfx/web-parts/get-started/deploy-web-part-to-cdn.md
@@ -38,16 +38,16 @@ This will create a new storage account endpoint **spfxsamples.blob.core.windows.
 
 2. Select the **+ Container** and create a new container with the following:
 
-   * Name: **helloworld-webpart**
-   * Access type: Container
+* Name: **helloworld-webpart**
+* Access type: Container
 
-   ![Image that shows the option to create blob container](../../../../images/deploy-option-blob-container.png)
+![Image that shows the option to create blob container](../../../../images/deploy-option-blob-container.png)
 
 ### Storage account access key
 
 3. In the storage account dashboard, choose **Access Key** in the dashboard and copy one of the access keys.
 
-  ![Image that shows the storage account access key](../../../../images/deploy-storage-account-accesskey.png)
+![Image that shows the storage account access key](../../../../images/deploy-storage-account-accesskey.png)
 
 ### CDN profile and endpoint
 
@@ -55,31 +55,31 @@ Create a new CDN profile and associate the CDN endpoint wit this BLOB container.
 
 4. Create a new CDN profile as described in [Step 2: Create a new CDN profile](https://azure.microsoft.com/en-us/documentation/articles/cdn-create-a-storage-account-with-cdn/#step-2-create-a-new-cdn-profile).
 
-   For example, in the following screenshot, **spfxwebparts** is the CDN profile name.
+For example, in the following screenshot, **spfxwebparts** is the CDN profile name.
 
 
-   ![Screenshot of create a new CDN profile](../../../../images/deploy-create-cdn-profile.png)
+![Screenshot of create a new CDN profile](../../../../images/deploy-create-cdn-profile.png)
 
 5. Create a CDN endpoint as described in [Step 3: Create a new CDN endpoint](https://azure.microsoft.com/en-us/documentation/articles/cdn-create-a-storage-account-with-cdn/#step-3-create-a-new-cdn-endpoint).
 
-   For example, in the following screenshot, **spfxsamples** is the endpoint name, **Storage** is the origin type, and **spfxsamples.blob.core.windows.net** is the storage account.
+For example, in the following screenshot, **spfxsamples** is the endpoint name, **Storage** is the origin type, and **spfxsamples.blob.core.windows.net** is the storage account.
 
-   ![Screenshot of create CDN endpoint](../../../../images/deploy-create-cdn-endpoint.png)
+![Screenshot of create CDN endpoint](../../../../images/deploy-create-cdn-endpoint.png)
 
-   The CDN endpoint will be created with the following URL: http://spfxsamples.azureedge.net
+The CDN endpoint will be created with the following URL: http://spfxsamples.azureedge.net
 
-   Because you associated the CDN endpoint with your storage account, you can also access the BLOB container at the following URL:http://spfxsamples.azureedge.net/helloworld-webpart/
+Because you associated the CDN endpoint with your storage account, you can also access the BLOB container at the following URL:http://spfxsamples.azureedge.net/helloworld-webpart/
 
-   Note, however that you have not yet deployed the files.
+Note, however that you have not yet deployed the files.
 
 ## Project directory
 
 1. Switch to console and make sure you are still in the project directory you used to set up your web part project.
 2. End the **gulp serve** task by choosing **Ctrl+C** and go to your project directory:
 
-	```
-	cd helloworld-webpart
-	```
+```
+cd helloworld-webpart
+```
 
 ## Configure Azure Storage account details
 
@@ -87,30 +87,31 @@ Create a new CDN profile and associate the CDN endpoint wit this BLOB container.
 
 2. Open **deploy-azure-storage.json** in the **config** folder.
 
-   This is the file that contains your Azure Storage account details.
+This is the file that contains your Azure Storage account details.
 
-   ```json
-   {
-     "workingDir": "./temp/deploy/",
-     "account": "<!-- STORAGE ACCOUNT NAME -->",
-     "container": "helloworld-webpart",
-     "accessKey": "<!-- ACCESS KEY -->"
-   }
-   ```
+```json
+{
+  "workingDir": "./temp/deploy/",
+  "account": "<!-- STORAGE ACCOUNT NAME -->",
+  "container": "helloworld-webpart",
+  "accessKey": "<!-- ACCESS KEY -->"
+}
+```
+
 3. Replace the **account**, **container**, **accessKey** with your storage account name, BLOB container and storage account access key respectively.
 
-  **workingDir** is the directory where the web part assets will be located.
+**workingDir** is the directory where the web part assets will be located.
 
-  In this example, with the storage account created earlier, this file will look like:
+In this example, with the storage account created earlier, this file will look like:
 
-  ```json
-  {
-    "workingDir": "./temp/deploy/",
-    "account": "spfxsamples",
-    "container": "helloworld-webpart",
-    "accessKey": "q1UsGWocj+CnlLuv9ZpriOCj46ikgBvDBCaQ0FfE8+qKVbDTVSbRGj41avlG73rynbvKizZpIKK9XpnpA=="
-  }
-  ```
+```json
+{
+  "workingDir": "./temp/deploy/",
+  "account": "spfxsamples",
+  "container": "helloworld-webpart",
+  "accessKey": "q1UsGWocj+CnlLuv9ZpriOCj46ikgBvDBCaQ0FfE8+qKVbDTVSbRGj41avlG73rynbvKizZpIKK9XpnpA=="
+}
+```
 
 4. Save the file.
 
@@ -120,18 +121,18 @@ Before uploading the assets to CDN, you need to build them.
 
 1. Switch to the console and execute the following `gulp` task:
 
-  ```
-  gulp --ship
-  ```
+```
+gulp --ship
+```
 
-  This will build the minified assets required to upload to the CDN provider. The `--ship` indicates the build tool to build for distribution. You should also notice the output of the build tools indicate the Build Target is SHIP.
+This will build the minified assets required to upload to the CDN provider. The `--ship` indicates the build tool to build for distribution. You should also notice the output of the build tools indicate the Build Target is SHIP.
 
-  ```
-  Build target: SHIP
-  [21:23:01] Using gulpfile ~/apps/helloworld-webpart/gulpfile.js
-  [21:23:01] Starting gulp
-  [21:23:01] Starting 'default'...
-  ```
+```
+Build target: SHIP
+[21:23:01] Using gulpfile ~/apps/helloworld-webpart/gulpfile.js
+[21:23:01] Starting gulp
+[21:23:01] Starting 'default'...
+```
 
 The minified assets can be found under the `temp\deploy` directory.
 
@@ -141,11 +142,11 @@ The minified assets can be found under the `temp\deploy` directory.
 
 2. Enter the gulp task to deploy the assets to your storage account:
 
-  ```
-  gulp deploy-azure-storage
-  ```
+```
+gulp deploy-azure-storage
+```
 
-  This will deploy the web part bundle along with other assets like JavaScript and CSS files to the CDN.
+This will deploy the web part bundle along with other assets like JavaScript and CSS files to the CDN.
 
 ### Configuring web part to load from CDN
 
@@ -155,21 +156,21 @@ In order for the web part to load from your CDN, you will need to tell it your C
 
 2. Enter your CDN base path for the **cdnBasePath** property.
 
-  ```json
-  {
-    "cdnBasePath": "<!-- PATH TO CDN -->"
-  }
-  ```
+```json
+{
+  "cdnBasePath": "<!-- PATH TO CDN -->"
+}
+```
 
-  In this example, with the CDN profile created earlier, this file will look like:
+In this example, with the CDN profile created earlier, this file will look like:
 
-  ```json
-  {
-    "cdnBasePath": "http://spfxsamples.azureedge.net/helloworld-webpart/"
-  }
-  ```
+```json
+{
+  "cdnBasePath": "http://spfxsamples.azureedge.net/helloworld-webpart/"
+}
+```
 
-  >**Note:** The CDN base path is the CDN endpoint with the BLOB container.
+>**Note:** The CDN base path is the CDN endpoint with the BLOB container.
 
 3. Save the file.
 
@@ -183,10 +184,10 @@ Because you changed the web part bundle, you will need to re-deploy the package 
 
 2. Enter the gulp task to package the client-side solution, this time with the `--ship` flag set. This forces the task to pick up the CDN base path configured in the previous step:
 
-  ```
-  gulp bundle --ship
-  gulp package-solution --ship
-  ```
+```
+gulp bundle --ship
+gulp package-solution --ship
+```
 
 > **Note:** "gulp bundle --ship" is a temporary fix needed with Developer Preview to ensure that files are rebuilt properly for packaging.
 
@@ -196,9 +197,9 @@ This will create the updated client-side solution package in the **sharepoint\so
 
 1. Upload or drag & drop the client-side solution package to the App Catalog.
 
-  Because you already  deployed the package, you will be prompted as to whether to replace the existing package.
+Because you already  deployed the package, you will be prompted as to whether to replace the existing package.
 
-  ![Screenshot of replace client-side solution package prompt](../../../../images/sp-app-replace-pkg.png)
+![Screenshot of replace client-side solution package prompt](../../../../images/sp-app-replace-pkg.png)
 
 2. Choose **Replace It**.
 

--- a/docs/spfx/web-parts/get-started/serve-your-web-part-in-a-sharepoint-page.md
+++ b/docs/spfx/web-parts/get-started/serve-your-web-part-in-a-sharepoint-page.md
@@ -11,19 +11,19 @@ Be sure you have completed the procedures in the following articles before you s
 
 ## Package the HelloWorld web part
 
-1. In the console window, go to the web part project directory created in [Build your first SharePoint client-side web part](./build-a-hello-world-web-part).
+In the console window, go to the web part project directory created in [Build your first SharePoint client-side web part](./build-a-hello-world-web-part).
 
 ```
 cd helloworld-webpart
 ```
 
-2. If `gulp serve` is still running, stop it from running by choosing `Ctrl+C`
+If `gulp serve` is still running, stop it from running by choosing `Ctrl+C`
 
 Unlike in the workbench, in order to use client-side web parts on classic SharePoint server-side pages, you need to deploy and register the web part with SharePoint. First you need to package the web part.
 
-3. Open the **HelloWorldWebPart** web part project in Visual Studio Code, or your preferred IDE.
+Open the **HelloWorldWebPart** web part project in Visual Studio Code, or your preferred IDE.
 
-4. Open **package-solution.json** from the **config** folder.
+Open **package-solution.json** from the **config** folder.
 
 The **package-solution.json** file defines the package metadata as shown in the following code:
 
@@ -40,7 +40,7 @@ The **package-solution.json** file defines the package metadata as shown in the 
 }
 ```
 
-5. In the console window, enter the following command to package your client-side solution that contains the web part:
+In the console window, enter the following command to package your client-side solution that contains the web part:
 
 ```
 gulp package-solution
@@ -68,9 +68,9 @@ The JavaScript files, CSS and other assets are not packaged and you will have to
 
 Next you need to deploy the package that was generated to the App Catalog.
 
-1. Go to your site's App Catalog.
+Go to your site's App Catalog.
 
-2. Upload or drag and drop the **helloworld-webpart.spapp** to the App Catalog.
+Upload or drag and drop the **helloworld-webpart.spapp** to the App Catalog.
 
 ![Upload solution to app catalog](../../../../images/upload-solution-app-catalog.png) 
 
@@ -78,19 +78,19 @@ This will deploy the client-side solution package. Since this is a full trust cl
 
 ![Trust client-side solution deployment](../../../../images/sp-app-deploy-trust.png) 
 	
-3. Choose **Deploy**
+Choose **Deploy**
 
 ## Install the client-side solution on your site
 
-1. Go to your developer site collection.
+Go to your developer site collection.
 
-2. Choose the gears icon on the top nav bar on the right and choose **Add an app** to go to your Apps page.
+Choose the gears icon on the top nav bar on the right and choose **Add an app** to go to your Apps page.
 
-3. In the **Search** box, enter **helloworld** and choose **Enter** to filter your apps.
+In the **Search** box, enter **helloworld** and choose **Enter** to filter your apps.
 	
 ![Add app to site](../../../../images/install-app-your-site.png) 
 	
-4. Choose the **helloworld-webpart-client-side-solution** app to install the app on the site.
+Choose the **helloworld-webpart-client-side-solution** app to install the app on the site.
 	
 ![Trust app](../../../../images/app-installed-your-site.png) 
 
@@ -102,7 +102,7 @@ The **Site Contents** page will show you the installation status of your client-
 
 Now that you have deployed and installed the client-side solution, add the web part to a classic SharePoint page. Remember that resources such as JavaScripts, and CSS, are available from the local computer.
 
-1. Open the **<your-webpart-guid>.manifest.json** from the **\dist** folder.
+Open the **<your-webpart-guid>.manifest.json** from the **\dist** folder.
 	
 Notice that the **internalModuleBaseUrls** property in the **loaderConfig** entry still refers to your local computer:
 
@@ -114,7 +114,7 @@ Notice that the **internalModuleBaseUrls** property in the **loaderConfig** entr
 
 Before adding the web part to a SharePoint server-side page, run the local server.
 	
-2. In the console window that has the **helloworld-webpart** project directory, run the gulp task to start serving from localhost:
+In the console window that has the **helloworld-webpart** project directory, run the gulp task to start serving from localhost:
 	
 ```
 gulp serve --nobrowser
@@ -124,25 +124,23 @@ gulp serve --nobrowser
 
 ## Add the HelloWorld web part to classic page
 
-1. In your browser go to your site collection.
+In your browser go to your site collection.
 	
 In the next steps, create a classic page, and go to the **SitePages** library in your site.
 	
-2. Choose the gears icon in the top nav bar on the right and choose **Site Contents**.
+Choose the gears icon in the top nav bar on the right and choose **Site Contents**.
 	
-3. Choose the **SitePages** library icon to go to the **SitePages** library.
+Choose the **SitePages** library icon to go to the **SitePages** library.
 	
-4. Choose **New** to create a classic SharePoint page.
+Choose **New** to create a classic SharePoint page.
 	
-5. Enter **HelloWorld** as the page name.
+Enter **HelloWorld** as the page name.
 	
-6. Choose the **Create** button to create the web part page.
+Choose the **Create** button to create the web part page. SharePoint will create your page.
 	
-SharePoint will create your page.
+In the ribbon, choose **Insert -> Web Part** to open the Web Part Gallery.
 	
-7. In the ribbon, choose **Insert -> Web Part** to open the Web Part Gallery.
-	
-8. In the Web Part Gallery, choose the category **Custom**.
+In the Web Part Gallery, choose the category **Custom**.
 	
 >**Note:** During preview, client-side web parts will be available under the **Custom** category in the web part gallery. 
 
@@ -150,9 +148,9 @@ You should see your Hello World web part.
 
 ![Web Part gallery opened with custom category](../../../../images/webpart-gallery-helloworld.png)
 	
-9. Select the Hello World web part and choose **Add** to add it to the page.
+Select the Hello World web part and choose **Add** to add it to the page.
 	
-10. The web part assets will be loaded from the local environment. In order to load the scripts hosted on your local computer, you need to enable the browser to load unsafe scripts. Depending on the browser you are using, make sure you enable loading unsafe scripts for this session.
+The web part assets will be loaded from the local environment. In order to load the scripts hosted on your local computer, you need to enable the browser to load unsafe scripts. Depending on the browser you are using, make sure you enable loading unsafe scripts for this session.
 	
 You should see the **HelloWorld** web part you built in the previous article that retrieves lists from the current site. 
 
@@ -160,7 +158,7 @@ You should see the **HelloWorld** web part you built in the previous article tha
 
 ## Edit web part properties
 
-1. Choose the web part edit menu and choose **Edit Web Part** to open the property pane for the web part.
+Choose the web part edit menu and choose **Edit Web Part** to open the property pane for the web part.
 	
 ![Edit web part](../../../../images/edit-webpart-classic-page.png)
 
@@ -168,25 +166,25 @@ The property pane opens as a server-side web part property pane. However, you ha
 
 ![Configure web part - Property Pane options](../../../../images/webpart-configure-property-pane.png)
 	
-2. Choose the **Configure** button to reveal the new client-side property pane for your client-side web part.
+Choose the **Configure** button to reveal the new client-side property pane for your client-side web part.
 	
 This is the same property pane you built and previewed in the workbench.
 	
-3. Edit the **Description** property and enter **Client-side web parts are awesome!**
+Edit the **Description** property and enter **Client-side web parts are awesome!**
 	
 ![Hello World web part in classic page](../../../../images/sp-wp-classic-page-pp.png)
 
 Notice that you still have the same behaviors such as a reactive pane where the web part is updated as you type.
 	
-4. Choose the **x** icon to close the client-side property pane.
+Choose the **x** icon to close the client-side property pane.
 	
 >**Note:** You will need to choose the **x** icon several times to close the property pane. This is a known issue.
 	
-5. Choose the **Ok** button in the server-side property pane to save and close the web part property pane.
+Choose the **Ok** button in the server-side property pane to save and close the web part property pane.
 	
 Since the web part is running in a classic SharePoint page, choosing **Ok** or **Apply** buttons will save the web part properties.
 	
-6. In the ribbon, choose **Save** to save the page.
+In the ribbon, choose **Save** to save the page.
 
 ## Next steps
 

--- a/docs/spfx/web-parts/get-started/serve-your-web-part-in-a-sharepoint-page.md
+++ b/docs/spfx/web-parts/get-started/serve-your-web-part-in-a-sharepoint-page.md
@@ -13,44 +13,44 @@ Be sure you have completed the procedures in the following articles before you s
 
 1. In the console window, go to the web part project directory created in [Build your first SharePoint client-side web part](./build-a-hello-world-web-part).
 
-	```
-	cd helloworld-webpart
-	```
+```
+cd helloworld-webpart
+```
 
 2. If `gulp serve` is still running, stop it from running by choosing `Ctrl+C`
 
-	Unlike in the workbench, in order to use client-side web parts on classic SharePoint server-side pages, you need to deploy and register the web part with SharePoint. First you need to package the web part.
+Unlike in the workbench, in order to use client-side web parts on classic SharePoint server-side pages, you need to deploy and register the web part with SharePoint. First you need to package the web part.
 
 3. Open the **HelloWorldWebPart** web part project in Visual Studio Code, or your preferred IDE.
 
 4. Open **package-solution.json** from the **config** folder.
 
-	The **package-solution.json** file defines the package metadata as shown in the following code:
+The **package-solution.json** file defines the package metadata as shown in the following code:
 
-	```json
-	{
-		"solution": {
-		"name": "helloworld-webpart-client-side-solution",
-		"id": "ed83e452-2286-4ea0-8f98-c79d257acea5",
-		"version": "1.0.0.0"
-		},
-		"paths": {
-		"zippedPackage": "helloworld-webpart.spapp"
-		}
+```json
+{
+	"solution": {
+	"name": "helloworld-webpart-client-side-solution",
+	"id": "ed83e452-2286-4ea0-8f98-c79d257acea5",
+	"version": "1.0.0.0"
+	},
+	"paths": {
+	"zippedPackage": "helloworld-webpart.spapp"
 	}
-	```
+}
+```
 
 5. In the console window, enter the following command to package your client-side solution that contains the web part:
 
-	```
-	gulp package-solution
-	```
+```
+gulp package-solution
+```
 
-	The command will create the package in the `sharepoint` folder:
+The command will create the package in the `sharepoint` folder:
 
-	```
-	helloworld-webpart.spapp
-	```
+```
+helloworld-webpart.spapp
+```
 
 ### Package contents
 
@@ -72,11 +72,11 @@ Next you need to deploy the package that was generated to the App Catalog.
 
 2. Upload or drag and drop the **helloworld-webpart.spapp** to the App Catalog.
 
-	![Upload solution to app catalog](../../../../images/upload-solution-app-catalog.png) 
-	
-	This will deploy the client-side solution package. Since this is a full trust client-side solution, SharePoint will display a dialog and ask you to trust the client-side solution to deploy.
-	
-	![Trust client-side solution deployment](../../../../images/sp-app-deploy-trust.png) 
+![Upload solution to app catalog](../../../../images/upload-solution-app-catalog.png) 
+
+This will deploy the client-side solution package. Since this is a full trust client-side solution, SharePoint will display a dialog and ask you to trust the client-side solution to deploy.
+
+![Trust client-side solution deployment](../../../../images/sp-app-deploy-trust.png) 
 	
 3. Choose **Deploy**
 
@@ -88,15 +88,15 @@ Next you need to deploy the package that was generated to the App Catalog.
 
 3. In the **Search** box, enter **helloworld** and choose **Enter** to filter your apps.
 	
-	![Add app to site](../../../../images/install-app-your-site.png) 
+![Add app to site](../../../../images/install-app-your-site.png) 
 	
 4. Choose the **helloworld-webpart-client-side-solution** app to install the app on the site.
 	
-	![Trust app](../../../../images/app-installed-your-site.png) 
-	
-	The client-side solution and the web part are installed on your developer site.
-	
-	The **Site Contents** page will show you the installation status of your client-side solution. Make sure the installation is complete before going to the next step.
+![Trust app](../../../../images/app-installed-your-site.png) 
+
+The client-side solution and the web part are installed on your developer site.
+
+The **Site Contents** page will show you the installation status of your client-side solution. Make sure the installation is complete before going to the next step.
 
 ## Preview the web part in a classic SharePoint page
 
@@ -104,29 +104,29 @@ Now that you have deployed and installed the client-side solution, add the web p
 
 1. Open the **<your-webpart-guid>.manifest.json** from the **\dist** folder.
 	
-	Notice that the **internalModuleBaseUrls** property in the **loaderConfig** entry still refers to your local computer:
-	
-	```json
-	"internalModuleBaseUrls": [
-		"http://`your-local-machine-name`:4321/"
-	]
-	```
-	
-	Before adding the web part to a SharePoint server-side page, run the local server.
+Notice that the **internalModuleBaseUrls** property in the **loaderConfig** entry still refers to your local computer:
+
+```json
+"internalModuleBaseUrls": [
+	"http://`your-local-machine-name`:4321/"
+]
+```
+
+Before adding the web part to a SharePoint server-side page, run the local server.
 	
 2. In the console window that has the **helloworld-webpart** project directory, run the gulp task to start serving from localhost:
 	
-	```
-	gulp serve --nobrowser
-	```
-	
-	>**Note:** `--nobrowser` will not automatically launch the Web Part Workbench.
+```
+gulp serve --nobrowser
+```
+
+>**Note:** `--nobrowser` will not automatically launch the Web Part Workbench.
 
 ## Add the HelloWorld web part to classic page
 
 1. In your browser go to your site collection.
 	
-	In the next steps, create a classic page, and go to the **SitePages** library in your site.
+In the next steps, create a classic page, and go to the **SitePages** library in your site.
 	
 2. Choose the gears icon in the top nav bar on the right and choose **Site Contents**.
 	
@@ -138,53 +138,53 @@ Now that you have deployed and installed the client-side solution, add the web p
 	
 6. Choose the **Create** button to create the web part page.
 	
-	SharePoint will create your page.
+SharePoint will create your page.
 	
 7. In the ribbon, choose **Insert -> Web Part** to open the Web Part Gallery.
 	
 8. In the Web Part Gallery, choose the category **Custom**.
 	
-	>**Note:** During preview, client-side web parts will be available under the **Custom** category in the web part gallery. 
-	
-	You should see your Hello World web part.
-	
-	![Web Part gallery opened with custom category](../../../../images/webpart-gallery-helloworld.png)
+>**Note:** During preview, client-side web parts will be available under the **Custom** category in the web part gallery. 
+
+You should see your Hello World web part.
+
+![Web Part gallery opened with custom category](../../../../images/webpart-gallery-helloworld.png)
 	
 9. Select the Hello World web part and choose **Add** to add it to the page.
 	
 10. The web part assets will be loaded from the local environment. In order to load the scripts hosted on your local computer, you need to enable the browser to load unsafe scripts. Depending on the browser you are using, make sure you enable loading unsafe scripts for this session.
 	
-	You should see the **HelloWorld** web part you built in the previous article that retrieves lists from the current site. 
-	
-	![Hello World web part in classic page](../../../../images/sp-wp-classic-page.png)
+You should see the **HelloWorld** web part you built in the previous article that retrieves lists from the current site. 
+
+![Hello World web part in classic page](../../../../images/sp-wp-classic-page.png)
 
 ## Edit web part properties
 
 1. Choose the web part edit menu and choose **Edit Web Part** to open the property pane for the web part.
 	
-	![Edit web part](../../../../images/edit-webpart-classic-page.png)
-	
-	The property pane opens as a server-side web part property pane. However, you have an option to configure the properties for your client-side web part.
-	
-	![Configure web part - Property Pane options](../../../../images/webpart-configure-property-pane.png)
+![Edit web part](../../../../images/edit-webpart-classic-page.png)
+
+The property pane opens as a server-side web part property pane. However, you have an option to configure the properties for your client-side web part.
+
+![Configure web part - Property Pane options](../../../../images/webpart-configure-property-pane.png)
 	
 2. Choose the **Configure** button to reveal the new client-side property pane for your client-side web part.
 	
-	This is the same property pane you built and previewed in the workbench.
+This is the same property pane you built and previewed in the workbench.
 	
 3. Edit the **Description** property and enter **Client-side web parts are awesome!**
 	
-	![Hello World web part in classic page](../../../../images/sp-wp-classic-page-pp.png)
-	
-	Notice that you still have the same behaviors such as a reactive pane where the web part is updated as you type.
+![Hello World web part in classic page](../../../../images/sp-wp-classic-page-pp.png)
+
+Notice that you still have the same behaviors such as a reactive pane where the web part is updated as you type.
 	
 4. Choose the **x** icon to close the client-side property pane.
 	
-	>**Note:** You will need to choose the **x** icon several times to close the property pane. This is a known issue.
+>**Note:** You will need to choose the **x** icon several times to close the property pane. This is a known issue.
 	
 5. Choose the **Ok** button in the server-side property pane to save and close the web part property pane.
 	
-	Since the web part is running in a classic SharePoint page, choosing **Ok** or **Apply** buttons will save the web part properties.
+Since the web part is running in a classic SharePoint page, choosing **Ok** or **Apply** buttons will save the web part properties.
 	
 6. In the ribbon, choose **Save** to save the page.
 

--- a/docs/spfx/web-parts/get-started/use-fabric-react-components.md
+++ b/docs/spfx/web-parts/get-started/use-fabric-react-components.md
@@ -15,89 +15,89 @@ The following image shows a DocumentCard component created with Office UI Fabric
 
 1. Create a new project directory in your favorite location:
 
-	```
-	md documentcardexample-webpart
-	```
+```
+md documentcardexample-webpart
+```
     
 2. Got to the project directory:
 
-	```
-	cd documentcardexample-webpart
-	```
+```
+cd documentcardexample-webpart
+```
 
 3. Create a new web part by running the Yeoman SharePoint generator:
 
-	```
-	yo @microsoft/sharepoint
-	```
+```
+yo @microsoft/sharepoint
+```
     
-	When prompted:
-	
-	* Accept the default **documentcardexample-webpart** as your solution name and choose **Enter**.
-	* Select **Use the current folder** as the location for the files.
-	* Use **DocumentCardExample** for your web part name and choose **Enter**.
-	* Accept the default **DocumentCardExample description** and choose **Enter**.
-	* Select **React** as the framework and choose **Enter**.
-	
-	At this point, Yeoman will install the required dependencies and scaffold the solution files. This might take a few minutes. Yeoman will scaffold the project to include your DocumentCardExample web part as well.
+When prompted:
+
+* Accept the default **documentcardexample-webpart** as your solution name and choose **Enter**.
+* Select **Use the current folder** as the location for the files.
+* Use **DocumentCardExample** for your web part name and choose **Enter**.
+* Accept the default **DocumentCardExample description** and choose **Enter**.
+* Select **React** as the framework and choose **Enter**.
+
+At this point, Yeoman will install the required dependencies and scaffold the solution files. This might take a few minutes. Yeoman will scaffold the project to include your DocumentCardExample web part as well.
 	
 4. When the scaffold is complete, in the console, type the following to open the web part project in Visual Studio Code:
 
-	```
-	code .
-	```
+```
+code .
+```
 	
-	You now have a web part project with the React framework.
-	
-	Open **DocumentCardExampleWebPart.ts** from the **src\webparts\documentCardExample** folder. 
-	
-	As you can see, the `render` method creates a react element and renders it in the web part DOM.
-	
-	```ts
-	public render(mode: DisplayMode, data?: IWebPartData): void {
-		const element: React.ReactElement<IDocumentCardProps> = React.createElement(DocumentCard, {
-			description: this.properties.description
-		});
-	
-	ReactDom.render(element, this.domElement);
-	}
-	```
+You now have a web part project with the React framework.
+
+Open **DocumentCardExampleWebPart.ts** from the **src\webparts\documentCardExample** folder. 
+
+As you can see, the `render` method creates a react element and renders it in the web part DOM.
+
+```ts
+public render(mode: DisplayMode, data?: IWebPartData): void {
+	const element: React.ReactElement<IDocumentCardProps> = React.createElement(DocumentCard, {
+		description: this.properties.description
+	});
+
+ReactDom.render(element, this.domElement);
+}
+```
 	
 5. Open **DocumentCardExample.tsx** from the **src\webparts\documentCardExample\components** folder. 
 	
-	This is the main react component that Yeoman added to your project that renders in the web part DOM.
-	
-	```ts
-	export default class DocumentCardExample extends React.Component<IDocumentCardProps, {}> {
-	public render(): JSX.Element {
-		return (
-			<div className={styles.documentcard}>
-				<div className={styles.container}>
-					<div className={css('ms-Grid-row ms-bgColor-themeDark ms-fontColor-white', styles.row)}>
-						<div className='ms-Grid-col ms-u-lg10 ms-u-xl8 ms-u-xlPush2 ms-u-lgPush1'>
-							<span className='ms-font-xl ms-fontColor-white'>
-								Welcome to SharePoint!
-							</span>
-							<p className='ms-font-l ms-fontColor-white'>
-								Customize SharePoint experiences using Web Parts.
-							</p>
-							<p className='ms-font-l ms-fontColor-white'>
-								{this.props.description}
-							</p>
-							<a
-								className={css('ms-Button', styles.button)}
-								href='https://github.com/SharePoint/sp-dev-docs/wiki'
-							>
-								<span className='ms-Button-label'>Learn more</span>
-							</a>
-						</div>
+This is the main react component that Yeoman added to your project that renders in the web part DOM.
+
+```ts
+export default class DocumentCardExample extends React.Component<IDocumentCardProps, {}> {
+public render(): JSX.Element {
+	return (
+		<div className={styles.documentcard}>
+			<div className={styles.container}>
+				<div className={css('ms-Grid-row ms-bgColor-themeDark ms-fontColor-white', styles.row)}>
+					<div className='ms-Grid-col ms-u-lg10 ms-u-xl8 ms-u-xlPush2 ms-u-lgPush1'>
+						<span className='ms-font-xl ms-fontColor-white'>
+							Welcome to SharePoint!
+						</span>
+						<p className='ms-font-l ms-fontColor-white'>
+							Customize SharePoint experiences using Web Parts.
+						</p>
+						<p className='ms-font-l ms-fontColor-white'>
+							{this.props.description}
+						</p>
+						<a
+							className={css('ms-Button', styles.button)}
+							href='https://github.com/SharePoint/sp-dev-docs/wiki'
+						>
+							<span className='ms-Button-label'>Learn more</span>
+						</a>
 					</div>
 				</div>
 			</div>
-			);
-		}
+		</div>
+		);
 	}
-	```
+}
+```
 
 ## Add an Office UI Fabric component
 
@@ -119,67 +119,67 @@ After you install the Office UI Fabric React components, you can add the compone
 
 2. Add the following `import` statement to to the top of the file to import fabric react components that we want to use.
 
-	```ts
-	import {
-	  DocumentCard,
-	  DocumentCardPreview,
-	  DocumentCardTitle,
-	  DocumentCardActivity,
-	  IDocumentCardPreviewProps
-	} from 'office-ui-fabric-react/lib/DocumentCard';
-	```
+```ts
+import {
+	DocumentCard,
+	DocumentCardPreview,
+	DocumentCardTitle,
+	DocumentCardActivity,
+	IDocumentCardPreviewProps
+} from 'office-ui-fabric-react/lib/DocumentCard';
+```
 
 3. Delete the current `render` method and add the following updated `render` method:
 
-	```ts
-	public render() {
-	  let previewProps: IDocumentCardPreviewProps = {
-	    previewImages: [
-	      {
-	        previewImageSrc: require('document-preview.png'),
-	        iconSrc: require('icon-ppt.png'),
-	        width: 318,
-	        height: 196,
-	        accentColor: '#ce4b1f'
-	      }
-	    ],
-	  };
-	
-	  return (
-	      <DocumentCard onClickHref='http://bing.com'>
-	        <DocumentCardPreview { ...previewProps } />
-	        <DocumentCardTitle title='Revenue stream proposal fiscal year 2016 version02.pptx'/>
-	        <DocumentCardActivity
-	          activity='Created Feb 23, 2016'
-	          people={
-	            [
-	              { name: 'Kat Larrson', profileImageSrc: require('avatar-kat.png') }
-	            ]
-	          }
-	        />
-	      </DocumentCard>
-	  );
-	}
-	```
+```ts
+public render() {
+	let previewProps: IDocumentCardPreviewProps = {
+	previewImages: [
+		{
+		previewImageSrc: require('document-preview.png'),
+		iconSrc: require('icon-ppt.png'),
+		width: 318,
+		height: 196,
+		accentColor: '#ce4b1f'
+		}
+	],
+	};
+
+	return (
+		<DocumentCard onClickHref='http://bing.com'>
+		<DocumentCardPreview { ...previewProps } />
+		<DocumentCardTitle title='Revenue stream proposal fiscal year 2016 version02.pptx'/>
+		<DocumentCardActivity
+			activity='Created Feb 23, 2016'
+			people={
+			[
+				{ name: 'Kat Larrson', profileImageSrc: require('avatar-kat.png') }
+			]
+			}
+		/>
+		</DocumentCard>
+	);
+}
+```
 
 4. Save the file.
 
-	In this code, the DocumentCard component includes some extra sections:
-	* DocumentCardPreview
-	* DocumentCardTitle
-	* DocumentCardActivity
-	
-	The `previewProps` property includes some properties of the DocumentCardPreview.
-	
-	Notice the use of relative path with a `require` statement to load images. Currently, you need to use the webpack public path plugin and input the file's relative path from your source file or folder to the `lib` folder. This should be the same as your current working source location.
+In this code, the DocumentCard component includes some extra sections:
+* DocumentCardPreview
+* DocumentCardTitle
+* DocumentCardActivity
+
+The `previewProps` property includes some properties of the DocumentCardPreview.
+
+Notice the use of relative path with a `require` statement to load images. Currently, you need to use the webpack public path plugin and input the file's relative path from your source file or folder to the `lib` folder. This should be the same as your current working source location.
 	
 5. Open **DocumentCardExampleWebPart.ts** from the **src\webparts\documentCardExample** folder. 
 	
 6. Add the following code at the top of the file to require the webpack public path plugin.
 	
-	```ts
-	require('set-webpack-public-path!');
-	```
+```ts
+require('set-webpack-public-path!');
+```
 	
 7. Save the file.
 
@@ -195,11 +195,11 @@ Copy the following images to your **src\webparts\documentCardExample** folder:
 
 1. In the console, type the following to preview your web part in workbench:
 	
-	```
-	gulp serve
-	```
+```
+gulp serve
+```
 	
 2. In the toolbox, select your `DocumentCardExample` web part to add:
 	
-	![Image of a DocumentCard Fabric component in a SharePoint workbench](../../../../images/fabric-components-doc-card-view-ex.png)
+![Image of a DocumentCard Fabric component in a SharePoint workbench](../../../../images/fabric-components-doc-card-view-ex.png)
 

--- a/docs/spfx/web-parts/get-started/use-fabric-react-components.md
+++ b/docs/spfx/web-parts/get-started/use-fabric-react-components.md
@@ -13,19 +13,19 @@ The following image shows a DocumentCard component created with Office UI Fabric
 
 ## Create a new web part project
 
-1. Create a new project directory in your favorite location:
+Create a new project directory in your favorite location:
 
 ```
 md documentcardexample-webpart
 ```
     
-2. Got to the project directory:
+Got to the project directory:
 
 ```
 cd documentcardexample-webpart
 ```
 
-3. Create a new web part by running the Yeoman SharePoint generator:
+Create a new web part by running the Yeoman SharePoint generator:
 
 ```
 yo @microsoft/sharepoint
@@ -41,7 +41,7 @@ When prompted:
 
 At this point, Yeoman will install the required dependencies and scaffold the solution files. This might take a few minutes. Yeoman will scaffold the project to include your DocumentCardExample web part as well.
 	
-4. When the scaffold is complete, in the console, type the following to open the web part project in Visual Studio Code:
+When the scaffold is complete, in the console, type the following to open the web part project in Visual Studio Code:
 
 ```
 code .
@@ -63,7 +63,7 @@ ReactDom.render(element, this.domElement);
 }
 ```
 	
-5. Open **DocumentCardExample.tsx** from the **src\webparts\documentCardExample\components** folder. 
+Open **DocumentCardExample.tsx** from the **src\webparts\documentCardExample\components** folder. 
 	
 This is the main react component that Yeoman added to your project that renders in the web part DOM.
 
@@ -115,9 +115,9 @@ npm i office-ui-fabric-react --save
 
 After you install the Office UI Fabric React components, you can add the component to your web part. 
 
-1. Open **DocumentCardExample.tsx** from the **src\webparts\components\documentCardExample** folder. 
+Open **DocumentCardExample.tsx** from the **src\webparts\components\documentCardExample** folder. 
 
-2. Add the following `import` statement to to the top of the file to import fabric react components that we want to use.
+Add the following `import` statement to to the top of the file to import fabric react components that we want to use.
 
 ```ts
 import {
@@ -129,7 +129,7 @@ import {
 } from 'office-ui-fabric-react/lib/DocumentCard';
 ```
 
-3. Delete the current `render` method and add the following updated `render` method:
+Delete the current `render` method and add the following updated `render` method:
 
 ```ts
 public render() {
@@ -162,7 +162,7 @@ public render() {
 }
 ```
 
-4. Save the file.
+Save the file.
 
 In this code, the DocumentCard component includes some extra sections:
 * DocumentCardPreview
@@ -173,15 +173,15 @@ The `previewProps` property includes some properties of the DocumentCardPreview.
 
 Notice the use of relative path with a `require` statement to load images. Currently, you need to use the webpack public path plugin and input the file's relative path from your source file or folder to the `lib` folder. This should be the same as your current working source location.
 	
-5. Open **DocumentCardExampleWebPart.ts** from the **src\webparts\documentCardExample** folder. 
+Open **DocumentCardExampleWebPart.ts** from the **src\webparts\documentCardExample** folder. 
 	
-6. Add the following code at the top of the file to require the webpack public path plugin.
+Add the following code at the top of the file to require the webpack public path plugin.
 	
 ```ts
 require('set-webpack-public-path!');
 ```
 	
-7. Save the file.
+Save the file.
 
 ## Copy the image assets
 
@@ -193,13 +193,13 @@ Copy the following images to your **src\webparts\documentCardExample** folder:
 
 ## Preview the web part in workbench
 
-1. In the console, type the following to preview your web part in workbench:
+In the console, type the following to preview your web part in workbench:
 	
 ```
 gulp serve
 ```
 	
-2. In the toolbox, select your `DocumentCardExample` web part to add:
+In the toolbox, select your `DocumentCardExample` web part to add:
 	
 ![Image of a DocumentCard Fabric component in a SharePoint workbench](../../../../images/fabric-components-doc-card-view-ex.png)
 


### PR DESCRIPTION
The numbered indentations is causing issues in rendering. One of the reasons the current docs in the wiki do not use numbered indentations. 

I also fixed few issues with the setup your development doc as well.