### PR TITLE
Update webhooks-reference-implementation.md

### DIFF
--- a/docs/apis/webhooks/webhooks-reference-implementation.md
+++ b/docs/apis/webhooks/webhooks-reference-implementation.md
@@ -146,7 +146,7 @@ Create a web job that on a weekly basis reads all the subscription IDs from the 
 
 > **Note:** This web job is not part of this reference implementation.
 
-The actual renewal of a SharePoint list webhook can be done using a [`PATCH /_api/web/lists('list-id')/subscriptions(‘subscriptionID’)`](./lists/update-subscription) REST call. In the reference implementation, updating of webhooks is implemented in the [WebHookManager](https://github.com/SharePoint/sp-dev-samples/blob/master/Samples/WebHooks.List/SharePoint.WebHooks.Common/WebHookManager.cs) class of the **SharePoint.WebHooks.Common** project. Updating a webhook is done using the **AddListWebHookAsync** method:
+The actual renewal of a SharePoint list webhook can be done using a [`PATCH /_api/web/lists('list-id')/subscriptions(‘subscriptionID’)`](./lists/update-subscription) REST call. In the reference implementation, updating of webhooks is implemented in the [WebHookManager](https://github.com/SharePoint/sp-dev-samples/blob/master/Samples/WebHooks.List/SharePoint.WebHooks.Common/WebHookManager.cs) class of the **SharePoint.WebHooks.Common** project. Updating a webhook is done using the **UpdateListWebHookAsync** method:
 
 ```csharp
 /// <summary>


### PR DESCRIPTION
Under the subheading "**Reliable but more complex model**", the text reads: Updating a webhook is done using the **AddListWebHookAsync** method. I changed the method name to **UpdateListWebHookAsync** 