### PR TITLE
updated docs to add typings for microsoft.ajax

### DIFF
--- a/docs/spfx/web-parts/basics/add-an-external-library.md
+++ b/docs/spfx/web-parts/basics/add-an-external-library.md
@@ -258,6 +258,12 @@ contoso.EventList.alert();
 
 Loading SharePoint JSOM is essentially the same scenario as loading non-AMD scripts that have dependencies. This means using both the **globalName** and **globalDependency** options.
 
+Install typings for Microsoft Ajax which is a dependency for JSOM typings:
+
+```
+tsd install microsoft.ajax --save
+```
+
 Install typings for the JSOM:
 
 ```


### PR DESCRIPTION
| Q                   | A
| ---------------     | ---
| content fix?        | yes
| New article?        | no
| Related issues?     | N/A

#### What's in this Pull Request?

Updated the documentation to mention installation of microsoft.ajax typings along withJSOM typings. The JSOM typings have a dependency on microsoft.ajax typings and the project cannot be built without including both.
