### PR TITLE
Update on LTS and added version information

### DIFF
--- a/docs/spfx/set-up-your-development-environment.md
+++ b/docs/spfx/set-up-your-development-environment.md
@@ -7,7 +7,7 @@ You can use Visual Studio, or your own custom development environment to build S
 ## Install developer tools
 
 ### NodeJS
-Install [NodeJS](https://nodejs.org/en/) Long Term Support (LTS) version.
+Install [NodeJS](https://nodejs.org/en/) Long Term Support (LTS) v4.x.x version.
 
 * If you have NodeJS already installed please check you have the latest version using `node -v`. It should return the current [LTS version](https://nodejs.org/en/download/). 
 * If you are using a Mac, it is recommended you use [homebrew](http://brew.sh/) to install and manage NodeJS. 


### PR DESCRIPTION
| Q                   | A
| ---------------     | ---
| content fix?        | yes
| New article?        | no
| Related issues?     | I opened no issue

#### What's in this Pull Request?

The problem is that we currently have two LTS versions of NodeJS
- v4.6.1 LTS
- v6.9.0 LTS

SPFx might fail with version 6.9.0 LTS but works for sure with v4.6.1 LTS. Using NodeJS Version reverences just by using LTS is not enough.

#### Guidance