### PR TITLE
Update build-a-hello-world-web-part.md

### DIFF
--- a/docs/spfx/web-parts/get-started/build-a-hello-world-web-part.md
+++ b/docs/spfx/web-parts/get-started/build-a-hello-world-web-part.md
@@ -249,7 +249,7 @@ Switch back to the **HelloWorldWebPart.ts** file.
 Replace the **propertyPaneConfiguration** method with the code below which adds the new property pane fields and maps them to their respective typed objects.
 
 ```ts
-protected get propertyPaneConfiguration(): IPropertyPaneConfiguration {
+protected get propertyPaneConfiguration(): IPropertyPaneSettings {
   return {
     pages: [
       {


### PR DESCRIPTION
| Q                   | A
| ---------------     | ---
| content fix?        |  yes
| New article?        | no?
| Related issues?     | none.

#### What's in this Pull Request?
just a documentation fix.  The correct return interface type for propertyPaneConfiguration seems to be IPropertyPaneSettings, not IPropertyPaneConfiguration (the latter does not seem to exist).

It could also be that I'm bit by a change between the drops of the framework, but I didn't see a mention of the ...configuration interface anywhere.  My apologies if this is way off.

Changed the interface type used for the return value of propertyPaneConfiguration