### PR TITLE
"**Note:** The SharePoint Framework is currently in preview ..." removed

### DIFF
--- a/reference/spfx/sp-core-library/consume-servicescope.md
+++ b/reference/spfx/sp-core-library/consume-servicescope.md
@@ -1,5 +1,5 @@
 # consume(serviceKey)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/converttoodatastringliteral-urlutilities.md
+++ b/reference/spfx/sp-core-library/converttoodatastringliteral-urlutilities.md
@@ -1,5 +1,5 @@
 # convertToODataStringLiteral()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/create-servicekey.md
+++ b/reference/spfx/sp-core-library/create-servicekey.md
@@ -1,5 +1,5 @@
 # create(name,serviceClass)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/createandprovide-servicescope.md
+++ b/reference/spfx/sp-core-library/createandprovide-servicescope.md
@@ -1,5 +1,5 @@
 # createAndProvide(serviceKey,simpleServiceClass)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/createcustom-servicekey.md
+++ b/reference/spfx/sp-core-library/createcustom-servicekey.md
@@ -1,5 +1,5 @@
 # createCustom(name,defaultCreator)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/createdefaultandprovide-servicescope.md
+++ b/reference/spfx/sp-core-library/createdefaultandprovide-servicescope.md
@@ -1,5 +1,5 @@
 # createDefaultAndProvide(serviceKey)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/equals-guid.md
+++ b/reference/spfx/sp-core-library/equals-guid.md
@@ -1,5 +1,5 @@
 # equals()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/equals-version.md
+++ b/reference/spfx/sp-core-library/equals-version.md
@@ -1,5 +1,5 @@
 # equals(compareWith)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/error-log.md
+++ b/reference/spfx/sp-core-library/error-log.md
@@ -1,5 +1,5 @@
 # error(source,error,scope)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/finish-servicescope.md
+++ b/reference/spfx/sp-core-library/finish-servicescope.md
@@ -1,5 +1,5 @@
 # finish()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/generate-irandomnumbergenerator.md
+++ b/reference/spfx/sp-core-library/generate-irandomnumbergenerator.md
@@ -1,5 +1,5 @@
 # generate()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/generate-randomnumbergenerator.md
+++ b/reference/spfx/sp-core-library/generate-randomnumbergenerator.md
@@ -1,5 +1,5 @@
 # generate()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/getdate-itimeprovider.md
+++ b/reference/spfx/sp-core-library/getdate-itimeprovider.md
@@ -1,5 +1,5 @@
 # getDate()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/getdate-timeprovider.md
+++ b/reference/spfx/sp-core-library/getdate-timeprovider.md
@@ -1,5 +1,5 @@
 # getDate()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/getparent-servicescope.md
+++ b/reference/spfx/sp-core-library/getparent-servicescope.md
@@ -1,5 +1,5 @@
 # getParent()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/gettimestamp-itimeprovider.md
+++ b/reference/spfx/sp-core-library/gettimestamp-itimeprovider.md
@@ -1,5 +1,5 @@
 # getTimestamp()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/gettimestamp-timeprovider.md
+++ b/reference/spfx/sp-core-library/gettimestamp-timeprovider.md
@@ -1,5 +1,5 @@
 # getTimestamp()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/getvalue-urlqueryparametercollection.md
+++ b/reference/spfx/sp-core-library/getvalue-urlqueryparametercollection.md
@@ -1,5 +1,5 @@
 # getValue(param)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/getvalues-urlqueryparametercollection.md
+++ b/reference/spfx/sp-core-library/getvalues-urlqueryparametercollection.md
@@ -1,5 +1,5 @@
 # getValues(param)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/greaterthan-version.md
+++ b/reference/spfx/sp-core-library/greaterthan-version.md
@@ -1,5 +1,5 @@
 # greaterThan(compareWith)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/info-log.md
+++ b/reference/spfx/sp-core-library/info-log.md
@@ -1,5 +1,5 @@
 # info(source,message,scope)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/isnonemptystring-validate.md
+++ b/reference/spfx/sp-core-library/isnonemptystring-validate.md
@@ -1,5 +1,5 @@
 # isNonemptyString(value,variableName)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/isnotnullorundefined-validate.md
+++ b/reference/spfx/sp-core-library/isnotnullorundefined-validate.md
@@ -1,5 +1,5 @@
 # isNotNullOrUndefined(value,variableName)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/istrue-validate.md
+++ b/reference/spfx/sp-core-library/istrue-validate.md
@@ -1,5 +1,5 @@
 # isTrue(value,variableName)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/isvalid-guid.md
+++ b/reference/spfx/sp-core-library/isvalid-guid.md
@@ -1,5 +1,5 @@
 # isValid(guid)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/isvalid-version.md
+++ b/reference/spfx/sp-core-library/isvalid-version.md
@@ -1,5 +1,5 @@
 # isValid(versionString)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/lessthan-version.md
+++ b/reference/spfx/sp-core-library/lessthan-version.md
@@ -1,5 +1,5 @@
 # lessThan(compareWith)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/newguid-guid.md
+++ b/reference/spfx/sp-core-library/newguid-guid.md
@@ -1,5 +1,5 @@
 # newGuid()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/parse-guid.md
+++ b/reference/spfx/sp-core-library/parse-guid.md
@@ -1,5 +1,5 @@
 # parse(guid)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/parse-version.md
+++ b/reference/spfx/sp-core-library/parse-version.md
@@ -1,5 +1,5 @@
 # parse(versionString)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/provide-servicescope.md
+++ b/reference/spfx/sp-core-library/provide-servicescope.md
@@ -1,5 +1,5 @@
 # provide(serviceKey,service)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/removeendslash-urlutilities.md
+++ b/reference/spfx/sp-core-library/removeendslash-urlutilities.md
@@ -1,5 +1,5 @@
 # removeEndSlash(url)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/startnewchild-servicescope.md
+++ b/reference/spfx/sp-core-library/startnewchild-servicescope.md
@@ -1,5 +1,5 @@
 # startNewChild()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/startnewroot-servicescope.md
+++ b/reference/spfx/sp-core-library/startnewroot-servicescope.md
@@ -1,5 +1,5 @@
 # startNewRoot()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/tostring-guid.md
+++ b/reference/spfx/sp-core-library/tostring-guid.md
@@ -1,5 +1,5 @@
 # toString()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/tostring-version.md
+++ b/reference/spfx/sp-core-library/tostring-version.md
@@ -1,5 +1,5 @@
 # toString()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/tryparse-guid.md
+++ b/reference/spfx/sp-core-library/tryparse-guid.md
@@ -1,5 +1,5 @@
 # tryParse(guid)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/tryparse-version.md
+++ b/reference/spfx/sp-core-library/tryparse-version.md
@@ -1,5 +1,5 @@
 # tryParse(versionString)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/verbose-log.md
+++ b/reference/spfx/sp-core-library/verbose-log.md
@@ -1,5 +1,5 @@
 # verbose(source,message,scope)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/warn-log.md
+++ b/reference/spfx/sp-core-library/warn-log.md
@@ -1,5 +1,5 @@
 # warn(source,message,scope)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-core-library/whenfinished-servicescope.md
+++ b/reference/spfx/sp-core-library/whenfinished-servicescope.md
@@ -1,5 +1,5 @@
 # whenFinished(callback)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/arraybuffer-httpclientresponse.md
+++ b/reference/spfx/sp-http/arraybuffer-httpclientresponse.md
@@ -1,5 +1,5 @@
 # arrayBuffer()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/beginbatch-sphttpclient.md
+++ b/reference/spfx/sp-http/beginbatch-sphttpclient.md
@@ -1,5 +1,5 @@
 # beginBatch()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/blob-httpclientresponse.md
+++ b/reference/spfx/sp-http/blob-httpclientresponse.md
@@ -1,5 +1,5 @@
 # blob()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/clone-httpclientresponse.md
+++ b/reference/spfx/sp-http/clone-httpclientresponse.md
@@ -1,5 +1,5 @@
 # clone()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/clone-sphttpclientresponse.md
+++ b/reference/spfx/sp-http/clone-sphttpclientresponse.md
@@ -1,5 +1,5 @@
 # clone()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/error-httpclientresponse.md
+++ b/reference/spfx/sp-http/error-httpclientresponse.md
@@ -1,5 +1,5 @@
 # error()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/fetch-httpclient.md
+++ b/reference/spfx/sp-http/fetch-httpclient.md
@@ -1,5 +1,5 @@
 # fetch(url,configuration,options)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
  Note: This is being made avaiable in **beta** mode. This is not recommended for use in Production.
 

--- a/reference/spfx/sp-http/fetch-sphttpclient.md
+++ b/reference/spfx/sp-http/fetch-sphttpclient.md
@@ -1,5 +1,5 @@
 # fetch(url,configuration,options)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/fetchcore-httpclient.md
+++ b/reference/spfx/sp-http/fetchcore-httpclient.md
@@ -1,5 +1,5 @@
 # fetchCore()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
  Note: This is being made avaiable in **beta** mode. This is not recommended for use in Production.
 

--- a/reference/spfx/sp-http/formdata-httpclientresponse.md
+++ b/reference/spfx/sp-http/formdata-httpclientresponse.md
@@ -1,5 +1,5 @@
 # formData()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/get-httpclient.md
+++ b/reference/spfx/sp-http/get-httpclient.md
@@ -1,5 +1,5 @@
 # get(url,configuration,options)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/get-sphttpclient.md
+++ b/reference/spfx/sp-http/get-sphttpclient.md
@@ -1,5 +1,5 @@
 # get(url,configuration,options)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/getweburlfromrequesturl-sphttpclient.md
+++ b/reference/spfx/sp-http/getweburlfromrequesturl-sphttpclient.md
@@ -1,5 +1,5 @@
 # getWebUrlFromRequestUrl(requestUrl)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/initializeflags-httpclientconfiguration.md
+++ b/reference/spfx/sp-http/initializeflags-httpclientconfiguration.md
@@ -1,5 +1,5 @@
 # initializeFlags()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
  Note: This is being made avaiable in **beta** mode. This is not recommended for use in Production.
 

--- a/reference/spfx/sp-http/initializeflags-sphttpclientcommonconfiguration.md
+++ b/reference/spfx/sp-http/initializeflags-sphttpclientcommonconfiguration.md
@@ -1,5 +1,5 @@
 # initializeFlags()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/initializeflags-sphttpclientconfiguration.md
+++ b/reference/spfx/sp-http/initializeflags-sphttpclientconfiguration.md
@@ -1,5 +1,5 @@
 # initializeFlags()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/json-httpclientresponse.md
+++ b/reference/spfx/sp-http/json-httpclientresponse.md
@@ -1,5 +1,5 @@
 # json()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/overridewith-httpclientconfiguration.md
+++ b/reference/spfx/sp-http/overridewith-httpclientconfiguration.md
@@ -1,5 +1,5 @@
 # overrideWith()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/overridewith-sphttpclientcommonconfiguration.md
+++ b/reference/spfx/sp-http/overridewith-sphttpclientcommonconfiguration.md
@@ -1,5 +1,5 @@
 # overrideWith()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/overridewith-sphttpclientconfiguration.md
+++ b/reference/spfx/sp-http/overridewith-sphttpclientconfiguration.md
@@ -1,5 +1,5 @@
 # overrideWith()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/post-httpclient.md
+++ b/reference/spfx/sp-http/post-httpclient.md
@@ -1,5 +1,5 @@
 # post(url,configuration,options)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/post-sphttpclient.md
+++ b/reference/spfx/sp-http/post-sphttpclient.md
@@ -1,5 +1,5 @@
 # post(url,configuration,options)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/redirect-httpclientresponse.md
+++ b/reference/spfx/sp-http/redirect-httpclientresponse.md
@@ -1,5 +1,5 @@
 # redirect()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/text-httpclientresponse.md
+++ b/reference/spfx/sp-http/text-httpclientresponse.md
@@ -1,5 +1,5 @@
 # text()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/tostring-odataversion.md
+++ b/reference/spfx/sp-http/tostring-odataversion.md
@@ -1,5 +1,5 @@
 # toString()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-http/tryparsefromheaders-odataversion.md
+++ b/reference/spfx/sp-http/tryparsefromheaders-odataversion.md
@@ -1,5 +1,5 @@
 # tryParseFromHeaders()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-loader/initialize-spcomponentloader.md
+++ b/reference/spfx/sp-loader/initialize-spcomponentloader.md
@@ -1,5 +1,5 @@
 # initialize()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-loader/loadcomponent-ispcomponentloader.md
+++ b/reference/spfx/sp-loader/loadcomponent-ispcomponentloader.md
@@ -1,5 +1,5 @@
 # loadComponent(manifest)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-loader/loadcomponent-spcomponentloader.md
+++ b/reference/spfx/sp-loader/loadcomponent-spcomponentloader.md
@@ -1,5 +1,5 @@
 # loadComponent()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-loader/loadcss-ispcomponentloader.md
+++ b/reference/spfx/sp-loader/loadcss-ispcomponentloader.md
@@ -1,5 +1,5 @@
 # loadCss(url)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-loader/loadcss-spcomponentloader.md
+++ b/reference/spfx/sp-loader/loadcss-spcomponentloader.md
@@ -1,5 +1,5 @@
 # loadCss()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-loader/loadscript-ispcomponentloader.md
+++ b/reference/spfx/sp-loader/loadscript-ispcomponentloader.md
@@ -1,5 +1,5 @@
 # loadScript(url,options)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-loader/loadscript-spcomponentloader.md
+++ b/reference/spfx/sp-loader/loadscript-spcomponentloader.md
@@ -1,5 +1,5 @@
 # loadScript()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-page-context/hasallpermissions-sppermission.md
+++ b/reference/spfx/sp-page-context/hasallpermissions-sppermission.md
@@ -1,5 +1,5 @@
 # hasAllPermissions(...requestedPerms)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-page-context/hasanypermissions-sppermission.md
+++ b/reference/spfx/sp-page-context/hasanypermissions-sppermission.md
@@ -1,5 +1,5 @@
 # hasAnyPermissions(...requestedPerms)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-page-context/haspermission-sppermission.md
+++ b/reference/spfx/sp-page-context/haspermission-sppermission.md
@@ -1,5 +1,5 @@
 # hasPermission(requestedPerm)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/__index-iwebpartpropertiesmetadata.md
+++ b/reference/spfx/sp-webpart-base/__index-iwebpartpropertiesmetadata.md
@@ -1,5 +1,5 @@
 # index()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/clearerror-baseclientsidewebpart.md
+++ b/reference/spfx/sp-webpart-base/clearerror-baseclientsidewebpart.md
@@ -1,5 +1,5 @@
 # clearError()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/clearerror-iclientsidewebpartstatusrenderer.md
+++ b/reference/spfx/sp-webpart-base/clearerror-iclientsidewebpartstatusrenderer.md
@@ -1,5 +1,5 @@
 # clearError(domElement)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/clearloadingindicator-iclientsidewebpartstatusrenderer.md
+++ b/reference/spfx/sp-webpart-base/clearloadingindicator-iclientsidewebpartstatusrenderer.md
@@ -1,5 +1,5 @@
 # clearLoadingIndicator(domElement)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/displayloadingindicator-iclientsidewebpartstatusrenderer.md
+++ b/reference/spfx/sp-webpart-base/displayloadingindicator-iclientsidewebpartstatusrenderer.md
@@ -1,5 +1,5 @@
 # displayLoadingIndicator(domElement,loadingMessage,timeout)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/getpropertypaneconfiguration-baseclientsidewebpart.md
+++ b/reference/spfx/sp-webpart-base/getpropertypaneconfiguration-baseclientsidewebpart.md
@@ -1,5 +1,5 @@
 # getPropertyPaneConfiguration()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/onafterdeserialize-baseclientsidewebpart.md
+++ b/reference/spfx/sp-webpart-base/onafterdeserialize-baseclientsidewebpart.md
@@ -1,5 +1,5 @@
 # onAfterDeserialize(deserializedObject,dataVersion)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/onafterpropertypanechangesapplied-baseclientsidewebpart.md
+++ b/reference/spfx/sp-webpart-base/onafterpropertypanechangesapplied-baseclientsidewebpart.md
@@ -1,5 +1,5 @@
 # onAfterPropertyPaneChangesApplied()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/onbeforeserialize-baseclientsidewebpart.md
+++ b/reference/spfx/sp-webpart-base/onbeforeserialize-baseclientsidewebpart.md
@@ -1,5 +1,5 @@
 # onBeforeSerialize()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/ondisplaymodechanged-baseclientsidewebpart.md
+++ b/reference/spfx/sp-webpart-base/ondisplaymodechanged-baseclientsidewebpart.md
@@ -1,5 +1,5 @@
 # onDisplayModeChanged(oldDisplayMode)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/ondispose-baseclientsidewebpart.md
+++ b/reference/spfx/sp-webpart-base/ondispose-baseclientsidewebpart.md
@@ -1,5 +1,5 @@
 # onDispose()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/oninit-baseclientsidewebpart.md
+++ b/reference/spfx/sp-webpart-base/oninit-baseclientsidewebpart.md
@@ -1,5 +1,5 @@
 # onInit()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/onpropertypaneconfigurationcomplete-baseclientsidewebpart.md
+++ b/reference/spfx/sp-webpart-base/onpropertypaneconfigurationcomplete-baseclientsidewebpart.md
@@ -1,5 +1,5 @@
 # onPropertyPaneConfigurationComplete()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/onpropertypaneconfigurationstart-baseclientsidewebpart.md
+++ b/reference/spfx/sp-webpart-base/onpropertypaneconfigurationstart-baseclientsidewebpart.md
@@ -1,5 +1,5 @@
 # onPropertyPaneConfigurationStart()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/onpropertypanefieldchanged-baseclientsidewebpart.md
+++ b/reference/spfx/sp-webpart-base/onpropertypanefieldchanged-baseclientsidewebpart.md
@@ -1,5 +1,5 @@
 # onPropertyPaneFieldChanged(propertyPath,oldValue,newValue)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/onpropertypanerendered-baseclientsidewebpart.md
+++ b/reference/spfx/sp-webpart-base/onpropertypanerendered-baseclientsidewebpart.md
@@ -1,5 +1,5 @@
 # onPropertyPaneRendered()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/propertypanebutton.md
+++ b/reference/spfx/sp-webpart-base/propertypanebutton.md
@@ -1,5 +1,5 @@
 # PropertyPaneButton(targetProperty,properties)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/propertypanecheckbox.md
+++ b/reference/spfx/sp-webpart-base/propertypanecheckbox.md
@@ -1,5 +1,5 @@
 # PropertyPaneCheckbox(targetProperty,properties)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/propertypanechoicegroup.md
+++ b/reference/spfx/sp-webpart-base/propertypanechoicegroup.md
@@ -1,5 +1,5 @@
 # PropertyPaneChoiceGroup(targetProperty,properties)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/propertypanedropdown.md
+++ b/reference/spfx/sp-webpart-base/propertypanedropdown.md
@@ -1,5 +1,5 @@
 # PropertyPaneDropdown(targetProperty,properties)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/propertypanehorizontalrule.md
+++ b/reference/spfx/sp-webpart-base/propertypanehorizontalrule.md
@@ -1,5 +1,5 @@
 # PropertyPaneHorizontalRule(properties)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/propertypanelabel.md
+++ b/reference/spfx/sp-webpart-base/propertypanelabel.md
@@ -1,5 +1,5 @@
 # PropertyPaneLabel(targetProperty,properties)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/propertypanelink.md
+++ b/reference/spfx/sp-webpart-base/propertypanelink.md
@@ -1,5 +1,5 @@
 # PropertyPaneLink(targetProperty,properties)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/propertypaneslider.md
+++ b/reference/spfx/sp-webpart-base/propertypaneslider.md
@@ -1,5 +1,5 @@
 # PropertyPaneSlider(targetProperty,properties)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/propertypanetextfield.md
+++ b/reference/spfx/sp-webpart-base/propertypanetextfield.md
@@ -1,5 +1,5 @@
 # PropertyPaneTextField(targetProperty,properties)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/propertypanetoggle.md
+++ b/reference/spfx/sp-webpart-base/propertypanetoggle.md
@@ -1,5 +1,5 @@
 # PropertyPaneToggle(targetProperty,properties)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/render-baseclientsidewebpart.md
+++ b/reference/spfx/sp-webpart-base/render-baseclientsidewebpart.md
@@ -1,5 +1,5 @@
 # render()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/rendercompleted-baseclientsidewebpart.md
+++ b/reference/spfx/sp-webpart-base/rendercompleted-baseclientsidewebpart.md
@@ -1,5 +1,5 @@
 # renderCompleted()
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/rendererror-baseclientsidewebpart.md
+++ b/reference/spfx/sp-webpart-base/rendererror-baseclientsidewebpart.md
@@ -1,5 +1,5 @@
 # renderError(error)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 

--- a/reference/spfx/sp-webpart-base/rendererror-iclientsidewebpartstatusrenderer.md
+++ b/reference/spfx/sp-webpart-base/rendererror-iclientsidewebpartstatusrenderer.md
@@ -1,5 +1,5 @@
 # renderError(domElement,error)
-**Note:** The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments.
+
 
 
 


### PR DESCRIPTION
| Q                   | A
| ---------------     | ---
| content fix?        | yes

#### What's in this Pull Request?

The following statement is removed from the documents since the framework is now generally available and not anymore in review:

"Note: The SharePoint Framework is currently in preview and is subject to change. SharePoint Framework client-side web parts are not currently supported for use in production environments." 