### PR TITLE
Updated example package-solution.json ID

### DIFF
--- a/docs/spfx/web-parts/get-started/provision-sp-assets-from-package.md
+++ b/docs/spfx/web-parts/get-started/provision-sp-assets-from-package.md
@@ -215,7 +215,7 @@ To ensure that our newly added Feature Framework files are taken into account wh
     "features": [{
       "title": "asset-deployment-webpart-client-side-solution",
       "description": "asset-deployment-webpart-client-side-solution",
-      "id": "523fe887-ced5-4036-b564-8dad5c6c6e24",
+      "id": "00bfea71-de22-43b2-a848-c05709900100",
       "version": "1.0.0.0",
       "assets": {        
         "elementManifests": [


### PR DESCRIPTION
When I tried this example the app wasnt marked as a valid app package. When I changed the id of the feature in the package-solution to match the FeaturedID of the schema.xml ListInstance it worked. So I've changed the ID to match so others dont get caught out. Either this or it should state to change the IDs so they match.

| Q                   | A
| ---------------     | ---
| content fix?        |  yes
| New article?        | no
| Related issues?     | no

#### What's in this Pull Request?

When I tried this example the app wasnt marked as a valid app package. When I changed the id of the feature in the package-solution to match the FeaturedID of the schema.xml ListInstance it worked. So I've changed the ID to match so others dont get caught out. Either this or it should state to change the IDs so they match.