### PR TITLE
Fix code indentation; Switch type def ack from TSD to scoped types via NPM

### DIFF
--- a/misc/SharePointReferenceToc.xml
+++ b/misc/SharePointReferenceToc.xml
@@ -176,8 +176,9 @@
 				<Item text="IWebPartPropertiesMetadata" url="spfx/sp-webpart-base/interface/iwebpartpropertiesmetadata" SEODescription=""/>
 			</Item>
 		</Item>
-		<Item text="horizontalline" url="/" IsSeparation="true" />
-        <Item text="External packages" url="spfx/web-apis-module" SEODescription="" />
+		<Item text="horizontalline" url="/" IsSeparation="true" SEODescription="">
+	</Item>
+		<Item text="External packages" url="spfx/web-apis-module" SEODescription="" />
 		<Item text="web-apis" url="spfx/web-apis-module" SEODescription="">
 			<Item text="Classes" url="spfx/web-apis" SEODescription="">
 				<Item text="Body" url="spfx/web-apis/class/body" SEODescription=""/>
@@ -208,8 +209,6 @@
 				<Item text="WeakSet" url="spfx/es6-collections/interface/weakset" SEODescription=""/>
 				<Item text="WeakSetConstructor" url="spfx/es6-collections/interface/weaksetconstructor" SEODescription=""/>
 			</Item>
-		</Item>
-		<Item text="web-apis" url="spfx/web-apis-module" SEODescription="">
 		</Item>
 	</Item>
 </Menu>

--- a/misc/SharePointReferenceToc.xml
+++ b/misc/SharePointReferenceToc.xml
@@ -187,9 +187,9 @@
 				<Item text="IWebPartPropertiesMetadata" url="spfx/sp-webpart-base/interface/iwebpartpropertiesmetadata" SEODescription=""/>
 			</Item>
 		</Item>
-		<Item text="horizontalline" url="/" IsSeparation="true" SEODescription="">
-		</Item>
-		<Item text="External packages" url="spfx/web-apis-module" SEODescription="" />
+		<Item text="horizontalline" url="/" IsSeparation="true" SEODescription=""/>
+	</Item>
+	<Item text="External packages" url="spfx/web-apis-module" SEODescription="" >
 		<Item text="web-apis" url="spfx/web-apis-module" SEODescription="">
 			<Item text="Classes" url="spfx/web-apis" SEODescription="">
 				<Item text="Body" url="spfx/web-apis/class/body" SEODescription=""/>

--- a/misc/SharePointReferenceToc.xml
+++ b/misc/SharePointReferenceToc.xml
@@ -48,6 +48,17 @@
 			</Item>
 		</Item>
 		<Item text="sp-dialog" url="spfx/sp-dialog-module" SEODescription="">
+			<Item text="Classes" url="spfx/sp-dialog" SEODescription="">
+				<Item text="BaseDialog" url="spfx/sp-dialog/class/basedialog" SEODescription=""/>
+				<Item text="Dialog" url="spfx/sp-dialog/class/dialog" SEODescription=""/>
+				<Item text="SecondaryDialog" url="spfx/sp-dialog/class/secondarydialog" SEODescription=""/>
+			</Item>
+			<Item text="Interfaces" url="spfx/sp-dialog" SEODescription="">
+				<Item text="IAlertOptions" url="spfx/sp-dialog/interface/ialertoptions" SEODescription=""/>
+				<Item text="IDialogConfiguration" url="spfx/sp-dialog/interface/idialogconfiguration" SEODescription=""/>
+				<Item text="IDialogShowingOptions" url="spfx/sp-dialog/interface/idialogshowingoptions" SEODescription=""/>
+				<Item text="IPromptOptions" url="spfx/sp-dialog/interface/ipromptoptions" SEODescription=""/>
+			</Item>
 		</Item>
 		<Item text="sp-extension-base" url="spfx/sp-extension-base-module" SEODescription="">
 			<Item text="Classes" url="spfx/sp-extension-base" SEODescription="">
@@ -177,7 +188,7 @@
 			</Item>
 		</Item>
 		<Item text="horizontalline" url="/" IsSeparation="true" SEODescription="">
-	</Item>
+		</Item>
 		<Item text="External packages" url="spfx/web-apis-module" SEODescription="" />
 		<Item text="web-apis" url="spfx/web-apis-module" SEODescription="">
 			<Item text="Classes" url="spfx/web-apis" SEODescription="">

--- a/misc/SharePointReferenceToc.xml
+++ b/misc/SharePointReferenceToc.xml
@@ -176,6 +176,8 @@
 				<Item text="IWebPartPropertiesMetadata" url="spfx/sp-webpart-base/interface/iwebpartpropertiesmetadata" SEODescription=""/>
 			</Item>
 		</Item>
+		<Item text="horizontalline" url="/" IsSeparation="true" />
+        <Item text="External packages" url="spfx/web-apis-module" SEODescription="" />
 		<Item text="web-apis" url="spfx/web-apis-module" SEODescription="">
 			<Item text="Classes" url="spfx/web-apis" SEODescription="">
 				<Item text="Body" url="spfx/web-apis/class/body" SEODescription=""/>


### PR DESCRIPTION
| Q                   | A
| ---------------     | ---
| content fix?        | yes
| New article?        | no
| Related issues?     | n/a

#### What's in this Pull Request?

- Some code snippets had no indentation making readability sub-optimal.
- Type def acquisition used outdated TSD utility; switched to using scoped types with NPM (`@types`).
- One part referred to a library (validator) & incorrectly said it didn't have a type definition, but it does. Modified to say it does but for the sake of argument, reworded to be more accurate for article.