### PR TITLE
The link to "Known Issues" is dead

### DIFF
--- a/docs/spfx/extensions/get-started/building-simple-cmdset-with-dialog-api.md
+++ b/docs/spfx/extensions/get-started/building-simple-cmdset-with-dialog-api.md
@@ -46,7 +46,7 @@ When the scaffold is complete, you should see the following message indicating a
 
 ![SharePoint client-side solution scaffolded successfully](../../../../images/ext-com-yeoman-complete.png)
 
-For information about troubleshooting any errors, see [Known issues](../basics/known-issues).
+For information about troubleshooting any errors, see [Known issues](../../web-parts/basics/known-issues).
 
 Once the solution scaffolding is completed, type the following into the console to start Visual Studio Code.
 


### PR DESCRIPTION
The link to "Known Issues" is dead - probably it would make sense to point it to the Web Parts Known issues. The same applies to each of the 6 Extensions tutorials.

| Q                   | A
| ---------------     | ---
| content fix?        | yes
| New article?        | no
| Related issues?     | no

#### What's in this Pull Request?

Please describe the changes in this PR. Sample description or details around bugs which are being fixed.


#### Guidance
*You can delete this section when you are submitting the pull request.* 
* *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
* *Please target your PR to 'staging' branch.*