### PR TITLE
Updated the SPFX property pane documentation with the code to turn on the non-reactive mode

### DIFF
--- a/docs/spfx/web-parts/basics/integrate-with-property-pane.md
+++ b/docs/spfx/web-parts/basics/integrate-with-property-pane.md
@@ -111,7 +111,13 @@ The property pane has two interaction modes:
 
 In reactive mode, on every change, a change event is triggered. Reactive behavior automatically updates the web part with the new values.
 
-While reactive mode is sufficient for many scenarios, at times you will need non-reactive behavior. Non-reactive does not update the web part automatically unless the user confirms the changes.
+While reactive mode is sufficient for many scenarios, at times you will need non-reactive behavior. Non-reactive does not update the web part automatically unless the user confirms the changes. To turn on the non-reactive mode, add the following code in your web part:
+
+```ts 
+protected get disableReactivePropertyChanges(): boolean { 
+  return true; 
+}
+```
 
 ## Custom field example
 


### PR DESCRIPTION
| Q                   | A
| ---------------     | ---
| content fix?        | yes
| New article?        | no

#### What's in this Pull Request?

The "Handling field changes" chapter describes the two modes but don't actually mention how to turn on the non-reactive mode... I needed to do some researches to figure out how. Maybe it can help people to just write the solution here because the solution is not obvious.
