### PR TITLE
Fix malformed ```ts section

### DIFF
--- a/docs/spfx/extensions/get-started/using-page-placeholder-with-extensions.md
+++ b/docs/spfx/extensions/get-started/using-page-placeholder-with-extensions.md
@@ -45,13 +45,12 @@ In the following steps, you'll modify the Hello World Application Customizer to 
 	
 	  Also add the following import statements after the `strings` import at the top of the file:
 
+	```ts
+	import styles from './AppCustomizer.module.scss';
+	import { escape } from '@microsoft/sp-lodash-subset'; 
+	```
 
-	    ```ts
-	    import styles from './AppCustomizer.module.scss';
-	    import { escape } from '@microsoft/sp-lodash-subset'; 
-	    ```
-
-	  You use `escape` to escape Application Customizer properties. You'll create style definitions for the output in the following steps.  
+	You use `escape` to escape Application Customizer properties. You'll create style definitions for the output in the following steps.  
 
 3. Create a new file named **AppCustomizer.module.scss** under the **src\extensions\helloWorld** folder. 
 


### PR DESCRIPTION
| Q                   | A
| ---------------     | ---
| content fix?        | yes
| New article?        | no

#### What's in this Pull Request?

One of the code sections in this page had incorrect whitespace in the markup, causing the boundary backticks to show through in the rendered page and also for the non-code line of text after the code to be rendered as code. I have fixed the whitespace so the content should be rendered correctly.

This is also currently visible on the published document: https://docs.microsoft.com/en-us/sharepoint/dev/spfx/extensions/get-started/using-page-placeholder-with-extensions