### PR TITLE
Fix grammar in "Deploy to an Azure CDN"

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -87,7 +87,7 @@
         href: spfx/web-parts/get-started/connect-to-sharepoint.md
       - name: Deploy your web part to a SharePoint page
         href: spfx/web-parts/get-started/serve-your-web-part-in-a-sharepoint-page.md
-      - name: Deploy to a Azure CDN
+      - name: Deploy to an Azure CDN
         href: spfx/web-parts/get-started/deploy-web-part-to-cdn.md
       - name: Add jQueryUI Accordion
         href: spfx/web-parts/get-started/add-jqueryui-accordion-to-web-part.md


### PR DESCRIPTION
| Q                   | A
| ---------------     | ---
| content fix?        | yes
| New article?        | yes

#### What's in this Pull Request?

The TOC entry "Deploy to a Azure CDN" was grammatically incorrect. I have fixed it by changing "a" to "an".