### PR TITLE
Try to fix the render code block in Microsoft doc.

### DIFF
--- a/docs/spfx/extensions/get-started/using-page-placeholder-with-extensions.md
+++ b/docs/spfx/extensions/get-started/using-page-placeholder-with-extensions.md
@@ -123,8 +123,6 @@ In the following steps, you'll modify the Hello World Application Customizer to 
 
 8. Create a new `_renderPlaceHolders` private method with the following code:
 
-
-
 	  ```ts
 	    private _renderPlaceHolders(): void {
 
@@ -192,7 +190,6 @@ In the following steps, you'll modify the Hello World Application Customizer to 
 		}
 	      }
 	    }
-
 	  ```
 
 	  * Use `this.context.placeholderProvider.tryCreateContent` to get access to the placeholder.


### PR DESCRIPTION
| Q                   | A
| ---------------     | ---
| content fix?        | no
| New article?        | no
| Related issues?     | ~~fixes #X, partially #Y, mentioned in #Z~~

#### What's in this Pull Request?

See the code block about `_renderPlaceHolders` method in [this page](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/extensions/get-started/using-page-placeholder-with-extensions) is not rendering correctly.

Not sure if this could resolve the formatting problem correctly.