### PR TITLE
Update replace-an-expiring-client-secret-in-a-sharepoint-add-in.md

### DIFF
--- a/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
+++ b/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
@@ -116,8 +116,6 @@ $newClientSecret
 
  **Tip**  By default, the add-in secret lasts one year. You can set this to a shorter or longer (up to 3 years maximum) by using the  **-EndDate** parameter on the three calls of the **New-MsolServicePrincipalCredential** cmdlet. The value of the parameter must be a [DateTime](http://msdn2.microsoft.com/EN-US/library/03ybds8y) object set to no longer than 3 years from **DateTime.Now**.
  
-
-
 ## Update the remote web application in Visual Studio to use the new secret
 
 
@@ -154,6 +152,8 @@ $newClientSecret
      ... other settings may be here ...
 </appSettings>
 ```
+
+***Important Note*** You will not be able to use the newly generated client secret until the current client secret expires.  Therefore, changing the ClientId key to the new client secret without the SecondaryClientSecret key present will NOT work.  You MUST follow the above procedure provided here and wait for the previous client secret to expire.  Then, you can remove the SecondaryClientSecret if you desire.
 
 4. If you changed to a new TokenHelper file, rebuild the project.
     

--- a/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
+++ b/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
@@ -9,13 +9,13 @@ ms.prod: sharepoint
 Learn how to add a new client secret for a SharePoint Add-in that is registered with AppRegNew.aspx.
  
 
- **Note**  The name "apps for SharePoint" is changing to "SharePoint Add-ins". During the transition, the documentation and the UI of some SharePoint products and Visual Studio tools might still use the term "apps for SharePoint". For details, see  [New name for apps for Office and SharePoint](new-name-for-apps-for-sharepoint.md#bk_newname).
+>**Note:**  The name "apps for SharePoint" is changing to "SharePoint Add-ins". During the transition, the documentation and the UI of some SharePoint products and Visual Studio tools might still use the term "apps for SharePoint". For details, see  [New name for apps for Office and SharePoint](new-name-for-apps-for-sharepoint.md#bk_newname).
  
 
 Client secrets for SharePoint Add-ins that are registered using the AppRegNew.aspx page expire after one year. This article explains how to add a new secret for the add-in, as well as how to create a new client secret that is valid for three years.
  
 
- **Note**  This article is about SharePoint Add-ins that are distributed through an organization catalog and registered with the AppRegNew.aspx page. If the add-in is registered on the Seller Dashboard, see  [Create or update client IDs and secrets in the Seller Dashboard](https://dev.office.com/officestore/docs/create-or-update-client-ids-and-secrets#bk_update).
+>**Note:**  This article is about SharePoint Add-ins that are distributed through an organization catalog and registered with the AppRegNew.aspx page. If the add-in is registered on the Seller Dashboard, see  [Create or update client IDs and secrets in the Seller Dashboard](https://dev.office.com/officestore/docs/create-or-update-client-ids-and-secrets#bk_update).
  
 
 
@@ -114,12 +114,12 @@ $newClientSecret
     
  
 
- **Tip**  By default, the add-in secret lasts one year. You can set this to a shorter or longer (up to 3 years maximum) by using the  **-EndDate** parameter on the three calls of the **New-MsolServicePrincipalCredential** cmdlet. The value of the parameter must be a [DateTime](http://msdn2.microsoft.com/EN-US/library/03ybds8y) object set to no longer than 3 years from **DateTime.Now**.
+>**Tip:**  By default, the add-in secret lasts one year. You can set this to a shorter or longer (up to 3 years maximum) by using the  **-EndDate** parameter on the three calls of the **New-MsolServicePrincipalCredential** cmdlet. The value of the parameter must be a [DateTime](http://msdn2.microsoft.com/EN-US/library/03ybds8y) object set to no longer than 3 years from **DateTime.Now**.
  
 ## Update the remote web application in Visual Studio to use the new secret
 
 
- **Important**  If your add-in was originally created with a prerelease version the Microsoft Office Developer Tools for Visual Studio, it may contain an out-of-date version of the TokenHelper.cs (or .vb) file. If the file does not contain the string "secondaryClientSecret", it is out-of-date and it must be replaced before you can update the web application with a new secret. To obtain a copy of a release version of the file, you need Visual Studio 2012 or later. Create a new SharePoint Add-in project in Visual Studio. Copy the TokenHelper file from it to the web application project of your SharePoint Add-in. 
+>**Important:**  If your add-in was originally created with a prerelease version the Microsoft Office Developer Tools for Visual Studio, it may contain an out-of-date version of the TokenHelper.cs (or .vb) file. If the file does not contain the string "secondaryClientSecret", it is out-of-date and it must be replaced before you can update the web application with a new secret. To obtain a copy of a release version of the file, you need Visual Studio 2012 or later. Create a new SharePoint Add-in project in Visual Studio. Copy the TokenHelper file from it to the web application project of your SharePoint Add-in. 
  
 
 
@@ -153,7 +153,7 @@ $newClientSecret
 </appSettings>
 ```
 
-***Important Note*** You will not be able to use the newly generated client secret until the current client secret expires.  Therefore, changing the ClientId key to the new client secret without the SecondaryClientSecret key present will NOT work.  You MUST follow the above procedure provided here and wait for the previous client secret to expire.  Then, you can remove the SecondaryClientSecret if you desire.
+>**Important:** You will not be able to use the newly generated client secret until the current client secret expires. Therefore, changing the ClientId key to the new client secret without the SecondaryClientSecret key present will not work. You must follow the  procedure in this article and wait for the previous client secret to expire. Then you can remove the SecondaryClientSecret if you want to.
 
 4. If you changed to a new TokenHelper file, rebuild the project.
     
@@ -180,7 +180,7 @@ connect-msolservice -credential $msolcred
 
 2. Get  **ServicePrincipals** and keys. Printing **$keys** returns three records. Replace each **KeyId** in *KeyId1*  , *KeyId2*  and *KeyId3*  . You will also see the **EndDate** of each key. Confirm whether your expired key appers there.
     
-     **Note:** The **clientId** needs to match your expired **clientId**. It's recommended to delete all keys, both expired and unexpired, for this **clientId**.
+     >**Note:** The **clientId** needs to match your expired **clientId**. It's recommended to delete all keys, both expired and unexpired, for this **clientId**.
     
 
 
@@ -220,9 +220,4 @@ $newClientSecret
 
 ## See also
 
-
-#### Other resources
-
-
- 
- [Provider Hosted App fails on SPO](http://blogs.technet.com/b/sharepointdevelopersupport/archive/2015/03/11/provider-hosted-app-fails-on-spo.aspx)
+[Provider Hosted App fails on SPO](http://blogs.technet.com/b/sharepointdevelopersupport/archive/2015/03/11/provider-hosted-app-fails-on-spo.aspx)


### PR DESCRIPTION
| Q                   | A
| ---------------     | ---
| content fix?        | yes
| New article?        | no
| Related issues?     | 

#### What's in this Pull Request?
We had a very nasty Sev 1 support case where the customer tried to simply replace the expiring client secret with the new one and it didn't work.  We told them to follow this article exactly but apparently it had been working in the past and there was absolutely no tolerance for downtime.  Finally we got the PG to state categorically that only one client secret can be active per App Principal.  This is different from a regular AAD Application.  We feel it is very important we include this information, although feel free to change the format.  We can save a lot of trouble, time and money for the customer and support by clearly documenting the expected behavior.  Thanks you very much and don't hesitate to contact me with any questions.