### PR TITLE
Attempt #3 to fix "rowspan" tag

### DIFF
--- a/docs/design/themes-colors.md
+++ b/docs/design/themes-colors.md
@@ -53,7 +53,7 @@ The SharePoint color palette has been optimized for screens and devices, and to 
 <td style="color:white; background-color:#333">neutralPrimary: #333</td>
 </tr>
 <tr>
-<td rowspan=3 style="font-weight:bold; vertical-align:middle; color:white; background-color:#d13438">themePrimary: #d13438</td>
+<td rowspan="3" style="font-weight:bold; vertical-align:middle; color:white; background-color:#d13438">themePrimary: #d13438</td>
 <td style="color:white; background-color:#3c3c3c">neutralPrimaryAlt: #3c3c3c</td>
 </tr>
 <tr>
@@ -101,7 +101,7 @@ The SharePoint color palette has been optimized for screens and devices, and to 
 <td style="color:white; background-color:#333">neutralPrimary: #333</td>
 </tr>
 <tr>
-<td rowspan=3 style="font-weight:bold; vertical-align:middle; color:white; background-color:#ca5010">themePrimary: #ca5010</td>
+<td rowspan="3" style="font-weight:bold; vertical-align:middle; color:white; background-color:#ca5010">themePrimary: #ca5010</td>
 <td style="color:white; background-color:#3c3c3c">neutralPrimaryAlt: #3c3c3c</td>
 </tr>
 <tr>
@@ -150,7 +150,7 @@ The SharePoint color palette has been optimized for screens and devices, and to 
 <td style="color:white; background-color:#333">neutralPrimary: #333</td>
 </tr>
 <tr>
-<td rowspan=3 style="font-weight:bold; vertical-align:middle; color:white; background-color:#10893e">themePrimary: #10893e</td>
+<td rowspan="3" style="font-weight:bold; vertical-align:middle; color:white; background-color:#10893e">themePrimary: #10893e</td>
 <td style="color:white; background-color:#3c3c3c">neutralPrimaryAlt: #3c3c3c</td>
 </tr>
 <tr>
@@ -199,7 +199,7 @@ The SharePoint color palette has been optimized for screens and devices, and to 
 <td style="color:white; background-color:#333">neutralPrimary: #333</td>
 </tr>
 <tr>
-<td rowspan=3 style="font-weight:bold; vertical-align:middle; color:white; background-color:#0078d7">themePrimary: #0078d7</td>
+<td rowspan="3" style="font-weight:bold; vertical-align:middle; color:white; background-color:#0078d7">themePrimary: #0078d7</td>
 <td style="color:white; background-color:#3c3c3c">neutralPrimaryAlt: #3c3c3c</td>
 </tr>
 <tr>
@@ -248,7 +248,7 @@ The SharePoint color palette has been optimized for screens and devices, and to 
 <td style="color:white; background-color:#333">neutralPrimary: #333</td>
 </tr>
 <tr>
-<td rowspan=3 style="font-weight:bold; vertical-align:middle; color:white; background-color:#6b69d6">themePrimary: #6b69d6</td>
+<td rowspan="3" style="font-weight:bold; vertical-align:middle; color:white; background-color:#6b69d6">themePrimary: #6b69d6</td>
 <td style="color:white; background-color:#3c3c3c">neutralPrimaryAlt: #3c3c3c</td>
 </tr>
 <tr>
@@ -297,7 +297,7 @@ The SharePoint color palette has been optimized for screens and devices, and to 
 <td style="color:white; background-color:#333">neutralPrimary: #333</td>
 </tr>
 <tr>
-<td rowspan=3 style="font-weight:bold; vertical-align:middle; color:white; background-color:#5d5a58">themePrimary: #5d5a58</td>
+<td rowspan="3" style="font-weight:bold; vertical-align:middle; color:white; background-color:#5d5a58">themePrimary: #5d5a58</td>
 <td style="color:white; background-color:#3c3c3c">neutralPrimaryAlt: #3c3c3c</td>
 </tr>
 <tr>


### PR DESCRIPTION
I added quotes around the number 3 in the rowspan tag

| Q                   | A
| ---------------     | ---
| content fix?        | yes
| New article?        | no

#### What's in this Pull Request?

I added quotation marks around the #3. Even though this is appearing correctly in preview, it doesn't appear correctly on staging. The source code for the rowspan row gets messed up and looks like this, causing it to not render.

&lt;td rowspan=3 style=&quot;font-weight:bold; vertical-align:middle; color:white; background-color:#d13438&quot;&gt;themePrimary: #d13438

Expected (plus fix): <td rowspan="3" style="font-weight:bold; vertical-align:middle; color:white; background-color:#d13438">themePrimary: #d13438</td>