### PR TITLE
Update build-a-hello-world-extension.md

### DIFF
--- a/docs/spfx/extensions/get-started/build-a-hello-world-extension.md
+++ b/docs/spfx/extensions/get-started/build-a-hello-world-extension.md
@@ -110,7 +110,7 @@ gulp serve --nobrowser
 
 You use the ```--nobrowser``` option because you don't need to launch the local workbench, since you can't debug extensions locally.
 
-When the code compiles without errors, it will serve the resulting manifest from http://localhost:4321.
+When the code compiles without errors, it will serve the resulting manifest from https://localhost:4321.
 
 ![Gulp serve](../../../images/ext-app-gulp-serve.png)
 


### PR DESCRIPTION
The localhost server only accepts connection with https protocol. As a result, the protocol here should be `https` but not `http`

| Q                   | A
| ---------------     | ---
| content fix?        | yes
| New article?        | no
| Related issues?     |

#### What's in this Pull Request?

The localhost is available in `https` but not `http`. Connection to the server with `http` will be denied.