### PR TITLE
Updated the API URL to add a solution package

### DIFF
--- a/docs/apis/alm-api-for-spfx-add-ins.md
+++ b/docs/apis/alm-api-for-spfx-add-ins.md
@@ -23,7 +23,7 @@ ALM APIs are natively provided using REST APIs, but there is also additional CSO
 Adding solution to the tenant app catalog. This API is designed to be executed in the context of the tenant app catalog site.
 
 ```
-/_api/web/tenantappcatalog/AvailableApps/GetById('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx')/Add(overwrite=true, url='test.txt')";
+/_api/web/tenantappcatalog/Add(overwrite=true, url='test.txt')";
 method: POST
 binaryStringRequestBody: true
 body: 'byte array of the file'


### PR DESCRIPTION
| Q                   | A
| ---------------     | ---
| content fix?        | yes

#### What's in this Pull Request?

The API URL to add a solution package seems to only be called with `tenantappcatalog/Add` instead of `AvailableApps/GetById('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx')/Add`.