### PR TITLE
Fixed a wrong command

### DIFF
--- a/docs/apis/alm-api-for-spfx-add-ins.md
+++ b/docs/apis/alm-api-for-spfx-add-ins.md
@@ -182,5 +182,5 @@ Uninstall-PnPApp -Identity <app id>
 Getting a list of apps that can be added to the site is possible using:
 
 ```PowerShell
-Get-PnPAvailableApp
+Get-PnPApp
 ```


### PR DESCRIPTION
Fixed a wrong command **Get-PnPAvailableApp** with the right one **Get-PnPApp**

| Q                   | A
| ---------------     | ---
| content fix?        | yes
| New article?        | no
| Related issues?     | no

#### What's in this Pull Request?

The cmdlet Get-PnPAvailableApp is documented to get a list of available apps, however the right command is Get-PnPApp.