### PR TITLE
update GitHub templates with improved instructions & consistency

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,7 @@
-Thank you for reporting an issue or suggesting an enhancement. We appreciate your feedback - to help the team to understand your needs, please complete the below template to ensure we have the necessary details to assist you. 
+> Thank you for reporting an issue or suggesting an enhancement. We appreciate your feedback - to help the team to understand your needs, please complete the below template to ensure we have the necessary details to assist you.
+>
+> _(DELETE THIS PARAGRAPH AFTER READING)_
+>
 
 #### Category
 - [ ] Question
@@ -6,23 +9,43 @@ Thank you for reporting an issue or suggesting an enhancement. We appreciate you
 - [ ] Bug
 - [ ] Additional article idea
 
-> If you are planning to share a new feature request (enhancement / suggestion), please use SP Dev UserVoice at http://aka.ms/sp-dev-uservoice.
+> For the above list, an empty checkbox is [ ] as in <kbd>[</kbd><kbd>SPACE</kbd><kbd>]</kbd>. A checked checkbox is [x] with no space between the brackets. Use the `PREVIEW` tab at the top right to preview the rendering before submitting your issue.
+>
+> If you are planning to share a new feature request (enhancement / suggestion), please use SP Dev UserVoice at http://aka.ms/sp-dev-uservoice. (DELETE THIS PARAGRAPH AFTER READING)
+>
+> _(DELETE THIS PARAGRAPH AFTER READING)_
+>
 
 #### Expected or Desired Behavior
-_If you are reporting a bug, please describe the expected behavior. If you are suggesting an enhancement please describe thoroughly the enhancement, how it can be achieved, and expected benefit._
+
+> If you are reporting a bug, please describe the expected behavior. If you are suggesting an enhancement please describe thoroughly the enhancement, how it can be achieved, and expected benefit.
+>
+> _(DELETE THIS PARAGRAPH AFTER READING)_
+>
 
 #### Observed Behavior
-_If you are reporting a bug, please describe the behavior you expected to occur when performing the action. If you are making a suggestion, you can delete this section._
+
+> If you are reporting a bug, please describe the behavior you expected to occur when performing the action. If you are making a suggestion, you can delete this section.
+>
+> _(DELETE THIS PARAGRAPH AFTER READING)_
+>
 
 #### Steps to Reproduce
-_If you are reporting a bug please describe the steps to reproduce the bug in sufficient detail to allow testing. Only way to fix things properly, is to have sufficient details to reproduce it. If you are making a suggestion, you can delete this section._
+
+> If you are reporting a bug please describe the steps to reproduce the bug in sufficient detail to allow testing. Only way to fix things properly, is to have sufficient details to reproduce it. If you are making a suggestion, you can delete this section.
+>
+> _(DELETE THIS PARAGRAPH AFTER READING)_
+>
 
 #### Submission Guidelines
-_Delete this section after reading_
-- All suggestions or bugs are welcome, please let us know what's on your mind.
-- If you are reporting an issue around any of the documents or articles, please ensure that you have clear reference on the specific file or URL, which should be fixed.
-- If you have technical questions about the framework, we’ll be monitoring #spfx, #spfx-webparts, and #spfx-tooling on (SharePoint StackExchange)[http://sharepoint.stackexchange.com/]. You can also alternatively submit your question to (SharePoint Developer group)[https://network.office.com/t5/SharePoint-Developer/bd-p/SharePointDev] at Office Network.
-- Remember to include sufficient details and context.
-- If you have multiple suggestions or bugs please submit them in separate bugs so we can track resolution.
+
+> - All suggestions or bugs are welcome, please let us know what's on your mind.
+> - If you are reporting an issue around any of the documents or articles, please ensure that you have clear > reference on the specific file or URL, which should be fixed.
+> - If you have technical questions about the framework, we’ll be monitoring #spfx, #spfx-webparts, and > #spfx-tooling on (SharePoint StackExchange)[http://sharepoint.stackexchange.com/]. You can also > alternatively submit your question to (SharePoint Developer group)> [https://network.office.com/t5/SharePoint-Developer/bd-p/SharePointDev] at Office Network.
+> - Remember to include sufficient details and context.
+> - If you have multiple suggestions or bugs please submit them in separate bugs so we can track resolution.
+>
+> _(DELETE THIS PARAGRAPH AFTER READING)_
+>
 
 Thanks for your contribution! Sharing is caring.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,22 @@
-| Q                   | A
-| ---------------     | ---
-| content fix?        | no - yes?
-| New article?        | no - yes?
-| Related issues?     | fixes #X, partially #Y, mentioned in #Z
+#### Category
+- [ ] Content fix
+- [ ] New article
+- Related issues: fixes #X, partially #Y, mentioned in #Z
+
+> For the above list, an empty checkbox is [ ] as in <kbd>[</kbd><kbd>SPACE</kbd><kbd>]</kbd>. A checked checkbox is [x] with no space between the brackets. Use the `PREVIEW` tab at the top right to preview the rendering before submitting your issue.
+> 
+> _(DELETE THIS PARAGRAPH AFTER READING)_
 
 #### What's in this Pull Request?
 
-Please describe the changes in this PR. Sample description or details around bugs which are being fixed.
-
+> Please describe the changes in this PR. Sample description or details around bugs which are being fixed.
+> 
+> _(DELETE THIS PARAGRAPH AFTER READING)_
 
 #### Guidance
-*You can delete this section when you are submitting the pull request.* 
-* *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
-* *Please target your PR to 'master' branch. Released documents are in live branch.*
+
+> *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
+> 
+> *Please target your PR to 'master' branch. Released documents are in `live` branch.*
+> 
+> _(DELETE THIS PARAGRAPH AFTER READING)_


### PR DESCRIPTION
| Q                   | A
| ---------------     | ---
| content fix?        | sort of?
| New article?        | no
| Related issues?     | n/a

#### What's in this Pull Request?

- too many don't seem to understand how GitHub does checkbox lists, so added some docs
- added "delete this paragraph" to parts that are
  docs for submitting issues / PR's and made all blockquote to easier read
- updated PR template to be consistent with Issue template