### PR TITLE
Fixed typo

### DIFF
--- a/docs/spfx/office-ui-fabric-integration.md
+++ b/docs/spfx/office-ui-fabric-integration.md
@@ -117,7 +117,7 @@ npm uninstall @microsoft/sp-office-ui-fabric-core --save-dev
 You can then import the core styles from the Sass declarations available in the Fabric React package.
 
 ```css
-@import '~office-ui-fabric-react/dist/sass/References.scss';
+@import '~office-ui-fabric-react/dist/sass/_References.scss';
 ```
 
 ### Understanding this approach and its shortcomings


### PR DESCRIPTION
File is named `_References.scss` (starts with underscore)

| Q                   | A
| ---------------     | ---
| content fix?        | yes
| New article?        | no 
| Related issues?     | n/a
#### What's in this Pull Request?

Updated type on file reference to OUIF, filename starts with `_` underscore