### PR TITLE
Update building-simple-cmdset-with-dialog-api.md

### DIFF
--- a/docs/spfx/extensions/get-started/building-simple-cmdset-with-dialog-api.md
+++ b/docs/spfx/extensions/get-started/building-simple-cmdset-with-dialog-api.md
@@ -221,7 +221,7 @@ The default solution takes advantage of a new Dialog API, which can be used to s
     ```typescript
       @override
       public onExecute(event: IListViewCommandSetExecuteEventParameters): void {
-        switch (event.commandId) {
+        switch (event.itemId) {
           case 'COMMAND_1':
             Dialog.alert(`Clicked ${strings.Command1}`);
             break;


### PR DESCRIPTION
As far as I know the IListViewCommandSetExecuteEventParameters interface doesn't have a commandId property. It should be the itemId property:
https://docs.microsoft.com/en-us/javascript/api/sp-listview-extensibility/ilistviewcommandsetexecuteeventparameters

| Q                   | A
| ---------------     | ---
| content fix?        |  yes
| New article?        | no 
| Related issues?     | fixes 