### PR TITLE
CEWS doesn't have RawData for BCS item

### DIFF
--- a/docs/general-development/how-to-use-the-content-enrichment-web-service-callout-for-sharepoint-server.md
+++ b/docs/general-development/how-to-use-the-content-enrichment-web-service-callout-for-sharepoint-server.md
@@ -132,7 +132,8 @@ The implementation requires two managed properties for each item received via th
     
 The **IContentProcessingEnrichmentService** implementation writes the raw binary data to a temporary location on disk, with **Filename** as the name of the file. Then, a new name is added to the list of authors and returned to the content processing component.
   
-    
+    > [!NOTE]
+    > If the data source for the crawl is an external data source, the ItemRawData property will not have a data stream, but will be null. The string representation of the raw data will be returned in the Item.Body property. This is a limitation of the BCS data source crawler. 
     
 
 ### To create the class file for the content enrichment service


### PR DESCRIPTION
BCS data source has a null rawdata property by design. Sample will not work property for BCS data source, so I recommend putting in a note to that effect.

#### Category
- [X] Content fix
- [ ] New article
- Related issues: fixes #X, partially #Y, mentioned in #Z

> For the above list, an empty checkbox is [ ] as in <kbd>[</kbd><kbd>SPACE</kbd><kbd>]</kbd>. A checked checkbox is [x] with no space between the brackets. Use the `PREVIEW` tab at the top right to preview the rendering before submitting your issue.
> 
> 

#### What's in this Pull Request?

> Please describe the changes in this PR. Sample description or details around bugs which are being fixed.
> 
> adding  a note about missing RawData property when datasource for crawl is external (BCS)

#### Guidance

> *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
> 
> *Please target your PR to 'master' branch. Released documents are in `live` branch.*
> 
> 