### PR TITLE
Add notice to always use ${style.*} reference in code

### DIFF
--- a/docs/spfx/extensions/get-started/using-page-placeholder-with-extensions.md
+++ b/docs/spfx/extensions/get-started/using-page-placeholder-with-extensions.md
@@ -210,6 +210,7 @@ Notice that you're requesting a well-known placeholder by using the correspondin
 	* Extension code should not assume that the expected placeholder is available.
 	* The code expects custom properties called `Top` and `Bottom`. If the properties exist, they render inside the placeholders.
 	* Notice that the code path for both the top and bottom placeholders is almost identical. The only differences are the variables used and the style definitions.
+	* It is possible to use the class names defined in the style sheet directly but it is not recommended. In case no style sheet reference defined in the ```styles``` variable is found in the code, the style sheet won't get added to the page. This is because unused references will get removed during bild process.
 
 9. Add the following method after the `_renderPlaceHolders` method. In this case, you simply output a console message when the extension is removed from the page. 
 


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article

#### What's in this Pull Request?
Update to the documentation. In case no reference to the `style` variable was made in the code the style sheet doesn't get added to the page. Happened to me sometimes and maybe others too.