### PR TITLE
Add SharePoint glossary

### DIFF
--- a/docs/community/community.md
+++ b/docs/community/community.md
@@ -47,3 +47,4 @@ There are numerous community calls for SharePoint development, and you can choos
 
 - [SharePoint developer portal](http://aka.ms/spdev)
 - [SharePoint developer samples](http://aka.ms/spdev-samples)
+- [SharePoint glossary](../general-development/sharepoint-glossary.md) 

--- a/docs/general-development/sharepoint-development-overview.md
+++ b/docs/general-development/sharepoint-development-overview.md
@@ -119,19 +119,12 @@ When you know the kinds of SharePoint Add-in that you want to create, we provide
    
 
 ## See also
-<a name="bk_additionalresources"> </a>
 
-
--  [Accessibility in SharePoint](accessibility-in-sharepoint.md)
-    
-  
--  [Protocol handler error due to deprecated interface in SharePoint 2016](protocol-handler-error-due-to-deprecated-interface-in-sharepoint-2016.md)
-    
-  
--  [.NET server API reference for SharePoint](http://msdn.microsoft.com/library/fb8a82f1-9239-49ae-89f3-ce1385fb28b5%28Office.15%29.aspx)
-    
-  
--  [.NET client API reference for SharePoint Online](http://msdn.microsoft.com/library/88e5e1b9-eab2-4f3b-a3f2-75c96b86f1f4%28Office.15%29.aspx)
+- [Accessibility in SharePoint](accessibility-in-sharepoint.md)
+- [Protocol handler error due to deprecated interface in SharePoint 2016](protocol-handler-error-due-to-deprecated-interface-in-sharepoint-2016.md)
+- [.NET server API reference for SharePoint](http://msdn.microsoft.com/library/fb8a82f1-9239-49ae-89f3-ce1385fb28b5%28Office.15%29.aspx)
+- [.NET client API reference for SharePoint Online](http://msdn.microsoft.com/library/88e5e1b9-eab2-4f3b-a3f2-75c96b86f1f4%28Office.15%29.aspx)
+- [SharePoint glossary](general-development/sharepoint-glossary.md) 
     
   
 

--- a/docs/general-development/sharepoint-development-overview.md
+++ b/docs/general-development/sharepoint-development-overview.md
@@ -124,7 +124,7 @@ When you know the kinds of SharePoint Add-in that you want to create, we provide
 - [Protocol handler error due to deprecated interface in SharePoint 2016](protocol-handler-error-due-to-deprecated-interface-in-sharepoint-2016.md)
 - [.NET server API reference for SharePoint](http://msdn.microsoft.com/library/fb8a82f1-9239-49ae-89f3-ce1385fb28b5%28Office.15%29.aspx)
 - [.NET client API reference for SharePoint Online](http://msdn.microsoft.com/library/88e5e1b9-eab2-4f3b-a3f2-75c96b86f1f4%28Office.15%29.aspx)
-- [SharePoint glossary](general-development/sharepoint-glossary.md) 
+- [SharePoint glossary](sharepoint-glossary.md) 
     
   
 

--- a/docs/general-development/sharepoint-glossary.md
+++ b/docs/general-development/sharepoint-glossary.md
@@ -31,7 +31,7 @@ Find definitions for terms used in SharePoint developer documentation.
 |alternate account  <br/> |An additional user account that is in a different domain, but within the same forest as the primary account.  <br/> |
 |app catalog  <br/> |A SharePoint document library that administrators can use to distribute apps for Office and SharePoint to their end users.  <br/> |
 |app custom action  <br/> |A type of custom action that is added to a host site by a SharePoint Add-in (formerly an app for SharePoint) and that links to more functionality that is contained by the add-in.  <br/> |
-|app for SharePoint  <br/> |A cloud-enabled app that integrates rich, scenario-focused content and services into a SharePoint environment. Now known as SharePoint Add-in. <br/> |
+|app for SharePoint  <br/> |A cloud-enabled app that integrates rich, scenario-focused content and services into a SharePoint environment. Now known as "SharePoint Add-in." <br/> |
 |app part  <br/> |A component of a SharePoint Add-in (formerly an app for SharePoint) that can be embedded on a site page to expose the functionality of the add-in.  <br/> |
 |app web  <br/> |A sub website to which the SharePoint components of an add-in are deployed when the add-in is installed on a host web.  <br/> |
 |application directory  <br/> |The directory on an index server or a query server where all files are stored for the purpose of creating a full-text index catalog or performing queries on a full-text index catalog.  <br/> |
@@ -176,6 +176,7 @@ Find definitions for terms used in SharePoint developer documentation.
 |server-to-server protocol  <br/> |An authentication protocol between two servers or services.  <br/> |
 |Shared Documents library  <br/> |A document library that is included by default in the Team Site site template.  <br/> |
 |shared view  <br/> |A view of a list or web part Page that every user who has the appropriate permissions can see.  <br/> |
+|SharePoint Add-in  <br/> |Formerly "app for SharePoint." A cloud-enabled add-in that integrates rich, scenario-focused content and services into a SharePoint environment. <br/> |
 |SharePoint Search SQL syntax  <br/> |The rules that govern the construction of an enterprise search SQL query.  <br/> |
 |single sign-on ticket  <br/> |A token that contains the encrypted identity of a single sign-on (SSO) user in the form of a security identifier string and a nonce.  <br/> |
 |site collection administrator  <br/> |A user who has administrative permissions for a site collection.  <br/> |

--- a/docs/general-development/sharepoint-glossary.md
+++ b/docs/general-development/sharepoint-glossary.md
@@ -1,0 +1,237 @@
+---
+title: "SharePoint glossary"
+manager: soliver
+ms.date: 4/18/2018
+ms.audience: Developer
+ms.topic: overview
+ms.prod: office-online-server
+localization_priority: Normal
+ms.assetid: be176603-ca27-40bf-a591-4aa7d0aed454
+description: "Find definitions for terms used in SharePoint developer documentation."
+---
+
+# SharePoint glossary
+
+Find definitions for terms used in SharePoint developer documentation.
+  
+## Glossary
+
+|**Term**|**Definition**|
+|:-----|:-----|
+|access control entry  <br/> |An entry in either a securable object's discretionary access control list (DACL) or an object's system access control list (SACL). In a DACL, the entry grants or denies permissions to a user or group. In a SACL, the entry specifies which security events to audit for a particular user or group or controls the Windows Integrity Level for the object.  <br/> |
+|access control list  <br/> |In Windows-based systems, a list of access control entries (ACE) that apply to an entire object, a set of the object's properties, or an individual property of an object, and that define the access granted to one or more security principals.  <br/> |
+|access URL  <br/> |The internal URL that is used by a crawler to identify and access an item.  <br/> |
+|ACE  <br/> |An entry in either a securable object's discretionary access control list (DACL) or an object's system access control list (SACL). In a DACL, the entry grants or denies permissions to a user or group. In a SACL, the entry specifies which security events to audit for a particular user or group or controls the Windows Integrity Level for the object.  <br/> |
+|ACL  <br/> |In Windows-based systems, a list of access control entries (ACE) that apply to an entire object, a set of the object's properties, or an individual property of an object, and that define the access granted to one or more security principals.  <br/> |
+|activity feed  <br/> |A feed that provides information, notifications and updates based on people, documents, and tags you are following.  <br/> |
+|activity flow  <br/> |A running instance of a workflow that consists of a sequence of action instances and/or activity model instances. Action instances and activity model instances can be sequenced in any order to create a single activity flow.  <br/> |
+|activity model  <br/> |A predefined sequence of actions.  <br/> |
+|after event  <br/> |An asynchronous event whose handler runs only after the action that raised the event is complete.  <br/> |
+|alert subscription  <br/> |A request to receive an Internet message automatically when user-defined criteria are met. Such messages are generated automatically when items such as documents, web pages, list items, sites, or other resources on a server are changed.  <br/> |
+|alternate account  <br/> |An additional user account that is in a different domain, but within the same forest as the primary account.  <br/> |
+|app catalog  <br/> |A SharePoint document library that administrators can use to distribute apps for Office and SharePoint to their end users.  <br/> |
+|app custom action  <br/> |A type of custom action that is added to a host site by a SharePoint Add-in (formerly an app for SharePoint) and that links to more functionality that is contained by the add-in.  <br/> |
+|app for SharePoint  <br/> |A cloud-enabled app that integrates rich, scenario-focused content and services into a SharePoint environment. Now known as SharePoint Add-in. <br/> |
+|app part  <br/> |A component of a SharePoint Add-in (formerly an app for SharePoint) that can be embedded on a site page to expose the functionality of the add-in.  <br/> |
+|app web  <br/> |A sub website to which the SharePoint components of an add-in are deployed when the add-in is installed on a host web.  <br/> |
+|application directory  <br/> |The directory on an index server or a query server where all files are stored for the purpose of creating a full-text index catalog or performing queries on a full-text index catalog.  <br/> |
+|application session  <br/> |The period of time when an application is running. When an application starts, the session starts. When an application quits, the session ends.  <br/> |
+|AppSource  <br/> | Formerly known as Office Store. An Internet site that provides a collection of products and services developed by Microsoft partners for Microsoft Office users.  <br/> |
+|audience identifier  <br/> |A GUID or string that is used to uniquely identify an audience.  <br/> |
+|audience rule  <br/> |A set of logical conditions that determine whether a user profile can be a member of an audience.  <br/> |
+|authoritative page  <br/> |A web page that a site collection administrator has designated as more relevant than other web pages. This is typically the URL of the home page for the intranet of an organization. The higher the authority level assigned to a page, the higher the page appears in search results. Also referred to as authoritative page.  <br/> |
+|authority level  <br/> |A floating-point number that designates that a specific web page is more relevant than other web pages. Allowed values are 0, 1, or 2. Zero (0) signifies the most valuable authoritative page level.  <br/> |
+|authority page  <br/> |A web page that a site collection administrator has designated as more relevant than other web pages. This is typically the URL of the home page for the intranet of an organization. The higher the authority level assigned to a page, the higher the page appears in search results. Also referred to as authoritative page.  <br/> |
+|autohost  <br/> |To deploy the components of an add-in on appropriate hosts and establish add-in isolation automatically.  <br/> |
+|available site template  <br/> |An XML-based collection of predefined or user-defined settings that are stored as a site definition configuration or a site template, and can be used when creating a site.  <br/> |
+|backward signing  <br/> |A condition of a handwritten signature, in an image or .ink file, that specifies the direction of the characters in the signature, right-to-left or left-to-right.  <br/> |
+|base view identifier  <br/> |An integer that uniquely identifies a view definition for a list.  <br/> |
+|basic page  <br/> |A web parts page that contains only one web part zone and, by default, a Content Editor web part.  <br/> |
+|BCS  <br/> |A feature that enables users to interact with back-end (LOB) data from within the Office Suite and SharePoint.  <br/> |
+|BCS solution deployment  <br/> |BCS server to client solution deployment that is based on ClickOnce technology.  <br/> |
+|before event  <br/> |A synchronous event whose handler runs completely before the action that raised the event starts.  <br/> |
+|blank site  <br/> |A site that was created by using the "Blank" site template.  <br/> |
+|Business Connectivity  <br/> |A feature that enables users to interact with back-end (LOB) data from within the Office Suite and SharePoint.  <br/> |
+|Business Connectivity Services  <br/> |A feature that enables users to interact with back-end (LOB) data from within the Office Suite and SharePoint.  <br/> |
+|CAML  <br/> |An XML-based language that is used to describe various elements, such as queries and views, in sites that are based on SharePoint products and technologies.  <br/> |
+|Central Administration site  <br/> |A special SharePoint site where an administrator can manage all sites and servers in a farm that is running SharePoint products and technologies.  <br/> |
+|chrome control  <br/> |An HTML and JavaScript based control that renders the top chrome, which is available to use in apps for SharePoint.  <br/> |
+|Collaborative Application Markup Language  <br/> |An XML-based language that is used to describe various elements, such as queries and views, in sites that are based on SharePoint products and technologies.  <br/> |
+|content migration package  <br/> |A package of XML-formatted files that is used to migrate content between site collections, sites, and lists.  <br/> |
+|content placeholder  <br/> |A region within a page layout that is populated dynamically with the value of the publishing page field to which it is bound.  <br/> |
+|content type group  <br/> |A named category of content types that is used to organize content types of a similar purpose.  <br/> |
+|content type identifier  <br/> |A unique identifier that is assigned to a content type.  <br/> |
+|content type order  <br/> |The sequence in which content types are displayed.  <br/> |
+|content type resource folder  <br/> |A folder that stores the resource files that are associated with a content type.  <br/> |
+|content type schema  <br/> |An XML definition that describes the contents of a content type.  <br/> |
+|content type specific view  <br/> |A view that is associated with a particular content type that is associated with a folder.  <br/> |
+|context site  <br/> |A site that corresponds to the context of the current request.  <br/> |
+|context type  <br/> |A GUID that is used as a classification for an event receiver.  <br/> |
+|contextual search scope  <br/> |A system-defined restriction that can optionally be added to a query to restrict the query results to items that are from a specific site or list.  <br/> |
+|crawl log  <br/> |A set of properties that provides information about the results of crawling a display URL. The information includes whether the crawl was successful, the content source to which the display URL belongs, and the level, message, time, and identifier for any errors that occur.  <br/> |
+|crawl queue  <br/> |A data structure that stores the list of items to crawl next.  <br/> |
+|crawled property  <br/> |A type of metadata that can be discovered during a crawl and applied to one or more items. It can be mapped to a managed property.  <br/> |
+|cross-domain library  <br/> |A JavaScript library available in apps for SharePoint to allow cross-domain client-level communication.  <br/> |
+|custom action  <br/> |A dropdown menu item or ribbon component that is added to a site page.  <br/> |
+|Data View web part  <br/> |A web part that is used to display items in a list.  <br/> |
+|declarative workflow association  <br/> |A code-free binding of a declarative workflow to a specific list or content type using XAML (Extensible Application Markup Language).  <br/> |
+|default list view  <br/> |The view of a list that is defined by the owner of the list to appear when users browse to the list without specifying a view.  <br/> |
+|default mobile list view  <br/> |The view of a list that is defined by the owner of the list to appear when users browse to the list from a mobile device without specifying a view.  <br/> |
+|default search scope  <br/> |The search scope that is assigned automatically to a search scope display group.  <br/> |
+|default user store  <br/> |A user store supplied as a starting point for expanding group membership when a user store is not already specified in FAST Search Authorization.  <br/> |
+|deployment system object  <br/> |An object that is created as part of a site or site collection. Examples of deployment system objects are root folders, catalogs, default pages, and galleries that are created during site or site collection creation. A deployment system object is not part of a template.  <br/> |
+|descendant content type  <br/> |Any content type that inherits from another content type.  <br/> |
+|dynamic rank  <br/> |A component of the rank that depends on how well query text matches an indexed item.  <br/> |
+|excluded item  <br/> |An item that is excluded from a crawl by the administrator of the host site or the search administrator of the crawler.  <br/> |
+|extracted definition  <br/> |The definition that is obtained by an index server during a crawl, to identify if any sentences in the item match the pattern for defining a term.  <br/> |
+|extracted term  <br/> |A term that an extracted definition applies to.  <br/> |
+|Farm Administrators group  <br/> |A group of users that has permission to manage all the servers in a server farm. Members of the Farm Administrators group can perform command-line operations and all the administrative tasks in Central Administration for the server or server farm.  <br/> |
+|farm solution  <br/> |A custom solution that can be deployed to a farm by a farm administrator. A farm solution has full access to system resources and other sites in the farm.  <br/> |
+|feature definition  <br/> |An XML fragment that defines a feature and its attributes.  <br/> |
+|feature identifier  <br/> |A GUID that identifies a feature.  <br/> |
+|feature property  <br/> |A property that is associated with an active feature at a particular scope.  <br/> |
+|feature scope  <br/> |The scope at which a feature can be activated.  <br/> |
+|federated location  <br/> |A source that returns a set of search results for a given search query. The source can be a search service in the local server farm or another server farm, or another search engine that is compliant with the OpenSearch protocol.  <br/> |
+|federated location definition  <br/> |The configuration settings that describe how to issue a query for a given federated location and display the search results.  <br/> |
+|field internal name  <br/> |A string that uniquely identifies a field in a content type or a SharePoint list.  <br/> |
+|first-stage Recycle Bin  <br/> |A container for items that are deleted. Items in this container are visible to users with the appropriate permissions and to site collection administrators.  <br/> |
+|FSA Manager  <br/> |The Windows service that provides administration functionality for FAST Search Authorization.  <br/> |
+|FSA worker  <br/> |The Windows service that generates user search security filters in FAST Search Authorization.  <br/> |
+|full-text index component  <br/> |A set of files that contain all index keys that are extracted from a set of items.  <br/> |
+|generic list  <br/> |A list whose base type is Generic List.  <br/> |
+|Group Approval document identifier  <br/> |A string that uniquely identifies a document that is subject to the policies defined for a Group Approval workflow. The string is generated and assigned automatically to a document by a protocol server.  <br/> |
+|high confidence property  <br/> |A managed property from the metadata index that the administrator identifies as a good indicator of a highly relevant item. It is used to produce a high confidence result.  <br/> |
+|high confidence result  <br/> |A search result that is considered to be highly relevant because of a precise match between a high confidence property value and the tokens in the query text.  <br/> |
+|high-trust app  <br/> |An app that uses the server-to-server (S2S) protocol, where the app is responsible for creating the user portion of the access token, and therefore is trusted to assert any user identity.  <br/> |
+|host web  <br/> |A SharePoint site to which an add-in is installed.  <br/> |
+|item identifier  <br/> |An integer that uniquely identifies an item in a SharePoint list.  <br/> |
+|keyword consumer  <br/> |A site collection that uses a particular set of keywords, synonyms, and Best Bets.  <br/> |
+|keyword synonym  <br/> |An alternate phrasing of a particular keyword. When a user types a keyword synonym, search returns the same Best Bet result as the keyword.  <br/> |
+|language auto-detection  <br/> |A process that automatically determines the language code identifier (LCID) for text in a document.  <br/> |
+|list folder  <br/> |A folder that is contained within a SharePoint list. A list folder can contain documents or list items, and it retains the characteristics of other items in the list, such as a customizable schema.  <br/> |
+|list form  <br/> |A page that allows users to create, view, or edit an item in a list.  <br/> |
+|List Form web part  <br/> |A web part that is used to display, edit, or view an item in a list.  <br/> |
+|list identifier  <br/> |A GUID that is used to identify a list in a site collection.  <br/> |
+|list item attachment  <br/> |A file contained within a list item that is stored in a folder in the list with the segment "Attachments."  <br/> |
+|list item identifier  <br/> |An integer that uniquely identifies an item in a SharePoint list.  <br/> |
+|list server template  <br/> |A value that identifies the template that is used for a list.  <br/> |
+|list template  <br/> |An XML-based definition of list settings, including fields and views, and optionally list items. List templates are stored in .stp files in the content database.  <br/> |
+|list template identifier  <br/> |A GUID that is used to identify a list template.  <br/> |
+|list view page  <br/> |A web part Page that displays a view of a list.  <br/> |
+|List View web part  <br/> |A reusable component that generates HTML-based views of items in a SharePoint list.  <br/> |
+|log level  <br/> |The amount of information that is stored in a log file for a transaction. Log levels can be represented by numbers or by words from the most to the least verbose.  <br/> |
+|managed keyword  <br/> |A word or phrase that is added to a SharePoint item, either as a value in the Managed Keyword column or as a social tag.  <br/> |
+|member group  <br/> |A group of users that is specific to the User Profile service.  <br/> |
+|member group source  <br/> |A qualified domain name, such as domain.corp.microsoft.com, that identifies the source of a member group.  <br/> |
+|Members group  <br/> |A default group of users on a SharePoint site. By default, the Members group is assigned the Contribute permission level.  <br/> |
+|membership group record identifier  <br/> |A unique identifier for a member group record.  <br/> |
+|metadata index  <br/> |A data structure on a back-end database server that stores properties that are associated with each item, and attributes of those properties.  <br/> |
+|metadata schema  <br/> |A schema that is used to manage information about an item.  <br/> |
+|Microsoft Business Connectivity Services  <br/> |A feature that enables users to interact with back-end (LOB) data from within the Office Suite and SharePoint.  <br/> |
+|moderated object  <br/> |An object for which a moderator reviews and either approves or rejects additions or changes to that object. New objects and changes to existing objects can be seen by other users only after they have been approved by the moderator.  <br/> |
+|moderation status  <br/> |A content approval status of an item in a list.  <br/> |
+|multivalue property  <br/> |A property that can contain multiple values of the same variant type.  <br/> |
+|navigation structure  <br/> |A hierarchical organization of links between related content, such as lists within a site.  <br/> |
+|new form  <br/> |A form that allows for the creation of a list item.  <br/> |
+|Office SharePoint Server Search service  <br/> |The farm-wide service that either responds to query requests from front-end web servers or crawls items.  <br/> |
+|Office Store  <br/> | Now known as AppSource. An Internet site that provides a collection of products and services developed by Microsoft partners for Microsoft Office users.  <br/> |
+|Open Item permission  <br/> |An authorization that allows a user to retrieve an entire file.  <br/> |
+|Open web permission  <br/> |A requisite permission during the import or export of a SharePoint site.  <br/> |
+|operator account  <br/> |The account of the user who is managing the import process for a deployment package.  <br/> |
+|organization identifier  <br/> |An integer that uniquely identifies an organization.  <br/> |
+|orphaned object  <br/> |A content database object that lacks a requisite relationship to a corresponding object.  <br/> |
+|paged view  <br/> |A view that supports one or more visual pages. A paged view is used to break up large sets of data into smaller sets for increased performance and manageability.  <br/> |
+|parent farm  <br/> |A farm that crawls content from another farm and also responds to query requests from that farm.  <br/> |
+|parent list  <br/> |A list that contains a list item or list folder.  <br/> |
+|PerformancePoint Data Connections Library  <br/> |A SharePoint document library that contains PerformancePoint data sources.  <br/> |
+|personal site  <br/> |A type of SharePoint site that is used by an individual user for personal productivity. The site appears to the user as My Site.  <br/> |
+|portal content  <br/> |The main search catalog, which contains content sources and settings that are related to a crawl.  <br/> |
+|principal aliasing  <br/> |The process of mapping a user or a group in one user store to a user or a group in another user store for the purpose of returning all documents that the user or group has rights to view, regardless of which user store the user or group is authenticated to.  <br/> |
+|privacy level  <br/> |A setting that specifies the category of users who are allowed to view the personal information of other users, such as user profile properties, colleagues, or memberships.  <br/> |
+|provisioned  <br/> |A condition of an object that was created and deployed successfully.  <br/> |
+|public filter  <br/> |The search security filter in FSA that finds documents that all users have access to.  <br/> |
+|publish to server  <br/> |A process that facilitates saving a document or portions of a document to a web server.  <br/> |
+|published version  <br/> |The version of a list item that is approved and can be seen by all users. The user interface (UI) version number for a published version is incremented to the next positive major version number and the minor version is zero.  <br/> |
+|publishing level  <br/> |An integer that is assigned to a document to indicate the publishing status of that version of the document.  <br/> |
+|publishing page  <br/> |A document that binds to a page layout to generate an HTML page for display to a reader. Publishing pages have specific fields that contain the content that is displayed in an HTML page.  <br/> |
+|query independent rank  <br/> |A system to rank items that uses features that do not vary with different queries.  <br/> |
+|query table  <br/> |A two-dimensional table that presents data from an external data source.  <br/> |
+|ranking parameter  <br/> |A value that is used to influence the algorithm that determines the rank of an item.  <br/> |
+|role identifier  <br/> |An integer that uniquely identifies a role definition within a site.  <br/> |
+|role type  <br/> |A predefined role definition.  <br/> |
+|root document  <br/> |A document in the root folder of a site.  <br/> |
+|scheduled  <br/> |A status that is applied to a list item or document that specifies a time when the item or document will be published or unpublished.  <br/> |
+|schema version  <br/> |An integer value that represents the version number of the schema for a deployment package.  <br/> |
+|search application  <br/> |A unique group of search settings that is associated, one-to-one, with a shared service provider.  <br/> |
+|search catalog  <br/> |All the crawl data that is associated with a given search application. A search catalog provides information that is used to generate query results.  <br/> |
+|search database  <br/> |A database that stores search-related information, including stored procedures and tables that are used for crawler data, document metadata, and administration information.  <br/> |
+|search query log  <br/> |A record of information about user searches, such as search terms and time of access.  <br/> |
+|search scope consumer  <br/> |A site collection that uses a particular search scope display group.  <br/> |
+|search scope display group  <br/> |An ordered set of search scopes, defined by an administrator or programmatically, and used for returning groups of search scopes. Search scope display groups are saved for each search scope consumer and search scopes can be in multiple search scope display groups.  <br/> |
+|search scope index  <br/> |A specialized component of a full-text index catalog that is built on the values of scoped properties for optimized queries.  <br/> |
+|search scope rule  <br/> |An attribute that specifies which items are included in a given search scope.  <br/> |
+|search service account  <br/> |A user account under which the search service runs.  <br/> |
+|search shared application object  <br/> |An instance of a shared application for search that holds search-specific settings.  <br/> |
+|second-stage Recycle Bin  <br/> |A container for items that have been deleted from a first-stage Recycle Bin. Items in a second-stage Recycle Bin are visible only to site collection administrators.  <br/> |
+|server-to-server protocol  <br/> |An authentication protocol between two servers or services.  <br/> |
+|Shared Documents library  <br/> |A document library that is included by default in the Team Site site template.  <br/> |
+|shared view  <br/> |A view of a list or web part Page that every user who has the appropriate permissions can see.  <br/> |
+|SharePoint Search SQL syntax  <br/> |The rules that govern the construction of an enterprise search SQL query.  <br/> |
+|single sign-on ticket  <br/> |A token that contains the encrypted identity of a single sign-on (SSO) user in the form of a security identifier string and a nonce.  <br/> |
+|site collection administrator  <br/> |A user who has administrative permissions for a site collection.  <br/> |
+|site collection flag  <br/> |A 4-byte unsigned integer bit mask that specifies the properties that are global to a site collection. One or more values can be set for this bit mask.  <br/> |
+|site collection identifier  <br/> |A GUID that identifies a site collection. In stored procedures, the identifier is typically @SiteId or @webSiteId. In databases, the identifier is typically SiteId/tp_SiteId.  <br/> |
+|site collection quota  <br/> |An option for a site collection that allows administrators to set levels for maximum storage allowed, maximum number of users allowed, and warnings that are associated with the maximum levels.  <br/> |
+|site column  <br/> |A field that can be associated with a content type or list within a site or site collection.  <br/> |
+|site content type  <br/> |A named and uniquely identifiable collection of settings and fields that store metadata for lists within individual sites.  <br/> |
+|site definition  <br/> |A family of site definition configurations. Each site definition specifies a name and contains a list of the site definition configurations.  <br/> |
+|site definition configuration  <br/> |An XML-based definition of lists, features, modules, and other data, that collectively define a type of SharePoint site. Site definition configurations are stored in the ONET.xml file.  <br/> |
+|site definition version  <br/> |A zero-based integer that indicates the version number of the site definition. Every time a site definition is updated, it is suggested that the version number be increased.  <br/> |
+|site flag  <br/> |A 4-byte unsigned integer bit mask that specifies properties that are unique to a site.  <br/> |
+|site identifier  <br/> |A GUID that is used to identify a site in a SharePoint site collection.  <br/> |
+|site membership  <br/> |The status of being a member of a site and having a defined set of user rights for accessing or managing content on that site.  <br/> |
+|site property  <br/> |A name/value pair of strings that serves as metadata for a site, such as the title or default language.  <br/> |
+|site solution  <br/> |A deployable, reusable package that contains a set of features, site definitions, and assemblies that apply to sites, and that can be enabled or disabled individually.  <br/> |
+|site template  <br/> |An XML-based definition of site settings, including formatting, lists, views, and elements such as text, graphics, page layout, and styles. Site templates are stored in .stp files in the content database.  <br/> |
+|start address  <br/> |A URL that identifies a point at which to start a crawl. Administrators specify start addresses when they create or edit a content source.  <br/> |
+|static rank  <br/> |The component of a rank that does not depend on the search query. It represents the perceived importance of an item and may be related to the origin of the item and relationships between the item and other items or business rules that are defined in the search application.  <br/> |
+|trusted authentication  <br/> |A mechanism whereby a user account or a process account can be used to perform operations on behalf of the current user.  <br/> |
+|trusted subsystem  <br/> |A method of communication in which two-way trust is established between two server components. Each server component communicates with the other component by using an account that is authorized to perform privileged actions such as retrieving files and settings.  <br/> |
+|UI culture  <br/> |The language that is used to display strings and other graphical elements in a user interface.  <br/> |
+|user display name  <br/> |A user profile property that can contain the preferred name of a user.  <br/> |
+|user profile change entry log  <br/> |A repository that logs all the changes that take place in a user profile.  <br/> |
+|user profile change event  <br/> |An event that occurs when a property of any user profile is changed.  <br/> |
+|user profile import  <br/> |The process of importing records from a directory service to the user profile store.  <br/> |
+|user profile record identifier  <br/> |An integer that uniquely identifies a user profile record.  <br/> |
+|user profile store  <br/> |A database that stores information about each user profile.  <br/> |
+|user search security filter  <br/> |The user search security filter that specifies group and user permissions for a specific FAST Search user. FAST Search Authorization (FSA) filters out inappropriate search results by intersecting the user's query with the user's search security filter, and checking each document's access control list to determine if the user has permission to view that document. The user search security filter is FSA's primary means of enforcing document-level security ("security trimming"), which helps to ensure that search results display only documents that the user has permissions to read.  <br/> |
+|user store  <br/> |A logical grouping of users, groups, and content permissions for a third-party security or content system that is accessed by FAST Search Authorization.  <br/> |
+|visible scope  <br/> |A search scope that is displayed to site collection administrators and users.  <br/> |
+|Visitors group  <br/> |A default group of users on a SharePoint site. By default, the Visitors group is assigned the Read permission level.  <br/> |
+|web application identifier  <br/> |A GUID that identifies a web application.  <br/> |
+|web control  <br/> |A server-side component that encapsulates user interface and related functionality.  <br/> |
+|web discussion comment  <br/> |An individual comment that is added within a web discussion.  <br/> |
+|web identifier  <br/> |A GUID that is used to identify a site in a SharePoint site collection.  <br/> |
+|web part cache  <br/> |A hash table of key/value pairs that is used to cache and locate internal information for web parts.  <br/> |
+|web part chrome state  <br/> |The condition of a web part and the web part chrome surrounding it. Possible values are zero (0) for normal state or one (1) for minimized state.  <br/> |
+|web part connection  <br/> |An element in a web parts page that defines a provider-consumer data relationship between two web parts. When a web parts page is rendered, data provided by one web part can affect how and what is rendered by the other web part.  <br/> |
+|web part identifier  <br/> |A GUID that identifies a web part.  <br/> |
+|web part property  <br/> |A configurable characteristic of a web part that determines the behavior of the web part.  <br/> |
+|web part type identifier  <br/> |A unique 16-byte value that is assigned to each web part type.  <br/> |
+|web part zone identifier  <br/> |A string that identifies a web part zone on a web parts page.  <br/> |
+|web part zone index  <br/> |An integer that specifies the relative position of a web part in a web part zone. web parts are positioned from the smallest to the largest zone index. If two or more web parts have the same zone index, they are positioned adjacent to each other in an undefined order.  <br/> |
+|web proxy  <br/> |A method exposed in a client object model to issue requests from SharePoint to a remote service that developers can use in apps for SharePoint.  <br/> |
+|web service method  <br/> |A procedure that is exposed to web service clients as an operation that can be called on the web service.  <br/> |
+|work item process  <br/> |A process that runs a work item.  <br/> |
+|work item type identifier  <br/> |A GUID that is used to identify a work item type.  <br/> |
+|workflow association  <br/> |An association of a workflow template to a specific list or content type.  <br/> |
+|workflow configuration file  <br/> |An implementation-specific file that is a part of a workflow. The workflow configuration file contains information that is necessary to create a workflow template from the specified workflow markup and rules files, and to associate it to a specific list.  <br/> |
+|workflow history item  <br/> |A list item that stores information about the current status of, and past actions for, a document or item that is associated with a workflow.  <br/> |
+|workflow history list  <br/> |A list that stores the history of actions or tasks for a business process.  <br/> |
+|workflow identifier  <br/> |A GUID that is used to identify a workflow.  <br/> |
+|workflow markup file  <br/> |A file that contains markup to specify the functional behavior of a workflow.  <br/> |
+|workflow task  <br/> |An action or task in a sequence that is related to a built-in or user-defined business process.  <br/> |
+|workflow task list  <br/> |A list that stores the sequence of actions or tasks for a business process.  <br/> |
+|zero-based index  <br/> |An index in which the first item has an index of zero.  <br/> |
+   
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -229,9 +229,9 @@ Build SharePoint Framework solutions, apps, add-ins, and solutions for SharePoin
                 <div class="card">
                     <div class="cardText">
                         <h3>SharePoint Add-ins</h3>
-                        <p><a href="https://docs.microsoft.com/en-us/sharepoint/dev/sp-add-ins/sharepoint-add-ins">Overview of SharePoint add-ins</a></p>
-                        <p><a href="https://docs.microsoft.com/en-us/sharepoint/dev/sp-add-ins/get-started-creating-provider-hosted-sharepoint-add-ins">Provider hosted add-ins</a></p>
-                        <p><a href="https://docs.microsoft.com/en-us/sharepoint/dev/sp-add-ins/get-started-creating-sharepoint-hosted-sharepoint-add-ins">SharePoint hosted add-ins</a></p>
+                        <p><a href="https://docs.microsoft.com/en-us/sharepoint/dev/sp-add-ins/sharepoint-add-ins">Overview of SharePoint Add-ins</a></p>
+                        <p><a href="https://docs.microsoft.com/en-us/sharepoint/dev/sp-add-ins/get-started-creating-provider-hosted-sharepoint-add-ins">Provider-hosted add-ins</a></p>
+                        <p><a href="https://docs.microsoft.com/en-us/sharepoint/dev/sp-add-ins/get-started-creating-sharepoint-hosted-sharepoint-add-ins">SharePoint-hosted add-ins</a></p>
                     </div>
                 </div>
             </div>
@@ -243,9 +243,10 @@ Build SharePoint Framework solutions, apps, add-ins, and solutions for SharePoin
                 <div class="card">
                     <div class="cardText">
                         <h3>SharePoint development overview</h3>
-                            <p><a href="/SharePoint/dev/general-development/programming-models-in-sharepoint.md">Programming models for SharePoint</a></p>
-                            <p><a href="/SharePoint/dev/general-development/office-365-cdn.md">Use the Office 365 content delivery network</a></p>
-                            <p><a href="/SharePoint/dev//general-development/site-collection-app-catalog.md">Use the site collection app catalog</a></p>
+                            <p><a href="../general-development/programming-models-in-sharepoint.md">Programming models for SharePoint</a></p>
+                            <p><a href="../general-development/office-365-cdn.md">Use the Office 365 content delivery network</a></p>
+                            <p><a href="../general-development/site-collection-app-catalog.md">Use the site collection app catalog</a></p>
+                            <p><a href="../general-development/sharepoint-glossary.md">Refer to the SharePoint glossary</a></p>
                     </div>
                 </div>
             </div>
@@ -256,10 +257,10 @@ Build SharePoint Framework solutions, apps, add-ins, and solutions for SharePoin
             <div class="cardPadding">
                 <div class="card">
                     <div class="cardText">
-                        <h3>Solution Guidance</h3>
-                            <p><a href="/sharepoint/dev/transform/modernize-classic-sites.md">Modernize your classic SharePoint sites</a></p>
-                            <p><a href="/sharepoint/dev/solution-guidance/modern-experience-customizations.md">Customizing modern experiences</a></p>
-                            <p><a href="/sharepoint/dev/solution-guidance/portal-overview.md">Building SharePoint Online portals</a></p>
+                        <h3>Solution guidance</h3>
+                            <p><a href="../transform/modernize-classic-sites.md">Modernize your classic SharePoint sites</a></p>
+                            <p><a href="../solution-guidance/modern-experience-customizations.md">Customizing modern experiences</a></p>
+                            <p><a href="../solution-guidance/portal-overview.md">Building SharePoint Online portals</a></p>
                     </div>
                 </div>
             </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -187,9 +187,9 @@ Build SharePoint Framework solutions, apps, add-ins, and solutions for SharePoin
                 <div class="card">
                     <div class="cardText">
                         <h3>SharePoint Framework</h3>
-                        <p><a href="https://docs.microsoft.com/en-us/sharepoint/dev/spfx/sharepoint-framework-overview">Overview of the SharePoint Framework</a></p>
-                        <p><a href="https://docs.microsoft.com/en-us/sharepoint/dev/spfx/set-up-your-development-environment">Set up your development environment</a></p>
-                        <p><a href="https://docs.microsoft.com/en-us/sharepoint/dev/spfx/web-parts/get-started/build-a-hello-world-web-part">Build your first client-side web part</a></p>
+                        <p><a href="/sharepoint/dev/spfx/sharepoint-framework-overview">Overview of the SharePoint Framework</a></p>
+                        <p><a href="/sharepoint/dev/spfx/set-up-your-development-environment">Set up your development environment</a></p>
+                        <p><a href="/sharepoint/dev/spfx/web-parts/get-started/build-a-hello-world-web-part">Build your first client-side web part</a></p>
                     </div>
                 </div>
             </div>
@@ -201,8 +201,8 @@ Build SharePoint Framework solutions, apps, add-ins, and solutions for SharePoin
                 <div class="card">
                     <div class="cardText">
                         <h3>SharePoint REST service</h3>
-                        <p><a href="https://docs.microsoft.com/en-us/sharepoint/dev/sp-add-ins/get-to-know-the-sharepoint-rest-service">Get to know the SharePoint REST service</a></p>
-                        <p><a href="https://docs.microsoft.com/en-us/sharepoint/dev/sp-add-ins/complete-basic-operations-using-sharepoint-rest-endpoints">Complete basic operations</a></p>
+                        <p><a href="/sharepoint/dev/sp-add-ins/get-to-know-the-sharepoint-rest-service">Get to know the SharePoint REST service</a></p>
+                        <p><a href="/sharepoint/dev/sp-add-ins/complete-basic-operations-using-sharepoint-rest-endpoints">Complete basic operations</a></p>
                         <p><a href="https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/sharepoint">SharePoint in Microsoft Graph</a></p>
                      </div>
                 </div>
@@ -215,9 +215,9 @@ Build SharePoint Framework solutions, apps, add-ins, and solutions for SharePoin
                 <div class="card">
                     <div class="cardText">
                         <h3>SharePoint webhooks</h3>
-                        <p><a href="https://docs.microsoft.com/en-us/sharepoint/dev/apis/webhooks/overview-sharepoint-webhooks">Overview of SharePoint webhooks</a></p>
-                        <p><a href="https://docs.microsoft.com/en-us/sharepoint/dev/apis/webhooks/get-started-webhooks">Get started with SharePoint webhooks</a></p>
-                        <p><a href="https://docs.microsoft.com/en-us/sharepoint/dev/apis/webhooks/lists/overview-sharepoint-list-webhooks">SharePoint list webhooks</a></p>
+                        <p><a href="/sharepoint/dev/apis/webhooks/overview-sharepoint-webhooks">Overview of SharePoint webhooks</a></p>
+                        <p><a href="/sharepoint/dev/apis/webhooks/get-started-webhooks">Get started with SharePoint webhooks</a></p>
+                        <p><a href="/sharepoint/dev/apis/webhooks/lists/overview-sharepoint-list-webhooks">SharePoint list webhooks</a></p>
                </div>
                 </div>
             </div>
@@ -229,9 +229,9 @@ Build SharePoint Framework solutions, apps, add-ins, and solutions for SharePoin
                 <div class="card">
                     <div class="cardText">
                         <h3>SharePoint Add-ins</h3>
-                        <p><a href="https://docs.microsoft.com/en-us/sharepoint/dev/sp-add-ins/sharepoint-add-ins">Overview of SharePoint Add-ins</a></p>
-                        <p><a href="https://docs.microsoft.com/en-us/sharepoint/dev/sp-add-ins/get-started-creating-provider-hosted-sharepoint-add-ins">Provider-hosted add-ins</a></p>
-                        <p><a href="https://docs.microsoft.com/en-us/sharepoint/dev/sp-add-ins/get-started-creating-sharepoint-hosted-sharepoint-add-ins">SharePoint-hosted add-ins</a></p>
+                        <p><a href="/sharepoint/dev/sp-add-ins/sharepoint-add-ins">Overview of SharePoint Add-ins</a></p>
+                        <p><a href="/sharepoint/dev/sp-add-ins/get-started-creating-provider-hosted-sharepoint-add-ins">Provider-hosted add-ins</a></p>
+                        <p><a href="/sharepoint/dev/sp-add-ins/get-started-creating-sharepoint-hosted-sharepoint-add-ins">SharePoint-hosted add-ins</a></p>
                     </div>
                 </div>
             </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Build SharePoint Framework solutions, apps, add-ins, and solutions for SharePoin
 
 <ul class="panelContent cardsFTitle">
     <li>
-        <a href="/sharepoint/dev/spfx/set-up-your-development-environment.md">
+        <a href="/sharepoint/dev/spfx/set-up-your-development-environment">
         <div class="cardSize">
             <div class="cardPadding">
                 <div class="card">
@@ -243,10 +243,10 @@ Build SharePoint Framework solutions, apps, add-ins, and solutions for SharePoin
                 <div class="card">
                     <div class="cardText">
                         <h3>SharePoint development overview</h3>
-                            <p><a href="../general-development/programming-models-in-sharepoint.md">Programming models for SharePoint</a></p>
-                            <p><a href="../general-development/office-365-cdn.md">Use the Office 365 content delivery network</a></p>
-                            <p><a href="../general-development/site-collection-app-catalog.md">Use the site collection app catalog</a></p>
-                            <p><a href="../general-development/sharepoint-glossary.md">Refer to the SharePoint glossary</a></p>
+                            <p><a href="/sharepoint/dev/general-development/programming-models-in-sharepoint">Programming models for SharePoint</a></p>
+                            <p><a href="/sharepoint/dev/general-development/office-365-cdn">Use the Office 365 content delivery network</a></p>
+                            <p><a href="/sharepoint/dev/general-development/site-collection-app-catalog">Use the site collection app catalog</a></p>
+                            <p><a href="/sharepoint/dev/general-development/sharepoint-glossary">Refer to the SharePoint glossary</a></p>
                     </div>
                 </div>
             </div>
@@ -258,9 +258,9 @@ Build SharePoint Framework solutions, apps, add-ins, and solutions for SharePoin
                 <div class="card">
                     <div class="cardText">
                         <h3>Solution guidance</h3>
-                            <p><a href="../transform/modernize-classic-sites.md">Modernize your classic SharePoint sites</a></p>
-                            <p><a href="../solution-guidance/modern-experience-customizations.md">Customizing modern experiences</a></p>
-                            <p><a href="../solution-guidance/portal-overview.md">Building SharePoint Online portals</a></p>
+                            <p><a href="/sharepoint/dev/transform/modernize-classic-sites">Modernize your classic SharePoint sites</a></p>
+                            <p><a href="/sharepoint/dev/solution-guidance/modern-experience-customizations">Customizing modern experiences</a></p>
+                            <p><a href="/sharepoint/dev/solution-guidance/portal-overview">Building SharePoint Online portals</a></p>
                     </div>
                 </div>
             </div>

--- a/docs/schema/schema-reference-for-sharepoint.md
+++ b/docs/schema/schema-reference-for-sharepoint.md
@@ -31,7 +31,9 @@ This section collects all SharePoint schemas into eight sections, providing easy
 - [Other SharePoint schemas](other-sharepoint-schemas.md)
 
 
+## See also
 
+- [SharePoint glossary](../general-development/sharepoint-glossary.md) 
 
 
 

--- a/docs/solution-guidance/Office-365-development-patterns-and-practices-solution-guidance.md
+++ b/docs/solution-guidance/Office-365-development-patterns-and-practices-solution-guidance.md
@@ -31,8 +31,7 @@ _**Applies to:** Office 365 | SharePoint 2016 | SharePoint 2013 | SharePoint Onl
 
 
 ## See also
-<a name="bk_addresources"> </a>
 
--  [Office 365 Development Patterns and Practices on GitHub](https://github.com/SharePoint/PnP)
-    
--  [Developing on the Office 365 platform](http://msdn.microsoft.com/en-us/office/office365/howto/platform-development-overview)
+- [Office 365 Development Patterns and Practices on GitHub](https://github.com/SharePoint/PnP)   
+- [Developing on the Office 365 platform](http://msdn.microsoft.com/en-us/office/office365/howto/platform-development-overview)
+- [SharePoint glossary](../general-development/sharepoint-glossary.md) 

--- a/docs/sp-add-ins/sharepoint-add-ins.md
+++ b/docs/sp-add-ins/sharepoint-add-ins.md
@@ -144,4 +144,5 @@ Ready to get started?
 
 ## See also
 
-[Developing Microsoft SharePoint Server 2013 Core Solutions Jump Start](http://www.microsoftvirtualacademy.com/training-courses/developing-microsoft-sharepoint-server-core-solutions-jump-start)
+- [Developing Microsoft SharePoint Server 2013 Core Solutions Jump Start](http://www.microsoftvirtualacademy.com/training-courses/developing-microsoft-sharepoint-server-core-solutions-jump-start)
+- [SharePoint glossary](../general-development/sharepoint-glossary.md) 

--- a/docs/spfx/sharepoint-framework-overview.md
+++ b/docs/spfx/sharepoint-framework-overview.md
@@ -68,3 +68,4 @@ You can also post issues, questions, or feedback about the docs or the SharePoin
 - [Overview of SharePoint client-side web parts](./web-parts/overview-client-side-web-parts.md)
 - [Overview of SharePoint Framework Extensions](./extensions/overview-extensions.md)
 - [SharePoint development](https://docs.microsoft.com/en-us/sharepoint/dev/)
+- [SharePoint glossary](../general-development/sharepoint-glossary.md) 

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -347,6 +347,8 @@
 - name: SharePoint development overview
   href: general-development/sharepoint-development-overview.md
   items:
+  - name: SharePoint glossary
+    href: general-development/sharepoint-glossary.md  
   - name: Protocol handler error in SharePoint 2016
     href: general-development/protocol-handler-error-due-to-deprecated-interface-in-sharepoint-2016.md
   - name: Programming models


### PR DESCRIPTION
- Converted SharePoint glossary from MSDN to markdown
- Added glossary to Development overview section
- Added glossary link in See also on top-level pages
- Added glossary link on Index page and fixed broken links on Index
- Added glossary link on TOC