### PR TITLE
Use tsx instead of typescriptx as formatting option

### DIFF
--- a/docs/spfx/web-parts/guidance/build-custom-property-pane-controls.md
+++ b/docs/spfx/web-parts/guidance/build-custom-property-pane-controls.md
@@ -254,7 +254,7 @@ When creating a custom property pane control that uses React in the SharePoint F
 
 4. Define the asynchronous dropdown React component. In the **src/controls/PropertyPaneAsyncDropdown/components** folder, create a new file named **AsyncDropdown.tsx**, and enter the following code:
 
-  ```typescriptx
+  ```tsx
   import * as React from 'react';
   import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/components/Dropdown';
   import { Spinner } from 'office-ui-fabric-react/lib/components/Spinner';

--- a/docs/spfx/web-parts/guidance/tutorial-share-data-between-web-parts-global-variable.md
+++ b/docs/spfx/web-parts/guidance/tutorial-share-data-between-web-parts-global-variable.md
@@ -502,7 +502,7 @@ The Recent Document web part displays information about the most recently modifi
 
 2. In the code editor, open the **./src/webparts/recentDocument/components/RecentDocument.tsx** file, and paste the following code:
 
-  ```typescriptx
+  ```tsx
   import * as React from 'react';
   import {
     DocumentCard,


### PR DESCRIPTION
It seems typescriptx isn't supported in many markdown formatters but tsx is.

#### Category
- [x] Content fix

#### What's in this Pull Request?
Syntax highlighting works better after these small changes in those two code blocks.
