### PR TITLE
Update sharepoint-search-rest-api-overview.md

### DIFF
--- a/docs/general-development/sharepoint-search-rest-api-overview.md
+++ b/docs/general-development/sharepoint-search-rest-api-overview.md
@@ -499,8 +499,7 @@ http:// _server_/_api/search/query?querytext='sharepoint'&amp;refiners='author,s
 {
 '__metadata':{'type':'Microsoft.Office.Server.Search.REST.SearchRequest'},
 'Querytext':'sharepoint',
-'Refiners': {
-'results' : ['author,size']
+'Refiners': 'author,size',
 }
 }
 ```


### PR DESCRIPTION
'Refiners'-property in search POST request should be 'string,string', not { results: ['string,string'] }

#### Category
- [x] Content fix
- [ ] New article

#### What's in this Pull Request?

The "Refiners" property expects a comma delimited string of refinable properties, not an array of strings. Fixed code example to reflect that.

See related [PnP-JS-Core issue](https://github.com/SharePoint/PnP-JS-Core/pull/243)


#### Guidance
