### PR TITLE
Adding missing instruction

### DIFF
--- a/docs/spfx/extensions/get-started/building-simple-cmdset-with-dialog-api.md
+++ b/docs/spfx/extensions/get-started/building-simple-cmdset-with-dialog-api.md
@@ -216,7 +216,11 @@ The default solution takes advantage of a new Dialog API, which can be used to s
 
 3. Open **HelloWorldCommandSet.ts** from the **src\extensions\helloWorld** folder.
 
-4. Add the following import statement for the `Dialog` class from `@microsoft/sp-dialog` after the existing import statements. 
+4. Ensure at the top of the file the following import statement is present for the `Dialog` class from `@microsoft/sp-dialog`. It should already be there, if not, add it.
+
+```typescript
+import { Dialog } from '@microsoft/sp-dialog';
+```
 
 5. Update the **onExecute** method as follows:
     


### PR DESCRIPTION
Step 4 under 'Enhance the ListView Command Set rendering' was missing the instruction to add. Moreover with the current latest version the import is already present anyway, thus does not need to be added manually. Changed the instruction to validate that it is indeed present. Order of imports doesn't seem to matter according to my tests.

#### Category
- [X] Content fix
- [ ] New article