### PR TITLE
improves cmdset elements.xml explanation

### DIFF
--- a/docs/spfx/extensions/get-started/building-simple-cmdset-with-dialog-api.md
+++ b/docs/spfx/extensions/get-started/building-simple-cmdset-with-dialog-api.md
@@ -282,7 +282,34 @@ Notice that we use a specific location value of `ClientSideExtension.ListViewCom
         Location="ClientSideExtension.ListViewCommandSet.CommandBar"
         ClientSideComponentId="5fc73e12-8085-4a4b-8743-f6d02ffe1240"
         ClientSideComponentProperties="{&quot;sampleTextOne&quot;:&quot;One item is selected in the list.&quot;, &quot;sampleTextTwo&quot;:&quot;This command is always visible.&quot;}">
+    </CustomAction>
+    
+</Elements>
+```
 
+> [!NOTE]
+> While running from localhost the custom action will work on both lists and document libraries, but will not once deployed unless the `elements.xml` is updated. `RegistrationId=100` will only associate the custom action with lists and **NOT** document libraries. In order to associate the custom action with document libraries, the `RegistrationId` must be set to **101**. If you would like the action to work on both lists and document libraries, another `CustomAction` must be added to the `elements.xml` file
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Elements xmlns="http://schemas.microsoft.com/sharepoint/">
+
+    <CustomAction 
+        Title="SPFxListViewCommandSet"
+        RegistrationId="100"
+        RegistrationType="List"
+        Location="ClientSideExtension.ListViewCommandSet.CommandBar"
+        ClientSideComponentId="5fc73e12-8085-4a4b-8743-f6d02ffe1240"
+        ClientSideComponentProperties="{&quot;sampleTextOne&quot;:&quot;One item is selected in the list.&quot;, &quot;sampleTextTwo&quot;:&quot;This command is always visible.&quot;}">
+    </CustomAction>
+
+    <CustomAction 
+        Title="SPFxListViewCommandSet"
+        RegistrationId="101"
+        RegistrationType="List"
+        Location="ClientSideExtension.ListViewCommandSet.CommandBar"
+        ClientSideComponentId="5fc73e12-8085-4a4b-8743-f6d02ffe1240"
+        ClientSideComponentProperties="{&quot;sampleTextOne&quot;:&quot;One item is selected in the list.&quot;, &quot;sampleTextTwo&quot;:&quot;This command is always visible.&quot;}">
     </CustomAction>
 
 </Elements>


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article

#### What's in this Pull Request?

Adds clarification to elements.xml section regarding RegistrationIds. The elements.xml currently provided is the default from the yeoman generator and will only work with lists when deployed, not document libraries. Based on the behavior when running localhost, it is easy to make the assumption that the custom action will be applied to both lists and document libraries, but that is not the case once deployed.