### PR TITLE
Language is unclear and we are seeing ISV's not following the guidance.

### DIFF
--- a/docs/general-development/how-to-avoid-getting-throttled-or-blocked-in-sharepoint-online.md
+++ b/docs/general-development/how-to-avoid-getting-throttled-or-blocked-in-sharepoint-online.md
@@ -72,7 +72,7 @@ The most common causes of per-user throttling in SharePoint Online are client-si
     A single process dramatically exceeds throttling limits, continually, over a long time period.
     
   - You used web services to build a tool to synchronize user profile properties. The tool updates user profile properties based on information from your line-of-business (LOB) human resources (HR) system. The tool makes calls at too high a frequency.
-  
+ 
   - You're running a load-testing script on SharePoint Online and you get throttled. Load testing is not allowed on SharePoint Online.
   
   - You customized your team site on SharePoint Online, for example, by adding a status indicator on the Home page. This status indicator updates frequently, which causes the page to make too many calls to the SharePoint Online service - this triggered throttling.
@@ -110,11 +110,11 @@ To ensure and maintain high-availability, some traffic may be throttled. Throttl
  
 What is definition of undecorated traffic?
 
-- Traffic is undecorated if there is no AppID/AppTitle or User Agent string in CSOM or REST API call to SharePoint Online.
+- Traffic is undecorated if there is no AppID/AppTitle and User Agent string in CSOM or REST API call to SharePoint Online.  The User Agent string should be in a specific format as described below.
 
 What are the recommendation?
 
-- If you have created an application, recommendation is to register and use  AppID and AppTitle – This will ensure the best overall experience and best path for any future issue resolution. Include also the User Agent string information as defined in following step.
+- If you have created an application, the recommendation is to register and use  AppID and AppTitle – This will ensure the best overall experience and best path for any future issue resolution. Include also the User Agent string information as defined in following step.
 
 - Make sure to include User Agent string in your API call to SharePoint with following naming convention
 


### PR DESCRIPTION
It's not clear what "register" means in "register and use  AppID and AppTitle."  Our experience in support has been that as soon as people add the User Agent, they experience far less throttling.  This should probably be check with the PG and maybe better verbiage applied.  The note:
[!NOTE]
> If you are developing front end components executing in the browser, most of modern browsers don't allow overwritting the user agent string and you don't need to implement this.
...is confusing.  I suspect some developers may think this means the User Agent header is optional if there is any kind of Add-in the executes from a browser.  Straight AJAX calls from JavaScript should allow this header, likewise with any kind of managed HTTPWebRequest.

#### Category
- [ ] Content fix
- [ ] New article
- Related issues: fixes #X, partially #Y, mentioned in #Z

> For the above list, an empty checkbox is [ ] as in <kbd>[</kbd><kbd>SPACE</kbd><kbd>]</kbd>. A checked checkbox is [x] with no space between the brackets. Use the `PREVIEW` tab at the top right to preview the rendering before submitting your issue.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### What's in this Pull Request?

> Please describe the changes in this PR. Sample description or details around bugs which are being fixed.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### Guidance

> *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
> 
> *Please target your PR to 'master' branch. Released documents are in `live` branch.*
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_