### PR TITLE
Further Namespace correction

### DIFF
--- a/docs/general-development/modify-sharepoint-components-for-mds.md
+++ b/docs/general-development/modify-sharepoint-components-for-mds.md
@@ -212,7 +212,7 @@ You also need to mark your controls and web parts as MDS compliant. The followin
 
 ```cs
 
-[assembly: Microsoft.SharePoint.WebControlsCompliantAttribute(IsCompliant = true)]
+[assembly: Microsoft.SharePoint.WebControls.MdsCompliantAttribute(IsCompliant = true)]
 namespace VisualWebPartProject2.VisualWebPart1
 {
     // Rest of your control logic


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article
- Related issues: fixes #1908 

#### What's in this Pull Request?

Namespace typo previously corrected didn't fully fix the issue (as per issue #1908). Actual class is [`Microsoft.SharePoint.WebControls.MdsCompliantAttribute`](https://msdn.microsoft.com/en-us/library/office/microsoft.sharepoint.webcontrols.mdscompliantattribute_members.aspx)