### PR TITLE
Additional info added to fifth step

### DIFF
--- a/docs/spfx/extensions/get-started/build-a-hello-world-extension.md
+++ b/docs/spfx/extensions/get-started/build-a-hello-world-extension.md
@@ -51,6 +51,7 @@ You can also follow the steps in this article by watching the video on the Share
 
     * Accept the default **HelloWorld** as your extension name, and select Enter.
     * Accept the default **HelloWorld description** as your extension description, and select Enter.
+    * For the fourth question **Do you want to allow the tenant admin the choice of being able to deploy the solution to all sites....**, ensure you select No (N) , and select Enter. If you select Yes (y), the scaffolding will not generate the Elements.xml featuer deployment file. This file is used in 'Deploy your extension to SharePoint' article.
 
     <br/>
 


### PR DESCRIPTION
In the 5th step, its better we explicitly call out to do not select 'y' for the "Do you want to allow tenant admin..." question while scaffolding the project. In the 3rd article (how to deploy extension to sharepoint), it uses the elements.xml file which will be missing if user selects 'y' for this question.

#### Category
- [ ] Content fix
- [ ] New article
- Related issues: fixes #X, partially #Y, mentioned in #Z

> For the above list, an empty checkbox is [ ] as in <kbd>[</kbd><kbd>SPACE</kbd><kbd>]</kbd>. A checked checkbox is [x] with no space between the brackets. Use the `PREVIEW` tab at the top right to preview the rendering before submitting your issue.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### What's in this Pull Request?

> Please describe the changes in this PR. Sample description or details around bugs which are being fixed.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### Guidance

> *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
> 
> *Please target your PR to 'master' branch. Released documents are in `live` branch.*
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_