### PR TITLE
Clarified use of internal field names

### DIFF
--- a/docs/declarative-customization/column-formatting.md
+++ b/docs/declarative-customization/column-formatting.md
@@ -1201,7 +1201,7 @@ The following example shows how a hyperlink field might be used on a current fie
 
 #### "[$FieldName]" 
 
-The column is formatted within the context of the entire row. You can use this context to reference the values of other fields within the same row. For example, to get the value of a field named "MarchSales", use `[$MarchSales]`.
+The column is formatted within the context of the entire row. You can use this context to reference the values of other fields within the same row by specififying the **internal name** of the field surrounded by square brackets and preceeded by a dollar sign: `[$InternalName]`. For example, to get the value of a field with an internal name of "MarchSales", use `[$MarchSales]`.
 
 If the value of a field is an object, the object's properties can be accessed. For example, to access the "Title" property of a person field named "SalesLead", use "[$SalesLead.title]".
 


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article
- Related issues: mentioned in #1250 

#### What's in this Pull Request?

Added clarification for referencing other fields to call out need to use internal field names. This was mentioned previously within an example in the article, but needed to be more explicit in the relevant detailed syntax section.