### PR TITLE
Fixed schema address

### DIFF
--- a/docs/declarative-customization/column-formatting.md
+++ b/docs/declarative-customization/column-formatting.md
@@ -95,7 +95,7 @@ This example uses the conditional operator `?` to apply a class (`sp-field-sever
 
 ```JSON
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/sp/column-formatting.schema.json",
+    "$schema": "https://developer.microsoft.com/json-schemas/sp/column-formatting.schema.json",
     "debugMode": true,
     "elmType": "div",
     "attributes": {
@@ -158,7 +158,7 @@ This pattern is useful when you want different values to map to different levels
 
 ```JSON
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/sp/column-formatting.schema.json",
+    "$schema": "https://developer.microsoft.com/json-schemas/sp/column-formatting.schema.json",
     "debugMode": true,
     "elmType": "div",
     "attributes": {
@@ -643,7 +643,7 @@ To use the sample below, you must substitute the ID of the Flow you want to run.
 
 ```JSON
 {
-	"$schema": "https://developer.microsoft.com/en-us/json-schemas/sp/column-formatting.schema.json",
+	"$schema": "https://developer.microsoft.com/json-schemas/sp/column-formatting.schema.json",
 	"elmType": "span",
 	"style": {
 		"color": "#0078d7"
@@ -730,7 +730,7 @@ Creating custom column formatting JSON from scratch is simple if you understand 
 
    ```JSON
     {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/sp/column-formatting.schema.json"
+    "$schema": "https://developer.microsoft.com/json-schemas/sp/column-formatting.schema.json"
     }
    ```
 


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article
- Related issues: mentioned in #2256 

#### What's in this Pull Request?

The column formatting schema is now redirecting from the `en-us` version to a more generic address. This causes an error in VS Code since it doesn't follow the redirect. So, I've updated all instances of the schema reference to prevent others from having the error.