### PR TITLE
Lookup Column Changes for SP2016

### DIFF
--- a/docs/sp-add-ins/working-with-lists-and-list-items-with-rest.md
+++ b/docs/sp-add-ins/working-with-lists-and-list-items-with-rest.md
@@ -171,9 +171,9 @@ Headers:
 
 <br/>
 
-### Lookup Column Changes
+### Lookup column changes
 
-When refering to a lookup column inside a list using REST API, use the display name of the lookup column instead of the internal name.
+When referring to a lookup column inside a list using REST API, use the display name of the lookup column instead of the internal name.
 
 ```
 http://site url/_api/web/lists/getbytitle('ListName')/Items?&$filter=LookupColumnId eq 1
@@ -219,7 +219,7 @@ headers:
 
 The following XML shows an example of the list item properties that are returned when you request the XML content type.
 
-```XML
+```xml
 <content type="application/xml">
 <m:properties> 
 <d:FileSystemObjectType m:type="Edm.Int32">0</d:FileSystemObjectType>
@@ -246,7 +246,7 @@ Retrieves information about the list and its data. Using this API you can retrie
 POST /_api/web/GetList(@listUrl)/RenderListDataAsStream?@listUrl=%27%2Fsites%2Fteam-a%2Flists%2FList%27
 ```
 
-#### URI Parameters
+#### URI parameters
 
 Following properties can be added as query string parameters to manipulate the returned data.
 
@@ -524,7 +524,7 @@ The following example shows how to create a list item in a folder.
 POST /_api/web/lists/GetByTitle('Test')/AddValidateUpdateItemUsingPath
 ```
 
-#### URI Parameters
+#### URI parameters
 
 None
 

--- a/docs/sp-add-ins/working-with-lists-and-list-items-with-rest.md
+++ b/docs/sp-add-ins/working-with-lists-and-list-items-with-rest.md
@@ -171,6 +171,17 @@ Headers:
 
 <br/>
 
+### Lookup Column Changes
+
+When refering to a lookup column inside a list using REST API, use the display name of the lookup column instead of the internal name.
+
+```
+http://site url/_api/web/lists/getbytitle('ListName')/Items?&$filter=LookupColumnId eq 1
+
+```
+
+<br/>
+
 <a name="ListItems"> </a>
 
 ## Working with list items by using REST


### PR DESCRIPTION
Added notes for how to call Lookup column via REST API which has been changed for SP2016.

#### Category
- [x] Content fix
- [ ] New article
- Related issues: fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?


> While working on code migration from SP2013 to SP2016, everything was working as expected except for one following REST API call which includes Lookup Columns:
```
SP2013: /_api/web/lists/getbytitle('ListName')/Items?&$filter=LookupColumn_x003a_ID eq 1
```
>After some hit and trial I was able to get it to work by referring the Lookup Column's display name (without referring to the lookup column’s internal name):
```
SP2016: /_api/web/lists/getbytitle('ListName')/Items?&$filter=LookupColumnId eq 1
```
