### PR TITLE
Removed notice about SPFx Extensions being in preview

### DIFF
--- a/docs/solution-guidance/modern-experience-customizations-customize-sites.md
+++ b/docs/solution-guidance/modern-experience-customizations-customize-sites.md
@@ -51,7 +51,7 @@ In numerous areas on the "modern" team sites, the typical customizations are not
 - Changing "modern" site to use "classic" seattle.master or oslo.master.
 - Custom page layouts; we are looking to have support for multiple canvases in the future.
 - Enabling site or site collection scoped publishing features; technically, features can be currently activated, but this is not a supported configuration.
-- User custom actions / custom JavaScript; there will be a more controlled way to embed JavaScript on the pages through the SharePoint Framework Extensions (currently in dev preview).
+- User custom actions / custom JavaScript; there will be a more controlled way to embed JavaScript on the pages through [SharePoint Framework Extensions](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/extensions/overview-extensions).
 - "Modern" subsites; subsites created on "modern" team sites use the "classic" experience, but you can change the user experience to be similar to "modern" sites.
 - Ability to control available subsite template options.
 - "Classic" publishing features (WCM).


### PR DESCRIPTION
#### Category
- [X] Content fix
- [ ] New article

#### What's in this Pull Request?

This article still mentioned SPFx Extensions to be in dev preview. As per https://docs.microsoft.com/en-us/sharepoint/dev/spfx/sharepoint-framework-overview#whats-next they're already in GA. Added link to the article with more information on SPFx Extensions.