### PR TITLE
Remove a repetition around the automatic deployment

### DIFF
--- a/docs/spfx/extensions/get-started/build-a-hello-world-extension.md
+++ b/docs/spfx/extensions/get-started/build-a-hello-world-extension.md
@@ -51,7 +51,7 @@ You can also follow the steps in this article by watching the video on the Share
 
     * Accept the default **HelloWorld** as your extension name, and select Enter.
     * Accept the default **HelloWorld description** as your extension description, and select Enter.
-    * For the next question **Do you want to allow the tenant admin the choice of being able to deploy the solution to all sites....**, ensure you select No (N) , and select Enter. If you select Yes (y), the scaffolding will not generate the Elements.xml feature deployment file.
+
 
     <br/>
 


### PR DESCRIPTION
We mention it twice that the N button should be pressed in order to avoid the the automatic deployment option. The second reference is unnecessary and confusing because it appears at a totally wrong moment.

#### Category
- [X ] Content fix
- [ ] New article
- Related issues: 