### PR TITLE
Fixed broken anchor

### DIFF
--- a/docs/sp-add-ins/set-custom-permissions-on-a-list-by-using-the-rest-interface.md
+++ b/docs/sp-add-ins/set-custom-permissions-on-a-list-by-using-the-rest-interface.md
@@ -10,7 +10,7 @@ ms.prod: sharepoint
 SharePoint sites, lists, and list items are types of **SecurableObject**. By default, a securable object inherits the permissions of its parent. To set custom permissions for an object, you need to break its inheritance so that it stops inheriting permissions from its parent, and then define new permissions by adding or removing role assignments. 
  
 > [!NOTE] 
-> See the [See also](#bk_addresources) section for links to articles about setting fine-grained permissions.
+> See the [See also](#see-also) section for links to articles about setting fine-grained permissions.
  
 The code example in this article sets custom permissions on a list, and then changes a group's permissions to it. The example uses the REST interface to:
 


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article
- Related issues: fixes #2368

#### What's in this Pull Request?

The See Also link had an incorrect anchor and so didn't work. As mentioned in Issue #2368. Now it will.