### PR TITLE
Update to the "GetTime" function for async

### DIFF
--- a/docs/spfx/dynamic-loading.md
+++ b/docs/spfx/dynamic-loading.md
@@ -106,7 +106,7 @@ However, in the code below the moment library is loaded asynchronous when the `G
 
 ```typescript
 export default class MyClass {
-    public GetTime(dateString:string){
+    public async GetTime(dateString:string){
          const moment = await import(
                 /* webpackChunkName: 'my-moment' */
                 'moment'
@@ -122,7 +122,7 @@ export default class MyClass {
 declare var System: any;
 
 export default class MyClass {
-    public GetTime(dateString:string){
+    public async GetTime(dateString:string){
          const moment = await System.import(
                 /* webpackChunkName: 'my-moment' */
                 'moment'


### PR DESCRIPTION
I might be incorrect, but when I did this with an OOB SPFx solution, whether web part or extension, I had to set my functions as "async" or I wasn't able to use the 'await'. Feel free to disregard if I'm not accurate, but wanted to pass along my experience.

#### Category
- [x] Content fix
- [ ] New article
- Related issues: fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Updated the functions that are used to perform the dynamic loading of the packages.
I might be incorrect, but when I did this with an OOB SPFx solution, whether web part or extension, I had to set my functions as "async" or I wasn't able to use the 'await'. Feel free to disregard if I'm not accurate, but wanted to pass along my experience.

#### Guidance

> *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
> 
> *Please target your PR to 'master' branch. Released documents are in `live` branch.*
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_