### PR TITLE
It is possible to create modern sites without a Group

### DIFF
--- a/docs/solution-guidance/modern-experience-customizations-provisioning-sites.md
+++ b/docs/solution-guidance/modern-experience-customizations-provisioning-sites.md
@@ -169,9 +169,21 @@ Connect-PnPOnline -Url https://contoso-admin.sharepoint.com
 # Create a new modern team site
 New-PnPSite -Type Team -Title "Awesome Group" -Description "Awesome Group" -Alias "awesome-group"
 ```
+#### Provision a modern teamsite using SharePoint Online Management Shell or PnP PowerShell
 
-> [!NOTE]
-> There is currently no support to provision "modern" team sites using [SharePoint Online Management Shell](https://www.microsoft.com/en-us/download/details.aspx?id=35588).
+It is now also possible to create a modern site which is not connected to a Group using PowerShell. Either by using the PnP PowerShell cmdlets or the SharePoint Online Management Shell. 
+
+```powershell
+$title = "Awesome ModernTeamsite"
+$url = "https://contoso.sharepoint.com/sites/awesomemodernteamsite"
+$owner = "denisd@contoso.com"
+
+// SharePoint Online Management Shell
+New-SPOSite -Title $_title -Url $_url -Owner $owner -StorageQuota 512 -Template "STS#3"
+
+// PnP
+New-PnPTenantSite -Url $_url -Description $_title -Title $_title -Template STS#3 -Owner $owner
+```
 
 ## Provisioning "modern" communication sites
 


### PR DESCRIPTION
Since a few months, it is possible to create a modern teamsite which is not connected to a Group.

#### Category
- [ ] Content fix
- [x ] New article
- Related issues: fixes #X, partially #Y, mentioned in #Z

> For the above list, an empty checkbox is [ ] as in <kbd>[</kbd><kbd>SPACE</kbd><kbd>]</kbd>. A checked checkbox is [x] with no space between the brackets. Use the `PREVIEW` tab at the top right to preview the rendering before submitting your issue.


#### What's in this Pull Request?

Added the possibility to create a modern site using the STS#3 template and also by utilizing the SharePoint Online Management Shell

#### Guidance

> *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
> 
> *Please target your PR to 'master' branch. Released documents are in `live` branch.*
