### PR TITLE
Fixed documentation on updating (renaming) a folder. Previous example…

### DIFF
--- a/docs/sp-add-ins/working-with-folders-and-files-with-rest.md
+++ b/docs/sp-add-ins/working-with-folders-and-files-with-rest.md
@@ -77,7 +77,7 @@ From the result, obtain the odata.type value, such as SP.Data.Shared_x0020_Docum
 
 
 ```
-url: http://site url/_api/web/GetFolderByServerRelativeUrl('/Folder Name')
+url: http://site url/_api/web/GetFolderByServerRelativeUrl('/Folder Name')/ListItemAllFields
 method: POST
 body: { '__metadata': { 'type': '(odata.type from previous call)' }, 'Title': 'New name', 'FileLeafRef': 'New name' }
 Headers: 

--- a/docs/sp-add-ins/working-with-folders-and-files-with-rest.md
+++ b/docs/sp-add-ins/working-with-folders-and-files-with-rest.md
@@ -59,12 +59,27 @@ Headers:
 
 <br/>
 
-The following example shows how to **update a folder by using the MERGE method**.
+The following example shows how to **rename a folder by using the MERGE method**.
+
+First, obtain the folder's OData type with a GET request.
+
+```
+url: http://site url/_api/web/GetFolderByServerRelativeUrl('/Folder Name')/ListItemAllFields
+method: GET
+Headers: 
+     Authorization: "Bearer " + accessToken
+    "IF-MATCH": etag or "*"
+    accept: "application/json;odata=verbose"
+    content-type: "application/json;odata=verbose"
+```
+
+From the result, obtain the odata.type value, such as SP.Data.Shared_x0020_DocumentsItem (the value may be different depending on your library configuration). Then issue a MERGE
+
 
 ```
 url: http://site url/_api/web/GetFolderByServerRelativeUrl('/Folder Name')
 method: POST
-body: { '__metadata': { 'type': 'SP.Folder' }, 'Name': 'New name' }
+body: { '__metadata': { 'type': '(odata.type from previous call)' }, 'Title': 'New name', 'FileLeafRef': 'New name' }
 Headers: 
      Authorization: "Bearer " + accessToken
     X-RequestDigest: form digest value


### PR DESCRIPTION
…, "update a folder with Merge method" did not work.

#### Category
- [x] Content fix
- [ ] New article
- Related issues: n/a

#### What's in this Pull Request?

The REST API documentation for how to "update" a folder using the MERGE method did not work. The example showed a title change to the folder - i.e. renaming the folder - and this fails. It's necessary to pass in the correct odata type and to update the FileLeafRef as well as the title. This PR corrects the issue.

#### Guidance

Please accept the PR so the documentation is correct.