### PR TITLE
PowerShell correction

### DIFF
--- a/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
+++ b/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
@@ -41,19 +41,14 @@ Ensure the following before you begin:
   - From the remainder, it filters out non-SharePoint add-ins and add-ins that use asymmetric keys, such as workflows.
 
   ```powershell
-    $applist = Get-MsolServicePrincipal -all  |Where-Object -FilterScript { ($_.DisplayName -notlike "*Microsoft*") -and ($_.DisplayName -notlike "autohost*") -and  ($_.ServicePrincipalNames -notlike "*localhost*") }
+$applist = Get-MsolServicePrincipal -all  |Where-Object -FilterScript { ($_.DisplayName -notlike "*Microsoft*") -and ($_.DisplayName -notlike "autohost*") -and  ($_.ServicePrincipalNames -notlike "*localhost*") }
 
-  foreach ($appentry in $applist)
-  {
-      $principalId = $appentry.AppPrincipalId
-      $principalName = $appentry.DisplayName
-      
-      Get-MsolServicePrincipalCredential -AppPrincipalId $principalId -ReturnKeyValues $false | Where-Object { ($_.Type -ne "Other") -and ($_.Type -ne "Asymmetric") }
-      
-      $date = get-date
-      Write-Host "$principalName;$principalId;$appentry.KeyId;$appentry.type;$date;$appentry.Usage"
-
-  }  > c:\temp\appsec.txt
+foreach ($appentry in $applist) {
+    $principalId = $appentry.AppPrincipalId
+    $principalName = $appentry.DisplayName
+    
+    Get-MsolServicePrincipalCredential -AppPrincipalId $principalId -ReturnKeyValues $false | ? { $_.Type -eq "Password" } | % { "$principalName;$principalId;" + $_.KeyId.ToString() +";" + $_.StartDate.ToString() + ";" + $_.EndDate.ToString() } | out-file -FilePath c:\temp\appsec.txt -append
+}
   ```
 
 4. Open the file C:\temp\appsec.txt to see the report. Leave the Windows PowerShell window open for the next procedure, if any of the secrets are near expiration.


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article
- Related issues: fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Correct the PowerShell given in the "Generate a report that lists each add-in and the date that its secret expires..." step. The current script simply outputs a static date (today) instead of the expiration date of the secret.

#### Guidance

Previous script did not produce expected results. This correction gives the output expected according to the paragraph written before it.