### PR TITLE
Update add-in-authorization-policy-types-in-sharepoint.md

### DIFF
--- a/docs/sp-add-ins/add-in-authorization-policy-types-in-sharepoint.md
+++ b/docs/sp-add-ins/add-in-authorization-policy-types-in-sharepoint.md
@@ -22,7 +22,7 @@ SharePoint provides three types of authorization policies:
     An expense approval add-in is an example of an add-in that could be designed to use this policy. The add-in allows users who wouldn't otherwise be able to approve expenses to approve expenses below a certain amount. For an example, see the [scenario](#Scenario) in the next section.
     
     > [!NOTE] 
-    > Certain APIs require a user context and can't be executed with an add-in-only policy. These include many APIs for interacting with Project Server 2013 and for performing search queries.
+    > Certain APIs require a user context and can't be executed with an add-in-only policy. These include many APIs for interacting with Project Server and Project Online and for performing search queries.
 
 - **User-only policy**. When the user-only policy is used, SharePoint checks only the permissions for the user. SharePoint uses this policy when the user is accessing resources directly without using an add-in, such as when a user first opens a SharePoint website's home page or accesses SharePoint APIs from PowerShell.
 


### PR DESCRIPTION
I have  changed the text to not only concern Project Server 2013 but also Project Online. We are experiencing the noted behavior on Project Online, and we presume it is also an issue for other versions of Project Server - e.g. 2016 and 2019. Specifically, we cannot access the /sites/<pwa>/_api/ProjectData/Resources API nor the /sites/<pwa>/_api/ProjectServer/EnterpriseResources API with app-only principal approach.

#### Category
- [ ] Content fix
- [ ] New article
- Related issues: fixes #X, partially #Y, mentioned in #Z

> For the above list, an empty checkbox is [ ] as in <kbd>[</kbd><kbd>SPACE</kbd><kbd>]</kbd>. A checked checkbox is [x] with no space between the brackets. Use the `PREVIEW` tab at the top right to preview the rendering before submitting your issue.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### What's in this Pull Request?

> Please describe the changes in this PR. Sample description or details around bugs which are being fixed.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### Guidance

> *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
> 
> *Please target your PR to 'master' branch. Released documents are in `live` branch.*
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_