### PR TITLE
Corrected web part name

### DIFF
--- a/docs/spfx/web-parts/get-started/using-web-part-as-ms-teams-tab.md
+++ b/docs/spfx/web-parts/get-started/using-web-part-as-ms-teams-tab.md
@@ -94,7 +94,7 @@ Teams folder contains following three files:
 
 ## Updating code to be aware of the Microsoft Teams context
 
-1. Open **src\webparts\helloWorld\HelloWorldWebPart.ts** for the needed edits on making our solution aware of the Microsoft Teams context, if it's used as a tab.
+1. Open **src\webparts\myFirstTeamTab\MyFirstTeamTabWebPart.ts** for the needed edits on making our solution aware of the Microsoft Teams context, if it's used as a tab.
 
 1. Add the following private variable inside the **MyFirstTeamsTabWebPart** class. We will be storing information around the Microsoft Teams context in this variable.
 


### PR DESCRIPTION
The web part name was left as src\webparts\helloWorld\HelloWorldWebPart.ts, it should have been src\webparts\myFirstTeamTab\MyFirstTeamTabWebPart.ts

#### Category
- [x] Content fix
- [ ] New article
- Related issues: fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Minor correction to Building Microsoft Teams tab using SharePoint Framework - Tutorial
