### PR TITLE
Update office-365-cdn.md

### DIFF
--- a/docs/general-development/office-365-cdn.md
+++ b/docs/general-development/office-365-cdn.md
@@ -68,9 +68,6 @@ The following is an overview of which links are automatically rewritten by the S
   - When extending pages, you can temporarily disable auto-rewriting URLs on a page by:
     - checking out the page
     - providing the query string parameter `?NoAutoReWrites=true`
-- Content By Search WebPart assets
-  - Display template JavaScript files
-  - Images in query results - URLs in the following standard Managed Properties are automatically replaced: _PictureUrl_, _PictureThumbnailUrl_, _PublishingImage_
 - Picture Library SlideShow webpart image URLs
 - Image fields in SPList REST API (RenderListDataAsStream) results
   - Use the new property ImageFieldsToTryRewriteToCdnUrls to provide a comma separated list of Fields.


### PR DESCRIPTION
Removing section indicating Content By Search web parts support private CDN for image assets.  Per response on https://icm.ad.msft.net/imp/v3/incidents/details/89072799/home and subsequent email discussion, this is not actually supported yet and no ETA has been provided on when it will be.  Removing documentation that it is to avoid further customer confusion.

#### Category
- [x] Content fix
- [ ] New article
- Related issues: fixes #X, partially #Y, mentioned in #Z

> For the above list, an empty checkbox is [ ] as in <kbd>[</kbd><kbd>SPACE</kbd><kbd>]</kbd>. A checked checkbox is [x] with no space between the brackets. Use the `PREVIEW` tab at the top right to preview the rendering before submitting your issue.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### What's in this Pull Request?

> Please describe the changes in this PR. Sample description or details around bugs which are being fixed.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### Guidance

> *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
> 
> *Please target your PR to 'master' branch. Released documents are in `live` branch.*
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_