### PR TITLE
Add onAfterClose override to the ColorPickerDialog example

### DIFF
--- a/docs/spfx/extensions/guidance/using-custom-dialogs-with-spfx.md
+++ b/docs/spfx/extensions/guidance/using-custom-dialogs-with-spfx.md
@@ -179,6 +179,13 @@ In the extension manifest, configure the extension to have only one button. In t
         isBlocking: false
       };
     }
+    
+    protected onAfterClose(): void {
+      super.onAfterClose();
+      
+      // Clean up the element for the next dialog
+      ReactDOM.unmountComponentAtNode(this.domElement);
+    }
 
     @autobind
     private _submit(color: string): void {


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article
- Related issues: mentioned in #2988 #3043 

Adding workaround for a known issue with opening multiple dialogs.

#### What's in this Pull Request?

Documentation update.

#### Guidance