### PR TITLE
Update building-simple-field-customizer.md

### DIFF
--- a/docs/spfx/extensions/get-started/building-simple-field-customizer.md
+++ b/docs/spfx/extensions/get-started/building-simple-field-customizer.md
@@ -352,7 +352,7 @@ Notice also that by default **includeClientSideAssets** attribute is set to true
 ```
 
 
-## Deploy the field to SharePoint Online and host JavaScript from local host
+## Deploy the field to SharePoint Online
 
 Now you are ready to deploy the solution to a SharePoint site and get the field association automatically included in a field. We will use the `ship` option with this packaging, so that all assets are packaged automatically inside of the solution package.
 


### PR DESCRIPTION
#### Category
- [X] Content fix
- [ ] New article

#### What's in this Pull Request?
Corrected Heading for [Deploy the field to SharePoint Online and host JavaScript from local host](/SharePoint/sp-dev-docs/blob/master/docs/spfx/extensions/get-started/building-simple-field-customizer.md#deploy-the-field-to-sharepoint-online-and-host-javascript-from-local-host): Other than the heading states, the assets are not hosted on localhost but on SharePoint online

#### Guidance
Missleading Heading on building-simple-field-customizer.md was corrected