### PR TITLE
added a not to let the reader know the setting might be hidden

### DIFF
--- a/docs/spfx/web-parts/get-started/using-web-part-as-ms-teams-tab.md
+++ b/docs/spfx/web-parts/get-started/using-web-part-as-ms-teams-tab.md
@@ -264,6 +264,9 @@ Now we have confirmed that the side-loading is enabled, and we can package our M
 > [!NOTE]
 > If this setting is not available, side loading is not enabled in the tenant which you are using. Double check the settings from the tenant admin UIs.
 
+> [!NOTE]
+> The setting might be hidden behind a message notification or the notification requesting to turn on desktop notifications.
+
 - Upload **MyFirstSPFxTab.zip** from the **Teams** folder under your newly created solution and ensure that it's properly visible in the list of Apps. Notice how the custom image is visible with the description of the solution.
 
     ![Manage Team](../../../images/sp-teams-app-uploaded.png)


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article
- Related issues: fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?
Teams tab creation with SPFX:
in some cases the setting to upload the team application might be hidden behind a notification. Added the note to help people not looking for too long.
