### PR TITLE
Switching between different versions of the generator removed

### DIFF
--- a/docs/spfx/set-up-your-development-environment.md
+++ b/docs/spfx/set-up-your-development-environment.md
@@ -81,12 +81,6 @@ To install the SharePoint Framework Yeoman generator globally, enter the followi
 npm install -g @microsoft/generator-sharepoint
 ```
 
-If you need to switch between the different projects created by using different versions of the SharePoint Framework Yeoman generator, you can install the generator locally as a development dependency in the project folder by executing the following command:
-
-```sh
-npm install @microsoft/generator-sharepoint --save-dev
-```
-
 For more information about the Yeoman SharePoint generator, see [Scaffold projects by using Yeoman SharePoint generator](toolchain/scaffolding-projects-using-yeoman-sharepoint-generator.md).
 
 ## Trusting the self-signed developer certificate


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article
- Related issues: mentioned in #2603 

#### What's in this Pull Request?
Switching between different generator version might be possible in the past but right now with the current versions, this is impossible.
All generator reference always to the global installations. So the local install won't have any effect.
An issue that describes this problem too can be found: https://github.com/SharePoint/sp-dev-docs/issues/2603

