### PR TITLE
Changed weatherservice mention to Typicode

### DIFF
--- a/docs/spfx/connect-to-anonymous-apis.md
+++ b/docs/spfx/connect-to-anonymous-apis.md
@@ -23,8 +23,8 @@ this.context.httpClient
   .then((res: HttpClientResponse): Promise<any> => {
     return res.json();
   })
-  .then((weather: any): void => {
-    console.log(weather);
+  .then((response: any): void => {
+    console.log(response);
   });
 ```
 
@@ -41,8 +41,8 @@ this.context.httpClient
   .then((res: HttpClientResponse): Promise<any> => {
     return res.json();
   })
-  .then((weather: any): void => {
-    console.log(weather);
+  .then((response: any): void => {
+    console.log(response);
   });
 ```
 

--- a/docs/spfx/connect-to-anonymous-apis.md
+++ b/docs/spfx/connect-to-anonymous-apis.md
@@ -15,7 +15,7 @@ When building SharePoint Framework solutions, you might want to consume public A
 
 ## Connect to anonymous APIs using the HttpClient
 
-The easiest way, to connect to anonymous APIs in your SharePoint Framework solutions, is by using the HttpClient provided as a part of the SharePoint Framework. For example, to get weather information for London from the public OpenWeatherMap service, you would execute:
+The easiest way, to connect to anonymous APIs in your SharePoint Framework solutions, is by using the HttpClient provided as a part of the SharePoint Framework. For example, to get dummy information from the Typicode service, you would execute:
 
 ```ts
 this.context.httpClient


### PR DESCRIPTION
#### Category
- [X] Content fix
- [ ] New article
- Related issues: N/A

#### What's in this Pull Request?

The documentation mentioned to be having the same call into the weatherservice while in fact the sample was calling into the Typicode service. Updated the text so it's aligned with the sample.