### PR TITLE
fix missing L from URL word

### DIFF
--- a/docs/apis/webhooks/overview-sharepoint-webhooks.md
+++ b/docs/apis/webhooks/overview-sharepoint-webhooks.md
@@ -20,7 +20,7 @@ To create a new SharePoint webhook, you add a new subscription to the specific S
 The following information is required for creating a new subscription:
 
 - **Resource**. The resource endpoint URL you are creating the subscription for. For example, a SharePoint List API URL.
-- **Server notification UR**. Your service endpoint URL. SharePoint sends an HTTP POST to this endpoint when events occur in the specified resource.
+- **Server notification URL**. Your service endpoint URL. SharePoint sends an HTTP POST to this endpoint when events occur in the specified resource.
 - **Expiration date**. The expiration date for your subscription. The expiration date should not be more than 180 days. By default, subscriptions are set to expire 180 days from when they are created. 
 
 You can also include the following information if needed:


### PR DESCRIPTION
"Server notification UR" must be "Server notification URL"

#### Category
- [x] Content fix
- [ ] New article
- Related issues: fixes #X, partially #Y, mentioned in #Z

> For the above list, an empty checkbox is [ ] as in <kbd>[</kbd><kbd>SPACE</kbd><kbd>]</kbd>. A checked checkbox is [x] with no space between the brackets. Use the `PREVIEW` tab at the top right to preview the rendering before submitting your issue.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### What's in this Pull Request?

> Please describe the changes in this PR. Sample description or details around bugs which are being fixed.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### Guidance

> *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
> 
> *Please target your PR to 'master' branch. Released documents are in `live` branch.*
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_