### PR TITLE
Removed unnecessary function from Delete sample

### DIFF
--- a/docs/declarative-customization/site-theming/sharepoint-site-theming-rest-api.md
+++ b/docs/declarative-customization/site-theming/sharepoint-site-theming-rest-api.md
@@ -120,10 +120,7 @@ function RestRequest(url,params) {
 }
 
  
-RestRequest("/_api/thememanager/DeleteTenantTheme", { name:"themeName.DarkYellow" });
- 
-RestRequest("/_api/thememanager/UpdateTenantTheme", { name:"themeName",
-     themeJson:""});
+RestRequest("/_api/thememanager/DeleteTenantTheme", { name:"Sounders Rave Green" });
 ```
 
 <br/>


### PR DESCRIPTION
#### Category
- [x] Content fix


#### What's in this Pull Request?

There are two "RestRequest" function call's in the 'DeleteTenantTheme' code sample, the second of which passes a 'UpdateTenantTheme' request with a blank 'themeJson' property, which is unneeded in the delete context and causes the theme engine to error if executed.  

Also updated the theme name in the delete example, to match the theme name used in the other examples, 'Sounders Rave Green'.
