### PR TITLE
Updating properties available on the person field

### DIFF
--- a/docs/declarative-customization/column-formatting.md
+++ b/docs/declarative-customization/column-formatting.md
@@ -1067,7 +1067,9 @@ The people field object has the following properties (with example values):
    "title": "Kalya Tucker",
    "email": "kaylat@contoso.com",
    "sip": "kaylat@contoso.com",
-   "picture": "https://contoso.sharepoint.com/kaylat_contoso_com_MThumb.jpg?t=63576928822"
+   "picture": "https://contoso.sharepoint.com/kaylat_contoso_com_MThumb.jpg?t=63576928822",
+   "department":"Human Resources",
+   "jobTitle":"HR Manager"
 }
 ```
 


### PR DESCRIPTION
Adding department and jobTitle, both fields are available on the person field for column formatting.

#### Category
- [x] Content fix
- Related issues: fixes #3515

#### What's in this Pull Request?
Updated documentation to include two properties available on person field
