### PR TITLE
Typo : Framweork -> Framework

### DIFF
--- a/docs/spfx/web-parts/get-started/using-web-part-as-ms-teams-tab.md
+++ b/docs/spfx/web-parts/get-started/using-web-part-as-ms-teams-tab.md
@@ -1,6 +1,6 @@
 ---
 title: Building Microsoft Teams tab using SharePoint Framework - Tutorial
-description: Tutorial on how to build Microsoft Teams tabs using SharePoint Framweork. Capability was released to general availability in SharePoint Framework v1.8.
+description: Tutorial on how to build Microsoft Teams tabs using SharePoint Framework. Capability was released to general availability in SharePoint Framework v1.8.
 ms.date: 03/14/2019
 ms.prod: sharepoint
 ---

--- a/docs/spfx/web-parts/get-started/using-web-part-as-ms-teams-tab.md
+++ b/docs/spfx/web-parts/get-started/using-web-part-as-ms-teams-tab.md
@@ -1,7 +1,6 @@
 ---
 title: Building Microsoft Teams tab using SharePoint Framework - Tutorial
 description: Tutorial on how to build Microsoft Teams tabs using SharePoint Framework. Capability was released to general availability in SharePoint Framework v1.8.
-
 ms.date: 04/04/2019
 ms.prod: sharepoint
 ---


### PR DESCRIPTION
Following #3707,  I searched other places where the word was mispelled. Found this only occurence.

#### Category
- [x] Content fix
- [ ] New article
- Related issues: #3707 