### PR TITLE
Fixed PowerShell sample

### DIFF
--- a/docs/declarative-customization/get-started-create-site-design.md
+++ b/docs/declarative-customization/get-started-create-site-design.md
@@ -24,7 +24,7 @@ Each action is specified by the "verb" value in the JSON script. Also, actions c
 3. Create - and assign the JSON that describes the new script - to a variable as shown in the following PowerShell code. You can view and reference the latest JSON schema file here: https://developer.microsoft.com/json-schemas/sp/site-design-script-actions.schema.json
 
    ```powershell
-    $site_script = @'
+    $site_script = '
     {
         "$schema": "schema.json",
             "actions": [
@@ -70,7 +70,7 @@ Each action is specified by the "verb" value in the JSON script. Also, actions c
                 "bindata": { },
         "version": 1
     }
-    '@
+    '
    ```
 
 <br/>


### PR DESCRIPTION
#### Category
- [X] Content fix
- [ ] New article
- Related issues: N/A

#### What's in this Pull Request?

The provided PowerShell sample with the sample JSON file could not be copy/pasted into PowerShell. It would leave it in the edit mode in PowerShell. With this minor update, you can safely copy/paste the sample into PowerShell and hit enter to load the sample JSON up into the $site_script variable
