### PR TITLE
Spelling fix

### DIFF
--- a/docs/declarative-customization/column-formatting.md
+++ b/docs/declarative-customization/column-formatting.md
@@ -1062,7 +1062,7 @@ An optional property that allows an element to duplicate itself for each member 
 
 The field used in the loop must be in a supported field type with multi-value option enabled: Person, Lookup, and Choice.
 
-In the element with `forEach` or its childern elements, the iterator variable can be referred as if it is a new field. The index of the iterator can be accessed with `loopIndex` operator.
+In the element with `forEach` or its children elements, the iterator variable can be referred as if it is a new field. The index of the iterator can be accessed with `loopIndex` operator.
 
 `forEach` cannot be applied to the root element, and will render no element if there is no value in the field.
 


### PR DESCRIPTION
Changed "childern" to "children", in response to #3855

#### Category
- [ ] Content fix
- [ ] New article
- Related issues: fixes #X, partially #Y, mentioned in #Z

> For the above list, an empty checkbox is [ ] as in <kbd>[</kbd><kbd>SPACE</kbd><kbd>]</kbd>. A checked checkbox is [x] with no space between the brackets. Use the `PREVIEW` tab at the top right to preview the rendering before submitting your issue.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### What's in this Pull Request?

> Please describe the changes in this PR. Sample description or details around bugs which are being fixed.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### Guidance

> *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
> 
> *Please target your PR to 'master' branch. Released documents are in `live` branch.*
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_