### PR TITLE
Fix broken link to "creating manifest manually"

### DIFF
--- a/docs/spfx/web-parts/get-started/using-web-part-as-ms-teams-tab.md
+++ b/docs/spfx/web-parts/get-started/using-web-part-as-ms-teams-tab.md
@@ -238,7 +238,7 @@ Now the web part is deployed and is automatically available cross the SharePoint
 
 In order to make your web part available in Microsoft Teams you will have synchronize your solution with teams. 
 
-1. Create a Microsoft Teams app manifest file by following the instructions detailed here: [Create Microsoft Teams manifest manually for a web part and deploy it to Microsoft Teams](./guidance/web-parts/creating-team-manifest-manually-for-webpart.md).
+1. Create a Microsoft Teams app manifest file by following the instructions detailed here: [Create Microsoft Teams manifest manually for a web part and deploy it to Microsoft Teams](../guidance/creating-team-manifest-manually-for-webpart.md).
 1. Create a Microsoft Teams app package by zipping the contents of the **./teams** folder. Make sure to zip just the contents and not the folder itself. This ZIP archive should contain 3 files at the root: two images & the **manifest.json**.
 1. Move to a channel in a team. In the below picture we have activated **General** channel in **Team**
 


### PR DESCRIPTION

#### Category
- [x] Content fix
- [ ] New article
- Related issues: fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

The link to `Create Microsoft Teams manifest manually for a web part and deploy it to Microsoft Teams.` was broken due to incorrect relative URL.
Correct URL is `../guidance/creating-team-manifest-manually-for-webpart`
