### PR TITLE
Typo fix in list URL (#3950)

### DIFF
--- a/docs/sp-add-ins/include-a-custom-button-in-the-provider-hosted-add-in.md
+++ b/docs/sp-add-ins/include-a-custom-button-in-the-provider-hosted-add-in.md
@@ -187,7 +187,7 @@ In this section, you include markup in the add-in that deploys a button to the l
     
     ```csharp
       // Go back to the Local Employees page
-    Response.Redirect(spContext.SPHostUrl.ToString() + "Lists/LocalEmployees/AllItems.aspx", true);
+    Response.Redirect(spContext.SPHostUrl.ToString() + "Lists/Local%20Employees/AllItems.aspx", true);
 
     ```
 
@@ -206,7 +206,7 @@ In this section, you include markup in the add-in that deploys a button to the l
             AddLocalEmployeeToCorpDB(employeeName);
 
             // Go back to the preceding page
-            Response.Redirect(spContext.SPHostUrl.ToString() + "Lists/LocalEmployees/AllItems.aspx", true);
+            Response.Redirect(spContext.SPHostUrl.ToString() + "Lists/Local%20Employees/AllItems.aspx", true);
         }
     ```
 


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article

#### Related issues
- closes #3950

#### What's in this Pull Request?

Fixed typo in the "Local Employees" list. Two instances missing space in URL.