### PR TITLE
Updated working-with-lists-and-list-items-with-rest.md to include snippet to get 

### DIFF
--- a/docs/sp-add-ins/working-with-lists-and-list-items-with-rest.md
+++ b/docs/sp-add-ins/working-with-lists-and-list-items-with-rest.md
@@ -504,7 +504,14 @@ content-type: application/json;odata=nometadata
 The following example shows how to create a list item.
  
 > [!NOTE] 
-> To do this operation, you must know the **ListItemEntityTypeFullName** property of the list and pass that as the value of **type** in the HTTP request body.
+> To do this operation, you must know the **ListItemEntityTypeFullName** property of the list and pass that as the value of **type** in the HTTP request body. Following is a sample rest call to get the ListItemEntityTypeFullName
+> ```
+> url: http://site url/_api/web/lists/GetByTitle('Test')?$select=ListItemEntityTypeFullName,
+> method: GET
+> Headers:
+>    Authorization: "Bearer " + accessToken
+>    accept: "application/json;odata=verbose" or "application/atom+xml"
+> ```
  
 ```
 url: http://site url/_api/web/lists/GetByTitle('Test')/items


### PR DESCRIPTION
#added snippet on how to get ListItemEntityTypeFullName

#### Category
- [x ] Content fix

#### Related issues:
- fixes #3859 

#### What's in this Pull Request?

> The [note on the page ](https://docs.microsoft.com/en-us/sharepoint/dev/sp-add-ins/working-with-lists-and-list-items-with-rest#create-list-item ) mentions a about ListItemEntityTypeFullName but there isn't an example include in the guides anywhere on how to get it. 
