### PR TITLE
Removing note on hub sites being new and potentially not yet available

### DIFF
--- a/docs/declarative-customization/site-design-json-schema.md
+++ b/docs/declarative-customization/site-design-json-schema.md
@@ -761,9 +761,6 @@ Use the **joinHubSite** verb to join the site to a designated hub site.
 
 #### Example
 
-> [!NOTE]
-> Hub sites are a new feature that are just rolling out to customers in Targeted Release in March 2018. This action might not be available for use in your environment. To learn more, see [SharePoint hub sites overview](https://docs.microsoft.com/en-us/sharepoint/dev/features/hub-site/hub-site-overview).
-
 ```json
 {
     "verb": "joinHubSite",


### PR DESCRIPTION
Note mentions Hub sites to roll out in March 2018. They are rolled out WW already by now, so the remark is no longer needed

#### Category
- [X] Content fix
- [ ] New article

#### Related issues:
N/A

#### What's in this Pull Request?
Note mentions Hub sites to roll out in March 2018. They are rolled out WW already by now, so the remark is no longer needed