### PR TITLE
Matching explanation on Azure Function environment variables to match current UI

### DIFF
--- a/docs/declarative-customization/site-design-pnp-provisioning.md
+++ b/docs/declarative-customization/site-design-pnp-provisioning.md
@@ -241,7 +241,7 @@ Next, upload the files so that your Azure Function can use the module.
     Apply-PnPProvisioningTemplate -Path D:\home\site\wwwroot\ApplyPnPProvisioningTemplate\FlowDemoTemplate.xml
     ```
 
-Notice that you're using two environment variables: ```SPO_AppId```and ```SPO_AppSecret```. To set those variables, go to the main Function App page in the Azure Portal, select **Application Settings**, and add two new application settings:
+Notice that you're using two environment variables: ```SPO_AppId```and ```SPO_AppSecret```. To set those variables, go to the main Function App page in the Azure Portal (the one with the yellow light bolt icon), select **Configuration** and add two new application settings:
 
 1. ```SPO_AppId``` - Set the value to the Client ID you copied in the first step when you created your app on your tenant.
 2. ```SPO_AppSecret``` - Set the value to the Client Secret that you copied in the first step when you created your app on your tenant.


### PR DESCRIPTION
#### Category
- [X] Content fix
- [ ] New article

#### Related issues:
N/A

#### What's in this Pull Request?
There has been a rename in the UI for accessing the Azure Function Environment Variables. I had a bit of a hard time finding them because of the changed name. Updating this article to make it reflect how it currently can be found.