### PR TITLE
Fixed references to "apps/addins in testing" list

### DIFF
--- a/docs/sp-add-ins/get-started-creating-sharepoint-hosted-sharepoint-add-ins.md
+++ b/docs/sp-add-ins/get-started-creating-sharepoint-hosted-sharepoint-add-ins.md
@@ -53,12 +53,12 @@ To get an Office 365 plan:
 
 ### Open your developer site 
 
-In a browser, navigate to the SharePoint site collection you created when you setup your Office 365 developer subscription. (*If you don't have a site, [follow the instructions here](https://docs.microsoft.com/sharepoint/dev/sp-add-ins/create-a-developer-site-on-an-existing-office-365-subscription)*). You should see a site that looks like the one in the following figure. The **Add-ins in Testing** list on the page confirms that the website was made with the SharePoint Developer Site template. If you see a regular team site instead, wait a few minutes and then restart your site.
+In a browser, navigate to the SharePoint site collection you created when you setup your Office 365 developer subscription. (*If you don't have a site, [follow the instructions here](https://docs.microsoft.com/sharepoint/dev/sp-add-ins/create-a-developer-site-on-an-existing-office-365-subscription)*). You should see a site that looks like the one in the following figure. The **Apps / Add-ins in Testing** list on the page confirms that the website was made with the SharePoint Developer Site template. If you see a regular team site instead, wait a few minutes and then restart your site.
     
 > [!NOTE]
 > Make a note of the site's URL; it's used when you create SharePoint Add-in projects in Visual Studio.
 
-**Your developer site home page with the Add-ins in Testing list**
+**Your developer site home page with the Apps / Add-ins in Testing list**
 
 ![Screenshot that shows the developer site homepage.](../images/SP15_DeveloperSiteHome_border.png)
 


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article

#### Related issues:
- fixes #3883

#### What's in this Pull Request?

Screenshot on doc shows Add-ins in Testing, but older dev sites may say Apps in testing. Updated docs to reflect it.
