### PR TITLE
Parallel package deployments not supported

### DIFF
--- a/docs/apis/alm-api-for-spfx-add-ins.md
+++ b/docs/apis/alm-api-for-spfx-add-ins.md
@@ -87,6 +87,9 @@ POST /_api/web/tenantappcatalog/AvailableApps/GetById('xxxxxxxx-xxxx-xxxx-xxxx-x
 > [!NOTE]
 > This operation is required to be completed after Add, before you can install packages to specific sites. 
 
+> [!NOTE]
+> It is currently not supported to deploy several packages in parallel - make sure to serialize your deployment operations to avoid deployment errors.
+
 ### Retract solution packages in the app catalog
 
 This retracts the solution to be available from the sites. This API is designed to be executed in the context of the app catalog site.


### PR DESCRIPTION
Add a comment about Parallel package deployments not being supported as per https://github.com/SharePoint/sp-dev-docs/issues/4022

#### Category
- [x] Content fix
- [ ] New article




#### Related issues:
- fixes #issuenumber
- partially #issuenumber
- mentioned in #issuenumber



#### What's in this Pull Request?

Add a comment about Parallel package deployments not being supported as per https://github.com/SharePoint/sp-dev-docs/issues/4022

