### PR TITLE
Removed Access Applications option

### DIFF
--- a/docs/solution-guidance/Migrate-InfoPath-forms-to-SharePoint.md
+++ b/docs/solution-guidance/Migrate-InfoPath-forms-to-SharePoint.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate InfoPath forms to SharePoint
-description: Migrate InfoPath forms in your SharePoint Add-ins to other supported solutions, such as Access applications, sandbox solutions, or the add-in model.
+description: Migrate InfoPath forms in your SharePoint Add-ins to other supported solutions, such as Microsoft Flow, PowerApps, or the add-in model.
 ms.date: 5/1/2018
 localization_priority: Priority
 ---
@@ -13,8 +13,6 @@ The client and the on-premises version of InfoPath Forms Services in SharePoint 
 
 To replace your InfoPath forms, you can choose one of the following alternatives:
 
-- Use Access applications.
-
 - Use Microsoft Flow and Microsoft PowerApps.
     
 - Move complex behaviors to the new add-in model and client-side developments.
@@ -25,7 +23,6 @@ We recommend the first two solutions because information workers that don't know
 
 |**Alternative**|**Scenario**|
 |:-----|:-----|
-|Access applications|This option supports multiple forms that handle relational data contained in multiple Access tables, Excel tables, and/or SharePoint lists.|
 |Microsoft Flow and Microsoft PowerApps|This is the recommended approach for extending lists by SharePoint power users .|
 |New add-in model and client-side developments |You can convert complex forms driven by extensive code into provider-hosted add-ins or client-side web parts. This option requires developer resources.|
 


### PR DESCRIPTION


#### Category
- [x] Content fix

#### Related issues:
- fixes https://github.com/SharePoint/sp-dev-docs/issues/4296

#### What's in this Pull Request?
On the page https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/migrate-infopath-forms-to-sharepoint
Removed the recommended option of Access Applications as an InfoPath replacement.

#### Guidance
Removed the recommended option of Access Applications as an InfoPath replacement.