### PR TITLE
Remove --save from npm install command(s)

### DIFF
--- a/docs/spfx/web-parts/get-started/add-jqueryui-accordion-to-web-part.md
+++ b/docs/spfx/web-parts/get-started/add-jqueryui-accordion-to-web-part.md
@@ -76,13 +76,13 @@ At this point, Yeoman installs the required dependencies and scaffolds the solut
 1. In the console, enter the following to install the jQuery npm package:
 
     ```shell
-    npm install jquery@2 --save
+    npm install jquery@2
     ```
 
 1. Now enter the following to install the jQueryUI npm package:
 
     ```shell
-    npm install jqueryui --save
+    npm install jqueryui
     ```
 
     Next, we need to install the typings for our project. Starting from TypeScript 2.0, we can use npm to install needed typings.
@@ -90,8 +90,8 @@ At this point, Yeoman installs the required dependencies and scaffolds the solut
 1. Open your console and install the needed types:
 
     ```shell
-    npm install @types/jquery@2 --save
-    npm install @types/jqueryui --save
+    npm install @types/jquery@2
+    npm install @types/jqueryui
     ```
 
 ### To unbundle external dependencies from web part bundle


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article

#### What's in this Pull Request?
> Removing --save from npm install command(s)

#### Guidance
As per NPM install docs (https://docs.npmjs.com/cli/install), by default, npm install will install all modules listed as dependencies in package.json. This seems to be the case since npm 5 release according to this official blog post (https://blog.npmjs.org/post/161081169345/v500) dated May 2017.