### PR TITLE
Updated a typo

### DIFF
--- a/docs/declarative-customization/site-design-json-schema.md
+++ b/docs/declarative-customization/site-design-json-schema.md
@@ -757,7 +757,7 @@ Use the **setSiteBranding** verb to specify the navigation layout, the header la
 
 - **navigationLayout** &ndash; Specify the navigation layout as Cascade or Megamenu
 - **headerLayout** &ndash; Specify the header layout as Standard or Compact
-- **headerBackground** &ndash; Specify the header background as None, Neutral, Soft or Stong
+- **headerBackground** &ndash; Specify the header background as None, Neutral, Soft or Strong
 
 #### Example
 


### PR DESCRIPTION
Strong was misspelled as stong

#### Category
- [x] Content fix
- [ ] New article
- [ ] Example checked item (*delete this line*)

> For the above list, an empty checkbox is [ ] as in <kbd>[</kbd><kbd>SPACE</kbd><kbd>]</kbd>. A checked checkbox is [x] with no space between the brackets. Use the `PREVIEW` tab at the top right to preview the rendering before submitting your issue.
> 
#### Related issues:
- fixes #4412 
- partially #4412 
- mentioned in #4412 

> If this fixes (aka: closes) or references an issue, please reference it here. This helps maintaining the issue list as it will (1) link the PR to the issue & (2) automatically close the issue when this PR is merged in.
> 

#### What's in this Pull Request?

> Content contained a typo, strong was misspelled as Stong. Updated the content.

#### Guidance

> Strong was misspelled as stong. Fixed the content.
> *Please target your PR to 'master' branch. Released documents are in `live` branch.*
>