### PR TITLE
Improve documentation around listening ports

### DIFF
--- a/docs/spfx/web-parts/get-started/build-a-hello-world-web-part.md
+++ b/docs/spfx/web-parts/get-started/build-a-hello-world-web-part.md
@@ -101,10 +101,11 @@ Now that we have installed the developer certificate, enter the following comman
 gulp serve
 ```
 
-This command executes a series of gulp tasks to create a local, node-based HTTPS server on `localhost:4321` and launches your default browser to preview web parts from your local dev environment.
+This command executes a series of gulp tasks to create a local, node-based HTTPS server on `localhost:4321` and `localhost:5432`. The workbench is then launched in your default browser to preview web parts from your local dev environment.
 
 > [!NOTE]
 > If you are seeing issues with the certificate in browser, please see details on installing a developer certificate from the [Set up your development environment](../../set-up-your-development-environment.md) article.
+> If you are still seeing issues, please check nothing else is listening on the port numbers, by using resmon.exe, the network tab and looking at Listening Ports.
 
 ![Gulp serve web part project](../../../images/helloworld-wp-gulp-serve.png)
 


### PR DESCRIPTION


#### Category
- [X] Content fix

#### Related issues:
- mentioned in #3033
- mentioned in #2333
- mentioned in #148

#### What's in this Pull Request?

The documentation around listening ports is incorrect.

gulp serve sets up a node server to listen on port 4321 and then the workbench on ports 5432. This is not included in the docs.

In addition, where port 5432 is the default port for postgres, and could be used by other applications. There is no indicator that the port is not available when starting the application. The existing note only refers to certificate issues in the browser. Modern browsers show the connection failure as a possible TLS issue, therefore, enhance the documentation by suggesting that the user may also wants to confirm that the port is available. 

Whilst i'd personally use tcpview from sysinternals, I've suggested an approach using built in windows 10 functionality.