### PR TITLE
Prevent an infinite loop

### DIFF
--- a/docs/general-development/how-to-avoid-getting-throttled-or-blocked-in-sharepoint-online.md
+++ b/docs/general-development/how-to-avoid-getting-throttled-or-blocked-in-sharepoint-online.md
@@ -202,12 +202,21 @@ public static void ExecuteQueryWithIncrementalRetry(this ClientContext clientCon
             }
             else
             {
-                // retry the previous request
+                //increment the retry count                
+                retryAttempts++;
+                
+                // retry the previous request using wrapper
                 if (wrapper != null && wrapper.Value != null)
                 {
                     clientContext.RetryQuery(wrapper.Value);
                     return;
-                }
+                } 
+                // retry the previous request as normal
+                else
+                {
+                    clientContext.ExecuteQuery();
+                    return;
+                }                
             }
         }
         catch (WebException ex)
@@ -237,8 +246,7 @@ public static void ExecuteQueryWithIncrementalRetry(this ClientContext clientCon
                 // Delay for the requested seconds
                 Thread.Sleep(retryAfterInterval * 1000);
 
-                // Increase counters
-                retryAttempts++;
+                // Increase counters          
                 backoffInterval = backoffInterval * 2;
             }
             else


### PR DESCRIPTION
We have confirmed, that sometimes the exception handling returns a null client wrapper. When this circumstance happens, and it has several times for us, the code goes into an infinite loop because the wrapper remains null and is never set again. Moving the retry attempts increment before the retry (and outside of the exceptions) prevents this infinite loop.  Executing the Query as normal when a wrapper is unavailable also ensures a retry is made when the wrapper is null.

#### Category
- [ ] Content fix
- [ ] New article
- [x] Example checked item (*delete this line*)

> For the above list, an empty checkbox is [ ] as in <kbd>[</kbd><kbd>SPACE</kbd><kbd>]</kbd>. A checked checkbox is [x] with no space between the brackets. Use the `PREVIEW` tab at the top right to preview the rendering before submitting your issue.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### Related issues:
- fixes #issuenumber
- partially #issuenumber
- mentioned in #issuenumber

> If this fixes (aka: closes) or references an issue, please reference it here. This helps maintaining the issue list as it will (1) link the PR to the issue & (2) automatically close the issue when this PR is merged in.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### What's in this Pull Request?

> Please describe the changes in this PR. Sample description or details around bugs which are being fixed.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### Guidance

> *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
> 
> *Please target your PR to 'master' branch. Released documents are in `live` branch.*
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_