### PR TITLE
Fix: Docs update for creating communication sites in app-only context

### DIFF
--- a/docs/solution-guidance/security-apponly.md
+++ b/docs/solution-guidance/security-apponly.md
@@ -9,10 +9,12 @@ Both methods are detailed in following articles:
  - [Granting access using SharePoint App-Only](security-apponly-azureacs.md)
 
 ## What are the limitations when using app-only
+
 App-Only does not work in following cases:
+
  - Updating taxonomy service entries (write) - read works
  - Creating modern team sites does not support app-only when you [use the SharePoint API](https://github.com/SharePoint/PnP-Sites-Core/blob/master/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs) for it. When modern team sites are created [using Microsoft Graph](https://github.com/SharePoint/PnP-Sites-Core/blob/master/Core/OfficeDevPnP.Core/Framework/Graph/UnifiedGroupsUtility.cs) to create the group then app-only is a supported scenario
- - Creating communication sites is now supported in app-only context, but owner property is required. [using the SharePoint API](https://docs.microsoft.com/en-us/sharepoint/dev/apis/site-creation-rest)
+ - Creating communication sites is supported in app-only context, but owner property is required. [using the SharePoint API](https://docs.microsoft.com/en-us/sharepoint/dev/apis/site-creation-rest)
  - Search when using SharePoint On-Premises. SharePoint Online support for it has been added ([blog post](https://blogs.msdn.microsoft.com/vesku/2016/03/07/using-add-in-only-app-only-permissions-with-search-queries-in-sharepoint-online/))
  - User Profile CSOM write operations do not work with **Azure AD application** - read operations work. Both read and write operations work through **SharePoint App-Only principal**
  - User Profile Bulk Update API can be used with app-only permissions

--- a/docs/solution-guidance/security-apponly.md
+++ b/docs/solution-guidance/security-apponly.md
@@ -12,7 +12,7 @@ Both methods are detailed in following articles:
 App-Only does not work in following cases:
  - Updating taxonomy service entries (write) - read works
  - Creating modern team sites does not support app-only when you [use the SharePoint API](https://github.com/SharePoint/PnP-Sites-Core/blob/master/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs) for it. When modern team sites are created [using Microsoft Graph](https://github.com/SharePoint/PnP-Sites-Core/blob/master/Core/OfficeDevPnP.Core/Framework/Graph/UnifiedGroupsUtility.cs) to create the group then app-only is a supported scenario
- - Creating communication sites currently does not support app-only [using the SharePoint API](https://github.com/SharePoint/PnP-Sites-Core/blob/master/Core/OfficeDevPnP.Core/Sites/SiteCollection.cs)
+ - Creating communication sites is now supported in app-only context, but owner property is required. [using the SharePoint API](https://docs.microsoft.com/en-us/sharepoint/dev/apis/site-creation-rest)
  - Search when using SharePoint On-Premises. SharePoint Online support for it has been added ([blog post](https://blogs.msdn.microsoft.com/vesku/2016/03/07/using-add-in-only-app-only-permissions-with-search-queries-in-sharepoint-online/))
  - User Profile CSOM write operations do not work with **Azure AD application** - read operations work. Both read and write operations work through **SharePoint App-Only principal**
  - User Profile Bulk Update API can be used with app-only permissions


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article

#### Related issues: 

NA

#### What's in this Pull Request?

This PR adds a content fix. 

Communication sites creation is now supported in app-only context. In this scenario, the owner property is required. This update fixes that in the documentation and also points to the correct documentation to create communication sites.