### PR TITLE
Updated page title

### DIFF
--- a/docs/spfx/web-parts/guidance/use-sp-pnp-js-with-spfx-web-parts.md
+++ b/docs/spfx/web-parts/guidance/use-sp-pnp-js-with-spfx-web-parts.md
@@ -6,7 +6,7 @@ ms.prod: sharepoint
 localization_priority: Priority
 ---
 
-# Use @pnp/sp with SharePoint Framework web parts
+# Use @pnp/sp (PnPJS) library with SharePoint Framework web parts
 
 You may choose to use the [@pnp/sp](https://www.npmjs.com/package/@pnp/sp) library when building your SharePoint Framework (SPFx) web parts. This library provides a fluent API to make building your REST queries intuitive and supports batching and caching. For more information, see the [project's homepage](https://github.com/pnp/pnpjs/), which has links to documentation, samples, and other resources to help you get started.
 


### PR DESCRIPTION
#### Category
- [x] Content fix

#### Related issues:
- fixes https://github.com/SharePoint/sp-dev-docs/issues/4243

#### What's in this Pull Request?
Updated page title as Use @pnp/sp (PnPJS) library with SharePoint Framework web parts.
This should show (PnPJS) library although @pnp/sp is escaped.

#### Guidance
Updated page title as Use @pnp/sp (PnPJS) library with SharePoint Framework web parts.
This should show (PnPJS) library although @pnp/sp is escaped.