### PR TITLE
Getting items by ID is unnecessary

### DIFF
--- a/docs/sp-add-ins/use-the-sharepoint-javascript-apis-to-work-with-sharepoint-data.md
+++ b/docs/sp-add-ins/use-the-sharepoint-javascript-apis-to-work-with-sharepoint-data.md
@@ -124,7 +124,7 @@ Even though SharePoint-hosted SharePoint Add-ins cannot have server-side code, y
 
         var i;
         for (i = 0; i < itemArray.length; i++) {
-            employeeList.getItemById(itemArray[i].get_id()).deleteObject();
+            itemArray[i].deleteObject();
         }
 
         clientContext.executeQueryAsync(onDeleteCompletedItemsSuccess, onDeleteCompletedItemsFail);


### PR DESCRIPTION
#### Category
- [x] Content fix

#### Related issues:
- fixes https://github.com/SharePoint/sp-dev-docs/issues/4531

#### What's in this Pull Request?
Instead of using code:
employeeList.getItemById(itemArray[i].get_id()).deleteObject();
we can use only this:
itemArray[i].deleteObject();
because we've already got these items by the previous clientContext.executeQueryAsync(deleteCompletedItems, onGetCompletedItemsFail), and that's enough.

#### Guidance
Updated code sample as Getting items by ID is unnecessary.