### PR TITLE
Included library as supported component

### DIFF
--- a/docs/spfx/toolchain/scaffolding-projects-using-yeoman-sharepoint-generator.md
+++ b/docs/spfx/toolchain/scaffolding-projects-using-yeoman-sharepoint-generator.md
@@ -56,7 +56,7 @@ Option | Description
 --help|Print the generator's options and usage.
 --skip-cache|Do not remember prompt answers. Default: *false*.
 --skip-install|Do not automatically install dependencies. Default: *false*.
---component-type|The type of component. Currently "webpart" or "extension" is supported.
+--component-type|The type of component. Currently "webpart", "extension", or "library" is supported.
 --component-description|Description of the component.
 --component-name|Name of the component.
 --framework|Framework to use for the solution. Choose one from "none", "react", "knockout".


### PR DESCRIPTION
SharePoint Framework v1.9.1 on wards supports library component. Included library in the type of supported component.

#### Category
- [x] Content fix

#### Related issues:


#### What's in this Pull Request?
SharePoint Framework v1.9.1 on wards supports library component. Included library as the type of supported component for "yo @microsoft/sharepoint" as a command line option.

#### Guidance
Included library as the type of supported component for "yo @microsoft/sharepoint" as a command line option.