### PR TITLE
Corrected sample property and added escape

### DIFF
--- a/docs/spfx/web-parts/basics/integrate-with-property-pane.md
+++ b/docs/spfx/web-parts/basics/integrate-with-property-pane.md
@@ -101,7 +101,7 @@ export interface IHelloWorldWebPartProps {
 This is then available in your web part by using **this.properties.targetProperty**.
 
 ```typescript
-<p class="ms-font-l ms-fontColor-white">${this.properties.description}</p>
+<p class="ms-font-l ms-fontColor-white">${escape(this.properties.targetProperty)}</p>
 ```
 
 When the properties are defined, you can access them in your web part by using the **this.properties.[property-name]**. For more information, see [render method of the HelloWorldWebPart](../get-started/build-a-hello-world-web-part.md#web-part-render-method).


### PR DESCRIPTION
#### Category
- [X] Content fix
- [ ] New article

#### Related issues:
- fixes #issuenumber
- partially #issuenumber
- mentioned in #issuenumber

#### What's in this Pull Request?

The sample was incorrect as the property name according to the explanation was targetProperty. Updated the sample. Also included the use of escape(...) around it as that is a recommended practice for user input fields rendered on the screen.