### PR TITLE
SPFX_COMPONENT_ID is parameterized

### DIFF
--- a/docs/spfx/web-parts/guidance/creating-team-manifest-manually-for-webpart.md
+++ b/docs/spfx/web-parts/guidance/creating-team-manifest-manually-for-webpart.md
@@ -26,7 +26,7 @@ To side load a SharePoint Framework web part as a Microsoft Teams application, y
   "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.2/MicrosoftTeams.schema.json",
   "manifestVersion": "1.2",
   "packageName": "{{SPFX_COMPONENT_ALIAS}}",
-  "id": "aa3fecf0-1fd0-4751-aba1-12314dc3a22f",
+  "id": "{{SPFX_COMPONENT_ID}}",
   "version": "0.1",
   "developer": {
     "name": "Parker Porcupine",
@@ -104,7 +104,7 @@ Below json structure demonstrates sample manifest file content.
   "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.2/MicrosoftTeams.schema.json",
   "manifestVersion": "1.2",
   "packageName": "SpFxTeamsTogetherWebPart",
-  "id": "aa3fecf0-1fd0-4751-aba1-12314dc3a22f",
+  "id": "b7771434-9587-4a79-9990-48c310f78a3d",
   "version": "0.1",
   "developer": {
     "name": "Parker Porcupine",


### PR DESCRIPTION
#### Category
- [x] Content fix

#### Related issues:
- fixes https://github.com/SharePoint/sp-dev-docs/issues/4757

#### What's in this Pull Request?
Under the section - Create a Microsoft Teams app manifest, the JSON should have id parameterized as {{SPFX_COMPONENT_ID}} instead of hard-coded value

#### Guidance
Under the section - Create a Microsoft Teams app manifest, the JSON should have id parameterized as {{SPFX_COMPONENT_ID}} instead of hard-coded value