### PR TITLE
Adding custom tag for content recommendation

### DIFF
--- a/docs/spfx/extensions/get-started/build-a-hello-world-extension.md
+++ b/docs/spfx/extensions/get-started/build-a-hello-world-extension.md
@@ -4,6 +4,7 @@ description: Create an extension project, and then code and debug your Applicati
 ms.date: 11/8/2018
 ms.prod: sharepoint
 localization_priority: Priority
+ms.custom: scenarios:getting-started
 ---
 
 

--- a/docs/spfx/extensions/get-started/building-simple-cmdset-with-dialog-api.md
+++ b/docs/spfx/extensions/get-started/building-simple-cmdset-with-dialog-api.md
@@ -3,6 +3,7 @@ title: Build your first ListView Command Set extension
 description: Create an extension project, and then code and debug your extension by using SharePoint Framework (SPFx) Extensions.
 ms.date: 03/14/2019
 ms.prod: sharepoint
+ms.custom: scenarios:getting-started
 ---
 
 # Build your first ListView Command Set extension

--- a/docs/spfx/extensions/get-started/building-simple-field-customizer.md
+++ b/docs/spfx/extensions/get-started/building-simple-field-customizer.md
@@ -3,6 +3,7 @@ title: Build your first Field Customizer extension
 description: Create an extension project, and then code and debug your extension by using SharePoint Framework (SPFx) Extensions.
 ms.date: 03/14/2019
 ms.prod: sharepoint
+ms.custom: scenarios:getting-started
 ---
 
 # Build your first Field Customizer extension

--- a/docs/spfx/extensions/get-started/hosting-extension-from-office365-cdn.md
+++ b/docs/spfx/extensions/get-started/hosting-extension-from-office365-cdn.md
@@ -4,6 +4,7 @@ description: Deploy your SharePoint Framework Application Customizer to be hoste
 ms.date: 08/27/2018
 ms.prod: sharepoint
 localization_priority: Priority
+ms.custom: scenarios:getting-started
 ---
 
 # Host extension from Office 365 CDN (Hello World part 4)

--- a/docs/spfx/extensions/get-started/serving-your-extension-from-sharepoint.md
+++ b/docs/spfx/extensions/get-started/serving-your-extension-from-sharepoint.md
@@ -4,6 +4,7 @@ description: Deploy your SharePoint Framework Application Customizer to SharePoi
 ms.date: 11/8/2018
 ms.prod: sharepoint
 localization_priority: Priority
+ms.custom: scenarios:getting-started
 ---
 
 # Deploy your extension to SharePoint (Hello World part 3)

--- a/docs/spfx/extensions/get-started/using-page-placeholder-with-extensions.md
+++ b/docs/spfx/extensions/get-started/using-page-placeholder-with-extensions.md
@@ -3,6 +3,7 @@ title: Use page placeholders from Application Customizer (Hello World part 2)
 description: Extend your Hello World extension to take advantage of page placeholders by using SharePoint Framework (SPFx) Extensions. 
 ms.date: 03/14/2019
 ms.prod: sharepoint
+ms.custom: scenarios:getting-started
 ---
 
 # Use page placeholders from Application Customizer (Hello World part 2)

--- a/docs/spfx/set-up-your-developer-tenant.md
+++ b/docs/spfx/set-up-your-developer-tenant.md
@@ -4,6 +4,7 @@ description: Build and deploy client-side web parts using the SharePoint Framewo
 ms.date: 08/20/2018
 ms.prod: sharepoint
 localization_priority: Priority
+ms.custom: scenarios:getting-started
 ---
 
 

--- a/docs/spfx/set-up-your-development-environment.md
+++ b/docs/spfx/set-up-your-development-environment.md
@@ -4,6 +4,7 @@ description: Use Visual Studio or your own custom development environment to bui
 ms.date: 08/20/2018
 ms.prod: sharepoint
 localization_priority: Priority
+ms.custom: scenarios:getting-started
 ---
 
 

--- a/docs/spfx/web-parts/get-started/add-jqueryui-accordion-to-web-part.md
+++ b/docs/spfx/web-parts/get-started/add-jqueryui-accordion-to-web-part.md
@@ -4,6 +4,7 @@ description: Adding the jQueryUI Accordion to your web part project involves cre
 ms.date: 11/08/2018
 ms.prod: sharepoint
 localization_priority: Priority
+ms.custom: scenarios:getting-started
 ---
 
 

--- a/docs/spfx/web-parts/get-started/build-a-hello-world-web-part.md
+++ b/docs/spfx/web-parts/get-started/build-a-hello-world-web-part.md
@@ -3,6 +3,7 @@ title: Build your first SharePoint client-side web part (Hello World part 1)
 description: Create a new web part project and preview it.
 ms.date: 03/14/2019
 ms.prod: sharepoint
+ms.custom: scenarios:getting-started
 ---
 
 # Build your first SharePoint client-side web part (Hello World part 1)

--- a/docs/spfx/web-parts/get-started/connect-to-sharepoint.md
+++ b/docs/spfx/web-parts/get-started/connect-to-sharepoint.md
@@ -4,6 +4,7 @@ description: Access functionality and data in SharePoint and provide a more inte
 ms.date: 10/22/2019
 ms.prod: sharepoint
 localization_priority: Priority
+ms.custom: scenarios:getting-started
 ---
 # Connect your client-side web part to SharePoint (Hello World part 2)
 

--- a/docs/spfx/web-parts/get-started/hosting-webpart-from-office-365-cdn.md
+++ b/docs/spfx/web-parts/get-started/hosting-webpart-from-office-365-cdn.md
@@ -3,6 +3,7 @@ title: Host your client-side web part from Office 365 CDN (Hello World part 4)
 description: An easy solution to host your assets directly from your own Office 365 tenant. Can be used for hosting any static assets that are used in SharePoint Online. 
 ms.date: 03/14/2019
 ms.prod: sharepoint
+ms.custom: scenarios:getting-started
 ---
 
 

--- a/docs/spfx/web-parts/get-started/provision-sp-assets-from-package.md
+++ b/docs/spfx/web-parts/get-started/provision-sp-assets-from-package.md
@@ -3,6 +3,7 @@ title: Provision SharePoint assets from your SharePoint client-side web part
 description: SharePoint assets can be provisioned as part of the SharePoint Framework solution, and are deployed to SharePoint sites when the solution is installed on it. 
 ms.date: 03/14/2019
 ms.prod: sharepoint
+ms.custom: scenarios:getting-started
 ---
 
 

--- a/docs/spfx/web-parts/get-started/serve-your-web-part-in-a-sharepoint-page.md
+++ b/docs/spfx/web-parts/get-started/serve-your-web-part-in-a-sharepoint-page.md
@@ -3,6 +3,7 @@ title: Deploy your client-side web part to a SharePoint page (Hello World part 3
 description: Deploy your client-side web part to SharePoint and see it working on a modern SharePoint page. 
 ms.date: 03/14/2019
 ms.prod: sharepoint
+ms.custom: scenarios:getting-started
 ---
 
 # Deploy your client-side web part to a SharePoint page (Hello World part 3)

--- a/docs/spfx/web-parts/get-started/use-fabric-react-components.md
+++ b/docs/spfx/web-parts/get-started/use-fabric-react-components.md
@@ -4,6 +4,7 @@ description: Build a simple web part that uses the DocumentCard component of Off
 ms.date: 11/08/2018
 ms.prod: sharepoint
 localization_priority: Priority
+ms.custom: scenarios:getting-started
 ---
 
 # Use Office UI Fabric React components in your SharePoint client-side web part


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article

#### What's in this Pull Request?
Added custom tags to the getting started documentation highlighted by Vesa. These tags allow the docs to be pulled into our automated process for recommending content to members of the Office Developer Program.

#### Guidance
Once these changes go live, the recommendation engine will pull these documents into the pipeline and begin analyzing them. SharePoint developers in the dev program will begin seeing the content once we turn on recommendations.
