### PR TITLE
Corrected typo in "button elements" para

### DIFF
--- a/docs/declarative-customization/column-formatting.md
+++ b/docs/declarative-customization/column-formatting.md
@@ -814,7 +814,7 @@ Any other value will result in an error.
 
 #### button elements
 
-`Button` elements can be used to launch a specific action on the parent item.  Every `button` element has a requred property, `customRowAction`, that specifies an `action` that's taken when the button is clicked. This action must be one of the following values:
+`Button` elements can be used to launch a specific action on the parent item.  Every `button` element has a required property, `customRowAction`, that specifies an `action` that's taken when the button is clicked. This action must be one of the following values:
 
 - **defaultClick**: buttons with this action will do the same thing as clicking the list item in an uncustomized view. Below is an example of a button that, when clicked, simulates a click on the item, which results in the details pane being opened.
 


### PR DESCRIPTION
#### Category
- [x] Content fix

#### Related issues:
- fixes https://github.com/SharePoint/sp-dev-docs/issues/4866

#### What's in this Pull Request?
Spelling correction for "required" under "button elements" para

#### Guidance
Spelling correction for "required" under "button elements" para