### PR TITLE
Update alm-api-for-spfx-add-ins.md

### DIFF
--- a/docs/apis/alm-api-for-spfx-add-ins.md
+++ b/docs/apis/alm-api-for-spfx-add-ins.md
@@ -1,7 +1,7 @@
 ---
 title:  Application Lifecycle Management (ALM) APIs 
 description: ALM APIs provide simple APIs to manage deployment of your SharePoint Framework solutions and add-ins across your tenant.
-ms.date: 04/10/2019
+ms.date: 11/16/2019
 ms.prod: sharepoint
 ms.assetid: fdf7ecb2-8851-425b-b058-3285fba77b68
 localization_priority: Priority

--- a/docs/apis/alm-api-for-spfx-add-ins.md
+++ b/docs/apis/alm-api-for-spfx-add-ins.md
@@ -23,7 +23,7 @@ ALM APIs provide simple APIs to manage deployment of your SharePoint Framework s
 ALM APIs can be used to perform exactly the same operations that are available from a UI perspective. When these APIs are used, all typical actions are performed. Following are some of the characteristics of ALM APIs:
 
 - `Install` and `UnInstall` events are being fired for provider-hosted add-ins when corresponding operations occur.
-- ALM APIs support app-only-based operations.
+- ALM APIs support app-only-based operations for SharePoint Framework solutions only. 
 
 ALM APIs are natively provided by using REST APIs, but there are additional CSOM extensions, PowerShell cmdlets, and the cross-platform Office 365 CLI available through SharePoint PnP Community channels.
 


### PR DESCRIPTION
clarified to support scope for app-only operations

#### Category
- [x] Content fix
- [ ] New article


#### What's in this Pull Request?

> We had several incidents (e.g. https://icm.ad.msft.net/imp/v3/incidents/details/155468115/home) due the fact that app only API was used for add-ins. App only usage of ALM APIs was intended and tested for SPFx solutions only. This PR addresses the lack of documentation on this limitation.
