### PR TITLE
Added info about how to get the hubSiteId

### DIFF
--- a/docs/declarative-customization/site-design-json-schema.md
+++ b/docs/declarative-customization/site-design-json-schema.md
@@ -809,6 +809,13 @@ Use the **joinHubSite** verb to join the site to a designated hub site.
 
 #### Example
 
+[!NOTE] To get the hubSiteId, sign in to a site by using the Connect-PnPOnline cmdlet, and then run:
+```PowerShell
+$hubSiteName = "My Hub Site"
+Get-PnPHubSite | Where-Object { $_.Title -eq $hubSiteName }
+```
+This returns information about the current site's Hub Site. The hubSiteId is returned as the SiteId.
+
 ```json
 {
     "verb": "joinHubSite",

--- a/docs/declarative-customization/site-design-json-schema.md
+++ b/docs/declarative-customization/site-design-json-schema.md
@@ -814,7 +814,7 @@ Use the **joinHubSite** verb to join the site to a designated hub site.
 $hubSiteName = "My Hub Site"
 Get-PnPHubSite | Where-Object { $_.Title -eq $hubSiteName }
 ```
-This returns information about the current site's Hub Site. The hubSiteId is returned as the SiteId.
+This returns information about the Hub Site named $hubSiteName. The hubSiteId is returned as the SiteId.
 
 ```json
 {


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article

Added info about how to get the hubSiteId:

[!NOTE] To get the hubSiteId, sign in to a site by using the Connect-PnPOnline cmdlet, and then run:
```PowerShell
$hubSiteName = "My Hub Site"
Get-PnPHubSite | Where-Object { $_.Title -eq $hubSiteName }
```
This returns information about the current site's Hub Site. The hubSiteId is returned as the SiteId.