### PR TITLE
Update authentication-authorization-and-security-in-sharepoint.md

### DIFF
--- a/docs/general-development/authentication-authorization-and-security-in-sharepoint.md
+++ b/docs/general-development/authentication-authorization-and-security-in-sharepoint.md
@@ -22,7 +22,7 @@ The following are some of the enhancements added to SharePoint:
   - SharePoint continues to offer support for both claims and classic authentication modes. Claims authentication is the default authentication option in SharePoint. Classic-mode authentication is deprecated and can be managed only by using Windows PowerShell. A lot of features in SharePoint require claims-mode. 
     
   
-  - The **MigrateUsers** method from SharePoint 2010 is now deprecated, it's no longer the correct way to migrate accounts. To migrate accounts, use the new Windows PowerShell cmdlet called `Convert-SPWebApplication`. For more information see  [Migrate from classic-mode to claims-based authentication in SharePoint](https://technet.microsoft.com/library/gg251985.aspx).
+  - The **MigrateUsers** method from SharePoint 2010 is now deprecated, it's no longer the correct way to migrate accounts. To migrate accounts, use the new Windows PowerShell cmdlet called `Convert-SPWebApplication`. For more information see  [Migrate from classic-mode to claims-based authentication in SharePoint](https://docs.microsoft.com/en-us/sharepoint/upgrade-and-update/migrate-from-classic-mode-to-claims-based-authentication-in-sharepoint-2013).
     
   
   - Requirement to register claims providers is eliminated. However, you do have to pre-configure claims type. You can choose the characters for the claim type and there is no enforcement on the ordering of claim types.
@@ -70,8 +70,8 @@ SharePoint supports the following types of authentication:
     
     For information about signing in to SharePoint by using Windows claims mode, see  [Incoming claims: Signing into SharePoint](incoming-claims-signing-into-sharepoint.md).
     
-    > **Important:**
-      >  For information about suspending impersonation, see [Avoid suspending impersonation of the calling user](https://msdn.microsoft.com/library/ff407852.aspx). 
+    > [!IMPORTANT]
+    > For information about suspending impersonation, see [Avoid suspending impersonation of the calling user](https://msdn.microsoft.com/library/ff407852.aspx). 
 - **ASP.NET Forms:** A non-Windows identity management system that uses the pluggable ASP.NET forms-based authentication system is supported. This mode enables SharePoint to work with a variety of identity management systems, including externally defined groups or roles such as Lightweight Directory Access Protocol (LDAP) and light-weight database identity management systems. Forms authentication allows ASP.NET to perform the authentication for SharePoint, often involving a redirect to a log-on page. In SharePoint, ASP.NET forms are supported only under claims authentication. A forms provider must be registered within a web application that is configured for claims.
     
     For information about signing in to SharePoint by using ASP.NET membership and role passive sign-in, see  [Incoming claims: Signing into SharePoint](incoming-claims-signing-into-sharepoint.md).


### PR DESCRIPTION
#### Category
- [x ] Content fix
- [ ] New article

The TechNet link redirects to an overview page of security. Instead I provided a link with goes directly to the docs.microsoft.com article about migrating from classic mode to claims based authentication.

Also adjusted the markdown tag for the important note block.


