### PR TITLE
Content fix 

### DIFF
--- a/docs/spfx/set-up-your-development-environment.md
+++ b/docs/spfx/set-up-your-development-environment.md
@@ -27,7 +27,7 @@ Install [NodeJS LTS version 12](https://nodejs.org).
 - If you have NodeJS already installed, check that you have the latest version by using `node -v`. It should return the current [LTS version](https://nodejs.org).
 
 > [!IMPORTANT]
-> The current supported LTS version of NodeJS for the SharePoint Framework is both **Node.js v8.x**, **Node.js v10.x** and **Node.js v12.x**. Notice that 9.x or 11.x versions are currently not supported with SharePoint Framework development.
+> The current supported LTS version of NodeJS for the SharePoint Framework are **Node.js v8.x**, **Node.js v10.x** and **Node.js v12.x**. Notice that 9.x or 11.x versions are currently not supported with SharePoint Framework development.
 
 > [!NOTE]
 > If you are building SharePoint Framework components for SharePoint Server 2016, refer to additional details in the **SPFx & SharePoint Server 2016** section for additional details on which version of NodeJS you should install.


### PR DESCRIPTION
Removed context 'both'  - The current supported LTS version of NodeJS for the SharePoint Framework is both Node.js v8.x, Node.js v10.x and Node.js v12.x. Notice that 9.x or 11.x versions are currently not supported with SharePoint Framework development

#### Category
- [ X] Content fix
- [ ] New article
- [] Example checked item (*delete this line*)

> For the above list, an empty checkbox is [ ] as in <kbd>[</kbd><kbd>SPACE</kbd><kbd>]</kbd>. A checked checkbox is [x] with no space between the brackets. Use the `PREVIEW` tab at the top right to preview the rendering before submitting your issue.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### Related issues:
- fixes #issuenumber
- partially #issuenumber
- mentioned in #issuenumber

> If this fixes (aka: closes) or references an issue, please reference it here. This helps maintaining the issue list as it will (1) link the PR to the issue & (2) automatically close the issue when this PR is merged in.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### What's in this Pull Request?

> Please describe the changes in this PR. Sample description or details around bugs which are being fixed.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### Guidance

> *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
> 
> *Please target your PR to 'master' branch. Released documents are in `live` branch.*
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_