### PR TITLE
Updated manifest sample with personal tab url

### DIFF
--- a/docs/spfx/web-parts/guidance/creating-team-manifest-manually-for-webpart.md
+++ b/docs/spfx/web-parts/guidance/creating-team-manifest-manually-for-webpart.md
@@ -46,6 +46,16 @@ To side load a SharePoint Framework web part as a Microsoft Teams application, y
     "color": "{{SPFX_COMPONENT_ID}}_color.png"
   },
   "accentColor": "#004578",
+  "staticTabs": [
+        {
+            "entityId": "com.contoso.personaltab.spfx",
+            "name": "My SPFx Personal Tab",
+            "contentUrl": "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId={{SPFX_COMPONENT_ID}}",
+            "scopes": [
+                "personal"
+            ]
+        }
+    ],
   "configurableTabs": [
     {
       "configurationUrl": "https://{teamSiteDomain}{teamSitePath}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest={teamSitePath}/_layouts/15/teamshostedapp.aspx%3FopenPropertyPane=true%26teams%26componentId={{SPFX_COMPONENT_ID}}%26forceLocale={locale}",
@@ -124,6 +134,16 @@ Below json structure demonstrates sample manifest file content.
     "color": "b7771434-9587-4a79-9990-48c310f78a3d_color.png"
   },
   "accentColor": "#004578",
+  "staticTabs": [
+        {
+            "entityId": "com.contoso.personaltab.spfx",
+            "name": "My SPFx Personal Tab",
+            "contentUrl": "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=50ef7075-1c74-4b40-809b-6aad4b4e2445",
+            "scopes": [
+                "personal"
+            ]
+        }
+    ],
   "configurableTabs": [
     {
       "configurationUrl": "https://{teamSiteDomain}{teamSitePath}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest={teamSitePath}/_layouts/15/teamshostedapp.aspx%3FopenPropertyPane=true%26teams%26componentId=b7771434-9587-4a79-9990-48c310f78a3d%26forceLocale={locale}",


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article

#### What's in this Pull Request?

SPFx 1.10 now supports personal tabs. Updating the teams manifest sample with the url to use in case of an SPFx based personal tab.