### PR TITLE
Update Upload-large-files-sample-app-for-SharePoint.md

### DIFF
--- a/docs/solution-guidance/Upload-large-files-sample-app-for-SharePoint.md
+++ b/docs/solution-guidance/Upload-large-files-sample-app-for-SharePoint.md
@@ -166,7 +166,7 @@ public Microsoft.SharePoint.Client.File UploadFileSlicePerSlice(ClientContext ct
   ctx.ExecuteQuery();
 
   // File object.
-  Microsoft.SharePoint.Client.File uploadFile;
+  Microsoft.SharePoint.Client.File uploadFile = null;
 
   // Calculate block size in bytes.
   int blockSize = fileChunkSizeInMB * 1024 * 1024;
@@ -255,9 +255,6 @@ public Microsoft.SharePoint.Client.File UploadFileSlicePerSlice(ClientContext ct
           }
           else
           {
-            // Get a reference to your file.
-            uploadFile = ctx.Web.GetFileByServerRelativeUrl(docs.RootFolder.ServerRelativeUrl + System.IO.Path.AltDirectorySeparatorChar + uniqueFileName);
-
             if (last)
             {
               // Is this the last slice of data?


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article
- [ ] Example checked item (*delete this line*)

#### Related issues:
- fixes #3737

#### What's in this Pull Request?

UploadFile object needs to be reused. Without it, it may sometimes fails to get the upload session or it may use wrong session and continue upload will fail.