### PR TITLE
Fix link for Azure Pipelines in approaches list

### DIFF
--- a/docs/spfx/toolchain/implement-ci-cd-with-azure-devops.md
+++ b/docs/spfx/toolchain/implement-ci-cd-with-azure-devops.md
@@ -19,8 +19,8 @@ Azure builds and releases is the historic one, featuring a graphical edition exp
 Azure multi-stage Pipelines is a newer feature still in preview, is relies on pipeline definitions stored as YAML files on the repository providing transparency, version history and repeatability.  
 Both approaches are decribed for the SharePoint Framework:
 
-- [Azure Build and Release](./implement-ci-cd-with-azure-pipelines.md)
-- Azure Multi-stage Pipelines (this article)
+- Azure Build and Release (this article)
+- [Azure Multi-stage Pipelines](./implement-ci-cd-with-azure-pipelines.md)
 
 
 ## Continuous Integration


### PR DESCRIPTION
In the approaches list, Azure Pipelines (Multi stage) was wrongly referred as this article.

#### Category
- [x] Content fix
- [ ] New article

#### What's in this Pull Request?

This article was referred to as Azure yaml pipelines implementation. Rather this article explains the GUI part. Fixed the link accordingly.
