### PR TITLE
Missing step to be able to import after running npm link

### DIFF
--- a/docs/spfx/library-component-tutorial.md
+++ b/docs/spfx/library-component-tutorial.md
@@ -56,6 +56,8 @@ localization_priority: Priority
 
 ## How to consume a 3rd party SPFx library (for local testing)
 1. Run `npm link` from the root directory of library solution. In this case it would be from the **```corporate-library```** folder.
+
+1. Right after creating the symbolic link to your new spfx library component, do not forget to run at least once ```gulp serve```. You need to compile your library component at least once in order to be able to import it as a module into a different project. Remember that the package.json says that ```"main": "lib/index.js"```, therefore, that location needs to exist prior any **import** attempt.
  
 1. This will create a local npm link to the library with the name which is provided in the ```package.json```.
  

--- a/docs/spfx/library-component-tutorial.md
+++ b/docs/spfx/library-component-tutorial.md
@@ -57,7 +57,7 @@ localization_priority: Priority
 ## How to consume a 3rd party SPFx library (for local testing)
 1. Run `npm link` from the root directory of library solution. In this case it would be from the **```corporate-library```** folder.
 
-1. Right after creating the symbolic link to your new spfx library component, do not forget to run at least once ```gulp serve```. You need to compile your library component at least once in order to be able to import it as a module into a different project. Remember that the package.json says that ```"main": "lib/index.js"```, therefore, that location needs to exist prior any **import** attempt.
+1. Right after creating the symbolic link to your new spfx library component, do not forget to run at least once `gulp serve`. You need to compile your library component at least once in order to be able to import it as a module into a different project. Remember that the package.json says that `"main": "lib/index.js"`, therefore, that location needs to exist prior any **import** attempt.
  
 1. This will create a local npm link to the library with the name which is provided in the ```package.json```.
  


### PR DESCRIPTION
I noticed that I was not able to import the library module into another webpart project unless I run "gulp build" 1st. If you dont run such command, you will get a tsc error "module is not found" since there is no "lib" folder at all.

#### Category
- [x] Content fix
- [ ] New article

#### Related issues:
- fixes #issuenumber
- partially #issuenumber
- mentioned in #issuenumber

#### What's in this Pull Request?

It is just a description of a missing step that I consider other developers may found when trying to import the library module while using the npm link command. Developer needs to compile the library project at least once prior any attempt to import.

#### Guidance

Dont know what to input in this section, sorry.