### PR TITLE
security-apponly-azuread.md: correct description of date format

### DIFF
--- a/docs/solution-guidance/security-apponly-azuread.md
+++ b/docs/solution-guidance/security-apponly-azuread.md
@@ -32,7 +32,7 @@ To create a self signed certificate with this script:
 ```
 
 > [!NOTE]
-> The dates are provided in US date format: YYYY-MM-dd
+> The dates are provided in ISO date format: YYYY-MM-dd
 
 The actual script can be copied from here:
 


### PR DESCRIPTION
#### Category
- [x] Content fix

The date format is ISO not US.