### PR TITLE
Correct wording regarding node version

### DIFF
--- a/docs/spfx/set-up-your-development-environment.md
+++ b/docs/spfx/set-up-your-development-environment.md
@@ -28,7 +28,7 @@ You can also follow these steps by watching this video on the SharePoint PnP You
 Install [NodeJS LTS version 10](https://nodejs.org/dist/latest-v10.x/).
 
 - If you are in Windows, you can use the msi installers ([x86](https://nodejs.org/dist/latest-v10.x/node-v10.19.0-x86.msi) or [x64](https://nodejs.org/dist/latest-v10.x/node-v10.19.0-x64.msi)) in this link for the easiest way to set up NodeJS (notice that these direct links evolve over time, so check the latest v10 from the above directory).
-- If you have NodeJS already installed, check that you have the correct version by using `node -v`. It should return the current [LTS version](https://nodejs.org).
+- If you have NodeJS already installed, check that you have the correct version by using `node -v`. It should return version 10.19.0.
 
 > [!IMPORTANT]
 > The current supported LTS version of NodeJS for the SharePoint Framework is  **Node.js v8.x** and **Node.js v10.x**. Notice that 9.x, 11.x or 12.x versions are currently not supported with SharePoint Framework development.

--- a/docs/spfx/set-up-your-development-environment.md
+++ b/docs/spfx/set-up-your-development-environment.md
@@ -28,7 +28,7 @@ You can also follow these steps by watching this video on the SharePoint PnP You
 Install [NodeJS LTS version 10](https://nodejs.org/dist/latest-v10.x/).
 
 - If you are in Windows, you can use the msi installers ([x86](https://nodejs.org/dist/latest-v10.x/node-v10.19.0-x86.msi) or [x64](https://nodejs.org/dist/latest-v10.x/node-v10.19.0-x64.msi)) in this link for the easiest way to set up NodeJS (notice that these direct links evolve over time, so check the latest v10 from the above directory).
-- If you have NodeJS already installed, check that you have the latest version by using `node -v`. It should return the current [LTS version](https://nodejs.org).
+- If you have NodeJS already installed, check that you have the correct version by using `node -v`. It should return the current [LTS version](https://nodejs.org).
 
 > [!IMPORTANT]
 > The current supported LTS version of NodeJS for the SharePoint Framework is  **Node.js v8.x** and **Node.js v10.x**. Notice that 9.x, 11.x or 12.x versions are currently not supported with SharePoint Framework development.


### PR DESCRIPTION
The portion in this document about the Node version is misleading: it says "ensure you have the latest version" when actually (as indicated in the note immediately below that line) SPFx is not compatible with the latest version of Node. It is only compatible with Node 10.

#### Category
- [x] Content fix
- [ ] New article

#### Related issues:


#### What's in this Pull Request?

Modified a few words in the documentation to provide more precise language (see explanation above).

#### Guidance

N/A