### PR TITLE
Update office-addins-tutorial.md

### DIFF
--- a/docs/spfx/web-parts/get-started/office-addins-tutorial.md
+++ b/docs/spfx/web-parts/get-started/office-addins-tutorial.md
@@ -172,7 +172,7 @@ Next, you need to deploy the package that was generated to the tenant App Catalo
 
     Notice how the **domain** list in the prompt says *SharePoint Online*. This is because the content is either served from the Office 365 CDN or from the App Catalog, depending on the tenant settings.
 
-    Ensure that the **Make this solution available to all sites in the organization** option is selected, so that the web part can be used from the Microsoft Teams side.
+    Ensure that the **Make this solution available to all sites in the organization** option is selected, so that the web part can be used from the Outlook Web Access side.
 
     ![Trust client-side solution deployment](../../../images/add-in-upload-solution-deploy.png)
 


### PR DESCRIPTION
Corrected text "Teams" to read: "Outlook Web Access"

#### Category
- [x] Content fix
- [ ] New article

#### Related issues:

N/A

#### What's in this Pull Request?

A text correction in the documentation because a section referred to Teams when it needed to be Outlook.