### PR TITLE
add references to tenant wide extensions list. correct typos

### DIFF
--- a/docs/spfx/extensions/basics/tenant-wide-deployment-extensions.md
+++ b/docs/spfx/extensions/basics/tenant-wide-deployment-extensions.md
@@ -13,7 +13,7 @@ Tenant Wide Deployment option for SharePoint Framework Extensions is supported f
 > [!NOTE]
 > SharePoint Framework extensions are supported with modern experiences regardless of the actual site template used when content site was created.
 
-When developers create a new SharePoint Framework extension solution using standard SharePoint Framework Yeoman packages, automation is included in the solution package to activate extension cross the tenant.
+When developers create a new SharePoint Framework extension solution using standard SharePoint Framework Yeoman packages, automation is included in the solution package to activate extension across the tenant.
 
 > [!WARNING]
 > Starting from SharePoint Framework v1.6, default scaffolding will automatically create example files in SharePoint Solution to activate extension across the tenant if you chose to use the tenant-scoped deployment option.
@@ -143,4 +143,4 @@ When an administrator adds a  solution that has a ClientSideInstance.xml file in
 
 ![SharePoint client-side solution scaffolded successfully](../../../images/ext-tenant-wide-solution-deployment.png)
 
-After solution deployment, administrator can change the deployment settings from the **Tenant Wide Extension** list.
+After solution deployment, an administrator can change the deployment settings from the **Tenant Wide Extension** list.

--- a/docs/spfx/tenant-scoped-deployment.md
+++ b/docs/spfx/tenant-scoped-deployment.md
@@ -11,7 +11,7 @@ localization_priority: Priority
 
 You can configure your SharePoint Framework components to be immediately available across the tenant when the solution package is installed to the tenant app catalog. This can be configured by using the **skipFeatureDeployment** attribute in the **package-solution.json** file.
 
-When the solution has this attribute enabled, the tenant administrator is provided the option to enable the solution to be available automatically across all site collections and sites in the tenant when the solution package is installed to the tenant app catalog. 
+When the solution has this attribute enabled, the tenant administrator is provided the option to enable the solution to be available automatically across all site collections and sites in the tenant when the solution package is installed to the tenant app catalog.
 
 You can also see the tenant-wide deployment option demonstrated by watching the following video on the SharePoint PnP YouTube Channel:
 
@@ -19,10 +19,10 @@ You can also see the tenant-wide deployment option demonstrated by watching the 
 
 > [!Video https://www.youtube.com/embed/pemHOZCSwZI]
 
-<br/> 
+<br/>
 
 
-> [!NOTE] 
+> [!NOTE]
 > You have to update to the latest SharePoint Framework Yeoman template version to be able to use this capability. You can update your global installation by executing `npm install -g @microsoft/generator-sharepoint`.
 > Tenant-wide deployment is not available for SharePoint 2016 Feature Pack 2 since it only supports SPFX 1.1, and this deployment option was released in version 1.4
 > If you are utilizing a SPFX webpart older than 1.4 you can upgrade with instructions via the [Office 365 CLI](https://aka.ms/o365cli)
@@ -33,18 +33,18 @@ When this option is used, any feature framework definitions in the SharePoint Fr
 
 For more information, see [Provision SharePoint assets with your solution package](./toolchain/provision-sharepoint-assets.md).
 
-> [!NOTE] 
-> Solutions that are configured to be automatically deployed across tenants are not visible in the add-an-app capability at the site level. 
+> [!NOTE]
+> Solutions that are configured to be automatically deployed across tenants are not visible in the add-an-app capability at the site level.
 
 ## Configure solution to be available across the tenant
 
-The SharePoint Framework Yeoman template asks a specific question related to this option. This question impacts directly on the **skipFeatureDeployment** attribute in the **package-solution.json** file. 
+The SharePoint Framework Yeoman template asks a specific question related to this option. This question impacts directly on the **skipFeatureDeployment** attribute in the **package-solution.json** file.
 
 ![Yeoman question around tenant deployed option](../images/tenant-deploy-yeoman.png)
 
 <br/>
 
-In following example configuration, **skipFeatureDeployment** is set to true, which indicates that the solution can be centrally deployed across the tenant. 
+In following example configuration, **skipFeatureDeployment** is set to true, which indicates that the solution can be centrally deployed across the tenant.
 
 ```json
 {
@@ -52,7 +52,21 @@ In following example configuration, **skipFeatureDeployment** is set to true, wh
     "name": "tenant-deploy-client-side-solution",
     "id": "dd4feca4-6f7e-47f1-a0e2-97de8890e3fa",
     "version": "1.0.0.0",
-    "skipFeatureDeployment": true
+    "skipFeatureDeployment": true,
+    "features": [
+      {
+        "title": "Application Extension - Deployment of custom action.",
+        "description": "Deploys a custom action with ClientSideComponentId association",
+        "id": "54f0dc0e-c190-439d-933b-2dd2809ed3c3",
+        "version": "1.0.0.0",
+        "assets": {
+          "elementManifests": [
+            "elements.xml",
+            "ClientSideInstance.xml"
+          ]
+        }
+      }
+    ]
   },
   "paths": {
     "zippedPackage": "solution/tenant-deploy-true.sppkg"
@@ -65,19 +79,26 @@ In following example configuration, **skipFeatureDeployment** is set to true, wh
 
 When the solution with the **skipFeatureDeployment** attribute set to **true** is deployed to the tenant app catalog, the administrator is given an option to configure the solution to be deployed centrally across the tenant.
 
-By default, the **Make this solution available to all sites in the organization** check box is not selected. If the check box is selected by the administrator, components in the solutions are automatically visible and available across the tenant. 
+By default, the **Make this solution available to all sites in the organization** check box is not selected. If the check box is selected by the administrator, components in the solutions are automatically visible and available across the tenant.
 
 ![The "Make this solution available to all sites in the organization" setting is visible when solution is deployed to app catalog](../images/tenant-deploy-app-catalog.png)
 
-Notice that because the solution and site-specific upgrade actions are only available when you use the feature framework, there's no specific upgrade option for the centrally deployed solutions. These solutions can be updated by updating the solution-specific assets in the CDN and by updating the package in the app catalog. This automatically updates all existing component instances across the tenant to use the latest component assets, such as JavaScript files and updated CSS files.
+Notice that because the solution and site-specific upgrade actions are only available when you use the feature framework, there's no specific upgrade option for the centrally deployed solutions. These solutions can be updated by updating the solution-specific assets in the CDN and by updating and deploying the package in the app catalog. This automatically updates all existing component instances across the tenant to use the latest component assets, such as JavaScript files and updated CSS files.
+
+> [!WARNING]
+> For solution packages containing site extension(s), selecting the **Make this solution available to all sites in the organization** check box is only required to activate the site extension(s) initially. When updating existing solution packages, selecting the check box during deployment may create duplicate entries in the  **Tenant Wide Extension** list.
 
 ## Client-side web part visibility on SharePoint sites
 
-Web parts included in solutions that have been centrally deployed are immediately visible in the web part picker in both classic and modern pages. 
+Web parts included in solutions that have been centrally deployed are immediately visible in the web part picker in both classic and modern pages.
 
 ## Impact of skipFeatureDeployment setting with Extensions
 
-[SharePoint Framework Extensions](./extensions/overview-extensions.md) are immediately available to be used on SharePoint sites. This means that they can be associated with **ClientSideComponentId** properties in the specific SharePoint elements, such as **fields** and **user custom actions**. 
+[SharePoint Framework Extensions](./extensions/overview-extensions.md) are immediately available to be used on SharePoint sites. This means that they can be associated with **ClientSideComponentId** properties in the specific SharePoint elements, such as **fields** and **user custom actions**.
+
+Additionally, if an administrator selects the **Make this solution available to all sites in the organization** checkbox during deployment, automations in the solution package may create entries in the **Tenant Wide Extensions** list on the app catalog. Entries in this list manage tenant-wide activation of site extensions. The automations are described by the **ClientSideInstance.xml** file as referenced in **package-solution.json**.
+
+For more information, see [Tenant Wide Deployment of SharePoint Framework Extensions](./extensions/basics/tenant-wide-deployment-extensions.md).
 
 ## See also
 


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article

#### Related issues:
- fixes #5396

#### What's in this Pull Request?

The tenant-scoped-deployment article targets broadly the concept of centrally deployed components. This fix and adds reference and guidance with respect to tenant wide site extensions and clarifies the steps for updating centrally deployed solutions.

I added the missing `features` attribute to the json example since it is generated by the yeoman generator and adding it allows ClientSideInstances.xml to be better referenced later in the article.