### PR TITLE
Included the Windows Terminal as optional tool

### DIFF
--- a/docs/spfx/set-up-your-development-environment.md
+++ b/docs/spfx/set-up-your-development-environment.md
@@ -93,6 +93,7 @@ Following are some tools that might come in handy as well:
 
 - [Fiddler](https://www.telerik.com/fiddler)
 - [Postman](https://www.getpostman.com/docs/postman/launching_postman/navigating_postman)
+- [Windows Terminal](https://github.com/Microsoft/Terminal)
 - [Cmder for Windows](http://cmder.net/)
 - [Oh My Zsh for Mac](http://ohmyz.sh/)
 - [Git source control tools](https://git-scm.com/)


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article

#### What's in this Pull Request?

If external tools like Cmder or Oh My Zsh are mentioned, the Windows Terminal - while still in preview - certainly has to be on this list too...