### PR TITLE
Corrected case mistakes

### DIFF
--- a/docs/spfx/web-parts/get-started/build-a-hello-world-web-part.md
+++ b/docs/spfx/web-parts/get-started/build-a-hello-world-web-part.md
@@ -82,7 +82,7 @@ Because the SharePoint client-side solution is HTML/TypeScript based, you can us
 * [Atom](https://atom.io)
 * [Webstorm](https://www.jetbrains.com/webstorm)
 
-SharePoint Framework documentation uses Visual Studio code in the steps and examples. Visual Studio Code is a lightweight but powerful source code editor from Microsoft that runs on your desktop and is available for Windows, Mac, and Linux. It comes with built-in support for JavaScript, TypeScript, and Node.js, and has a rich ecosystem of extensions for other languages (such as C++, C#, Python, PHP) and runtimes.
+SharePoint Framework documentation uses Visual Studio Code in the steps and examples. Visual Studio Code is a lightweight but powerful source code editor from Microsoft that runs on your desktop and is available for Windows, Mac, and Linux. It comes with built-in support for JavaScript, TypeScript, and Node.js, and has a rich ecosystem of extensions for other languages (such as C++, C#, Python, PHP) and runtimes.
 
 ## Preview the web part
 
@@ -223,7 +223,7 @@ When the properties are defined, you can access them in your web part by using `
 
 Notice that we are performing an HTML escape on the property's value to ensure a valid string. To learn more about how to work with the property pane and property pane field types, see [Make your SharePoint client-side web part configurable](../basics/integrate-with-property-pane.md). 
 
-Let's now add a few more properties to the property pane: a check box, a drop-down list, and a toggle. We first start by importing the respective property pane fields from the framework.
+Let's now add a few more properties to the property pane: a checkbox, a drop-down list, and a toggle. We first start by importing the respective property pane fields from the framework.
 
 1. Scroll to the top of the file and add the following to the import section from `@microsoft/sp-property-pane`:
 

--- a/docs/spfx/web-parts/get-started/office-addins-tutorial.md
+++ b/docs/spfx/web-parts/get-started/office-addins-tutorial.md
@@ -1,7 +1,7 @@
 ---
 title: Tutorial for creating Outlook Web Access extension using SharePoint Framework
 description: Creating Outlook add-ins using SharePoint Framework
-ms.date: 02/08/2020
+ms.date: 02/19/2020
 ms.prod: sharepoint
 localization_priority: Priority
 ---
@@ -86,7 +86,7 @@ Manifest file contains by default definition to expose your add-in as a tool pan
 In the console, enter the following to install the types for the Office JavaScript SDK from the npm:
 
 ```shell
-npm install @types/office-js
+npm install @types/office-js --save-dev
 ```
 
 This adds the needed intelligence for the Office JavaScript SDK types when you develop your solution in TypeScript.

--- a/docs/spfx/web-parts/guidance/use-existing-javascript-libraries.md
+++ b/docs/spfx/web-parts/guidance/use-existing-javascript-libraries.md
@@ -1,7 +1,7 @@
 ---
 title: Use existing JavaScript libraries in SharePoint Framework client-side web parts
 description: Ensure that your web parts won't negatively impact the performance of SharePoint pages that they are being used on.
-ms.date: 01/29/2018
+ms.date: 02/19/2020
 ms.prod: sharepoint
 localization_priority: Priority
 ---
@@ -24,7 +24,7 @@ The most common way of referencing existing JavaScript libraries in SharePoint F
 2. To use Angular with TypeScript, you would install typings using **npm**:
 
   ```sh
-  npm install @types/angular --save
+  npm install @types/angular --save-dev
   ```
 
 3. Reference Angular in your web part by using the `import` statement:
@@ -97,7 +97,7 @@ Referencing existing JavaScript libraries in the SharePoint Framework is easy an
 Using Angular as an example, to reference it as an external resource in your client-side web part, you start by installing its TypeScript typings using **npm**:
 
 ```sh
-  npm install @types/angular --save
+  npm install @types/angular --save-dev
 ```
 
 <br/>

--- a/docs/spfx/web-parts/overview-client-side-web-parts.md
+++ b/docs/spfx/web-parts/overview-client-side-web-parts.md
@@ -15,7 +15,7 @@ You can build client-side web parts using modern script development tools and th
 
 In addition to plain JavaScript projects, you can build web parts alongside common scripting frameworks, such as AngularJS and React. For example, you can use React along with components from Office UI Fabric React to quickly create experiences based on the same components used in Office 365.
 
-For more information, see the Getting started, Basics, and Concepts sections (in the TOC).
+For more information, see the Getting Started, Basics, and Concepts sections (in the TOC).
 
 ## See also
 


### PR DESCRIPTION
Changed letter 'c' to capital in Visual Studio Code.
Updated check box to checkbox (no space)

#### Category
- [x] Content fix
- [ ] New article


#### What's in this Pull Request?

1. Changed letter 'c' to capital letter 'C' in Visual Studio Code.
2. Updated check box to checkbox (no space)