### PR TITLE
Fixed Typo - Granting access via Azure AD App-Only

### DIFF
--- a/docs/solution-guidance/security-apponly-azuread.md
+++ b/docs/solution-guidance/security-apponly-azuread.md
@@ -216,7 +216,7 @@ To confirm that the certificate was successfully registered, click on "Manifest"
 
 If you see a section looking somewhat similar to this, the certificate has been added successfully.
 
-In this sample the Sites.FullControl.All application permission require admin consent in a tenant before it can be used. In order to do this, click on "API permissions" in the left menu again. At the bottom you will see a section "Grand consent". Click on the "Grand admin constent for <organization name>" button and confirm the action by clicking on the "Yes" button that appears at the top.
+In this sample the Sites.FullControl.All application permission require admin consent in a tenant before it can be used. In order to do this, click on "API permissions" in the left menu again. At the bottom you will see a section "Grant consent". Click on the "Grand admin constent for <organization name>" button and confirm the action by clicking on the "Yes" button that appears at the top.
 
 ![granting permissions to azure ad application](media/apponly/azureadapponly5.png)
 


### PR DESCRIPTION
Corrected "Grand consent"

#### Category
- [x] Content fix

#### Related issues:
- fixes https://github.com/SharePoint/sp-dev-docs/issues/5455

#### What's in this Pull Request?
Corrected "Grand consent"

#### Guidance
Fixed Typo in Granting access via Azure AD App-Only. Corrected "Grand consent"
