### PR TITLE
Teams Personal Tab clarification

### DIFF
--- a/docs/spfx/web-parts/get-started/using-web-part-as-ms-teams-tab.md
+++ b/docs/spfx/web-parts/get-started/using-web-part-as-ms-teams-tab.md
@@ -1,7 +1,7 @@
 ---
 title: Building Microsoft Teams tab using SharePoint Framework - Tutorial
 description: Tutorial on how to build Microsoft Teams tabs using SharePoint Framework. Capability was released to general availability in SharePoint Framework v1.8.
-ms.date: 02/08/2020
+ms.date: 03/31/2020
 ms.prod: sharepoint
 localization_priority: Priority
 ---

--- a/docs/spfx/web-parts/get-started/using-web-part-as-ms-teams-tab.md
+++ b/docs/spfx/web-parts/get-started/using-web-part-as-ms-teams-tab.md
@@ -116,7 +116,7 @@ Locate the manifest json file for the web part you want to make available to Tea
 ```
 
 > [!NOTE]
-> Starting from the SharePoint Framework 1.10 version, you can also expose SharePoint Framework web parts as personal Microsoft Teams apps. This can be controlled by including `"TeamsPersonalApp"` in the `supportedHosts` value.
+> Starting from the SharePoint Framework 1.10 version, you can also expose SharePoint Framework web parts as personal Microsoft Teams apps. This can be controlled by including `"TeamsPersonalApp"` in the `supportedHosts` value. Personal tabs do not have a configuration option, and so web parts added to Teams as personal apps will not expose the web part property pane. If you need to configure the web part in this situation you will have to implement it within the web part UI.
 
 ## Updating code to be aware of the Microsoft Teams context
 


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article

#### What's in this Pull Request?

Make clear that personal tabs don't expose the web part property pane, as discussed in the Teams channel on 27/02/2020.

