### PR TITLE
Removed capitalization on "setDescription"

### DIFF
--- a/docs/declarative-customization/get-started-create-site-design.md
+++ b/docs/declarative-customization/get-started-create-site-design.md
@@ -1,7 +1,7 @@
 ---
 title: Get started creating SharePoint site designs and site scripts
 description: Create site designs to provide reusable lists, themes, layouts, pages, or custom actions so that your users can quickly build new SharePoint sites with the features they need.
-ms.date: 12/19/2018
+ms.date: 04/17/2020
 localization_priority: Priority
 ---
 

--- a/docs/declarative-customization/get-started-create-site-design.md
+++ b/docs/declarative-customization/get-started-create-site-design.md
@@ -34,7 +34,7 @@ Each action is specified by the "verb" value in the JSON script. Also, actions c
                     "templateType": 100,
                     "subactions": [
                         {
-                            "verb": "SetDescription",
+                            "verb": "setDescription",
                             "description": "List of Customers and Orders"
                         },
                         {


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article

#### Related issues:

#### What's in this Pull Request?
Subaction "setDescription" failed due to the capitalization of the verb.
Updated from "SetDescription" to "setDescription"

#### Guidance