### PR TITLE
windows.location.query is a bit outdated

### DIFF
--- a/docs/spfx/web-parts/guidance/intercepting-query-changes-in-webparts.md
+++ b/docs/spfx/web-parts/guidance/intercepting-query-changes-in-webparts.md
@@ -16,7 +16,7 @@ First let's assume you have a basic web part class that renders the current quer
 ```typescript
 export default class HelloWorldWebPart extends BaseClientSideWebPart<IHelloWorldWebPartProps> {
   public render(): void {
-    this.domElement.innerHTML = window.location.query;
+    this.domElement.innerHTML = window.location.search;
   }
 }
 ```


### PR DESCRIPTION
window.location.search is a better method to get the URL search query string

#### Category
- [x] Content fix
- [ ] New article

#### What's in this Pull Request?

A better approach to get the url search query
