### PR TITLE
Leverage Arrow functions. Browser history nav button issue

### DIFF
--- a/docs/spfx/web-parts/guidance/intercepting-query-changes-in-webparts.md
+++ b/docs/spfx/web-parts/guidance/intercepting-query-changes-in-webparts.md
@@ -16,7 +16,7 @@ First let's assume you have a basic web part class that renders the current quer
 ```typescript
 export default class HelloWorldWebPart extends BaseClientSideWebPart<IHelloWorldWebPartProps> {
   public render(): void {
-    this.domElement.innerHTML = window.location.query;
+    this.domElement.innerHTML = window.location.search;
   }
 }
 ```
@@ -46,7 +46,7 @@ export default class HelloWorldWebPart extends BaseClientSideWebPart<IHelloWorld
     this.domElement.innerHTML = window.location.search;
   }
 
-  private _onUrlChange(newpath==window.location.href): void {    
+  private _onUrlChange(newpath=window.location.search): void {    
     // any logic you might want to trigger when the query string updates
     // e.g. fetching data
     // e.g. logging the URL changes // console.log(newpath)

--- a/docs/spfx/web-parts/guidance/intercepting-query-changes-in-webparts.md
+++ b/docs/spfx/web-parts/guidance/intercepting-query-changes-in-webparts.md
@@ -26,28 +26,30 @@ We can use the following changes to trigger our web part to re-render in the eve
 ```typescript
 export default class HelloWorldWebPart extends BaseClientSideWebPart<IHelloWorldWebPartProps> {
   public onInit(): Promise<void> {
-    (function (history) {
+    ((history) => {
       var pushState = history.pushState;
-      history.pushState = function (state, key, path) {
-          this._onUrlChange();
-          return pushState.apply(history, arguments);
+      history.pushState = (state, key, path)=> {          
+          pushState.apply(history, [state, key, path]);
+          this._onUrlChange(path);
       };
     })(window.history);
 
     window.addEventListener('popstate', function (e) {
-      this._onUrlChange();
+      //Currently browsing by the browser history buttons ( back / forward ) doesnt cause any effect on a sp conditionally loaded page.
+      //this._onUrlChange();
     });
 
     return Promise.resolve();
   }
 
   public render(): void {
-    this.domElement.innerHTML = window.location.query;
+    this.domElement.innerHTML = window.location.search;
   }
 
-  private _onUrlChange(): void {
+  private _onUrlChange(newpath==window.location.href): void {    
     // any logic you might want to trigger when the query string updates
     // e.g. fetching data
+    // e.g. logging the URL changes // console.log(newpath)
     this.render();
   }
 }

--- a/docs/spfx/web-parts/guidance/intercepting-query-changes-in-webparts.md
+++ b/docs/spfx/web-parts/guidance/intercepting-query-changes-in-webparts.md
@@ -2,7 +2,7 @@
 title: Intercepting Query String Changes in Web Parts
 description: Building web parts that respond to query string changes.
 ms.author: bekaise
-ms.date: 01/28/2020
+ms.date: 04/22/2020
 ms.prod: sharepoint
 localization_priority: Normal
 ---
@@ -28,7 +28,7 @@ export default class HelloWorldWebPart extends BaseClientSideWebPart<IHelloWorld
   public onInit(): Promise<void> {
     ((history) => {
       var pushState = history.pushState;
-      history.pushState = (state, key, path)=> {          
+      history.pushState = (state, key, path) => {          
           pushState.apply(history, [state, key, path]);
           this._onUrlChange(path);
       };
@@ -46,7 +46,7 @@ export default class HelloWorldWebPart extends BaseClientSideWebPart<IHelloWorld
     this.domElement.innerHTML = window.location.search;
   }
 
-  private _onUrlChange(newpath=window.location.search): void {    
+  private _onUrlChange(newpath = window.location.search): void {    
     // any logic you might want to trigger when the query string updates
     // e.g. fetching data
     // e.g. logging the URL changes // console.log(newpath)


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article

#### Related issues:
- partially #4557

#### What's in this Pull Request?
I have proposed these changes beacuse: 
- When trying to leverage this on my spfx extension, using yeoman, I had issues on the code and the solution was to implement arrow functions. Also, it makes the code more understable.
- I have noticed that when using the back/forwards browser history buttons, doesnt have any effect, when the conditionally page load is in place ( aka page transition ). For instance, you can go to a library, and start to browser among the folders. You will notice that clicking on back/forward doesnt have any effect on page content load.
- I have documented how you can pass the url info change to the event handler
- This approach can help users to track down which folder the user is browsing, on a list/library