### PR TITLE
Updating Create List Item Example

### DIFF
--- a/docs/sp-add-ins/working-with-lists-and-list-items-with-rest.md
+++ b/docs/sp-add-ins/working-with-lists-and-list-items-with-rest.md
@@ -498,8 +498,8 @@ The following example shows how to create a list item.
 ```http
 POST https://{site_url}/_api/web/lists/GetByTitle('Test')/items
 Authorization: "Bearer " + accessToken
-Accept: "application/json;odata=nometadata"
-Content-Type: "application/json"
+Accept: "application/json;odata=verbose"
+Content-Type: "application/json;odata=verbose"
 Content-Length: {length of request body as integer}
 X-RequestDigest: "{form_digest_value}"
 


### PR DESCRIPTION
Updating the headers in this example, to fix #5665 . Passing in the __metadata property in the request without specifying verbose, results in a 400 error "The property '__metadata' does not exist on type 'SP.Data.ListItem". 

Updating the headers of this sample to support the body that is being passed in the request.

#### Category
- [x] Content fix
- [ ] New article

#### Related issues:
- fixes #5665 

#### What's in this Pull Request?
Updated sample to include proper headers when specifying __metadata on the request object. Otherwise, this sample returns a 400 error. 
