### PR TITLE
Build command instead of Serve for library component

### DIFF
--- a/docs/spfx/library-component-tutorial.md
+++ b/docs/spfx/library-component-tutorial.md
@@ -52,7 +52,7 @@ localization_priority: Priority
 ## How to consume a third-party SPFx library (for local testing)
 
 1. Run `npm link` from the root directory of library solution. In this case, it would be from the **corporate-library** folder.
-1. Right after creating the symbolic link to your new SPFx library component, don't forget to run at least once `gulp serve`. Compile your library component at least once in order to be able to import it as a module into a different project. Remember that the **package.json** says that `"main": "lib/index.js"`, therefore, that location needs to exist prior to any **import** attempt.
+1. Right after creating the symbolic link to your new SPFx library component, don't forget to run at least once `gulp build`. Compile your library component at least once in order to be able to import it as a module into a different project. Remember that the **package.json** says that `"main": "lib/index.js"`, therefore, that location needs to exist prior to any **import** attempt.
 1. This will create a local npm link to the library with the name, which is provided in the **package.json**.
 1. Create a web part project in a **separate project folder, so not in the library project folder structure**, following the instructions from [here](https://docs.microsoft.com/sharepoint/dev/spfx/web-parts/get-started/build-a-hello-world-web-part#to-create-a-new-web-part-project). Name your web part **CorporateWebPart**.
 1. From the root of the new web part folder, run the command `npm link corporate-library`

--- a/docs/spfx/library-component-tutorial.md
+++ b/docs/spfx/library-component-tutorial.md
@@ -1,7 +1,7 @@
 ---
 title: Building solutions with the library component type in SharePoint Framework
 description: Building solutions with the library component type in SharePoint Framework
-ms.date: 2/3/2020
+ms.date: 05/15/2020
 ms.prod: sharepoint
 localization_priority: Priority
 ---


### PR DESCRIPTION
#### Category
- [x] Content fix

#### What's in this Pull Request?
In order to compile library component, we should do "gulp build" instead of "gulp serve", since library component does not have any visual appearance.