### PR TITLE
Update creating-team-manifest-manually-for-webpart.md

### DIFF
--- a/docs/spfx/web-parts/guidance/creating-team-manifest-manually-for-webpart.md
+++ b/docs/spfx/web-parts/guidance/creating-team-manifest-manually-for-webpart.md
@@ -107,6 +107,9 @@ Notice the `componentId` query parameter in the `configurationUrl`. You should n
 
 See more details around the Microsoft Teams manifest options from the [Microsoft Teams developer guidance](https://docs.microsoft.com/microsoftteams/platform/concepts/apps/apps-package).
 
+> [!IMPORTANT]
+> Everytime `/_layouts/15/TeamsLogon.aspx` is specified in the manifest, the `dest` attribute value must be URL encoded. A Non encoded value might prevent the component from loading properly in Teams.
+
 Below json structure demonstrates sample manifest file content.
 
 ```json


### PR DESCRIPTION
stated that the 'dest' parameter must be encodede

#### Category
- [X] Content fix
- [ ] New article



#### What's in this Pull Request?

Made a note in the article to specify that URLs provided in TeamsLogon.aspx MUST be encoded