### PR TITLE
App Permissions - Manage app access to this tenant

### DIFF
--- a/docs/solution-guidance/development-experience-tenant-apponly-permissions-in-sharepoint-online.md
+++ b/docs/solution-guidance/development-experience-tenant-apponly-permissions-in-sharepoint-online.md
@@ -55,6 +55,8 @@ Since you want to debug the add-in, ensure that you supply https://localhost.com
 
 Now deploy the add-in in the app catalog site.
 
+Feedback: Need to include information on the App Permissions - Manage app access to this tenant option in SharePoint Admin Center. Need more information about this. For example, will the apps discussed in this document show up under App Permissions, etc? 
+
 ### Step 5: Install your add-in in your developer site collection
 
 Navigate to the developer site and add the app. Click on **App Details**.


### PR DESCRIPTION
Under the Apps section of the SharePoint Admin Center, there is an App Permissions option. I'm not able to find much documentation around the App Permissions, what should show up here and what shouldn't. I don't know what should show up here, but seems it should be any/all apps that have access across the tenancy as opposed to site level only access. Can we elaborate on this option please, somewhere?

#### Category
- [x] Content fix
- [ ] New article
- [x] Example checked item (*delete this line*)

> For the above list, an empty checkbox is [ ] as in <kbd>[</kbd><kbd>SPACE</kbd><kbd>]</kbd>. A checked checkbox is [x] with no space between the brackets. Use the `PREVIEW` tab at the top right to preview the rendering before submitting your issue.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### Related issues:
- fixes #issuenumber
- partially #issuenumber
- mentioned in #issuenumber

> If this fixes (aka: closes) or references an issue, please reference it here. This helps maintaining the issue list as it will (1) link the PR to the issue & (2) automatically close the issue when this PR is merged in.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### What's in this Pull Request?

> Please describe the changes in this PR. Sample description or details around bugs which are being fixed.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### Guidance

> *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
> 
> *Please target your PR to 'master' branch. Released documents are in `live` branch.*
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_