### PR TITLE
Change the link in the 'see also' section

### DIFF
--- a/docs/general-development/site-collection-app-catalog.md
+++ b/docs/general-development/site-collection-app-catalog.md
@@ -126,6 +126,6 @@ Before deploying solutions to site collection app catalogs, site collection admi
 
 ## See also
 
-- [Manage the Site Collection App Catalog](https://support.office.com/article/Manage-the-Site-Collection-App-Catalog-928b9b61-a9de-4563-a7d1-6231aa9d4d19)
+- [Manage the Organizational App Catalog](https://docs.microsoft.com/en-us/sharepoint/use-app-catalog)
 - [Office 365 CLI](https://sharepoint.github.io/office365-cli?utm_source=msft_docs&utm_medium=page&utm_campaign=Use+the+site+collection+app+catalog)
 

--- a/docs/general-development/site-collection-app-catalog.md
+++ b/docs/general-development/site-collection-app-catalog.md
@@ -1,6 +1,6 @@
 ---
 title: Use the site collection app catalog
-ms.date: 05/18/2018
+ms.date: 06/05/2020
 ms.prod: sharepoint
 ms.assetid: fdf7ecb1-9951-475b-b058-3285fba77b68
 localization_priority: Priority


### PR DESCRIPTION
The link is to an article on managing the App Catalog for the Organization (the single app catalog for the tenant), not a site collection app catalog (the per site collection app catalog). I updated the link to so it is not misleading.

## Category

- [X] Content fix
- [ ] New article


## Related issues

none

## What's in this Pull Request?

A change to the link in the 'see also' section at the bottom

