### PR TITLE
Add known issue implicit auth fail no AAD roles

### DIFF
--- a/docs/spfx/use-msgraph.md
+++ b/docs/spfx/use-msgraph.md
@@ -1,7 +1,7 @@
 ---
 title: Use the MSGraphClient to connect to Microsoft Graph
 description: Use the MSGraphClient class to make calls to the Microsoft Graph REST API.
-ms.date: 01/18/2020
+ms.date: 06/11/2020
 ms.prod: sharepoint
 localization_priority: Priority
 ---
@@ -120,11 +120,11 @@ Additional permission scopes can be requested by developers and granted by tenan
 
 ### Azure AD roles with delegated authentication
 
-The MSGraphClient currently uses implicit authentication flow when requesting delegated permissions from Microsoft Graph.  As stated in [Microsoft identity platform access tokens](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens#payload-claims), the `wids` claim may not be present when using implicit authentication flow due to length concerns.  The `wids` claim contains the listing of Azure AD tenant-wide roles that have been assigned to the delegated user.
+The MSGraphClient currently uses implicit authentication flow when requesting delegated permissions from Microsoft Graph.  As stated in [Microsoft identity platform access tokens](https://docs.microsoft.com/azure/active-directory/develop/access-tokens#payload-claims), the `wids` claim may not be present when using implicit authentication flow due to length concerns.  The `wids` claim contains the listing of Azure AD tenant-wide roles that have been assigned to the delegated user.
 
 As a result, queries to Microsoft Graph endpoints that rely on Azure AD roles in addition to delegated permissions may fail due to the `wids` claim not being present.  At the time of writing this includes the following endpoints:
 
-  - [Office 365 usage reports](https://docs.microsoft.com/en-us/graph/reportroot-authorization)
+  - [Office 365 usage reports](https://docs.microsoft.com/graph/reportroot-authorization)
 
 ## See also
 

--- a/docs/spfx/use-msgraph.md
+++ b/docs/spfx/use-msgraph.md
@@ -116,6 +116,16 @@ By default, the service principal has no explicit permissions granted to access 
 
 Additional permission scopes can be requested by developers and granted by tenant administrators. For more information, see [Connect to Azure AD-secured APIs in SharePoint Framework solutions](./use-aadhttpclient.md).
 
+## Known issues
+
+### Azure AD roles with delegated authentication
+
+The MSGraphClient currently uses implicit authentication flow when requesting delegated permissions from Microsoft Graph.  As stated in [Microsoft identity platform access tokens](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens#payload-claims), the `wids` claim may not be present when using implicit authentication flow due to length concerns.  The `wids` claim contains the listing of Azure AD tenant-wide roles that have been assigned to the delegated user.
+
+As a result, queries to Microsoft Graph endpoints that rely on Azure AD roles in addition to delegated permissions may fail due to the `wids` claim not being present.  At the time of writing this includes the following endpoints:
+
+  - [Office 365 usage reports](https://docs.microsoft.com/en-us/graph/reportroot-authorization)
+
 ## See also
 
 - [Microsoft Graph](https://graph.microsoft.com)


### PR DESCRIPTION
Add a known issues section which includes mention of implicit auth calls failing when calling a Microsoft Graph endpoint that requires Azure AD roles to be assigned.   Share links to supporting documentation and Office 365 usage reports which is currently known to exhibit this behavior.

## Category

- [X ] Content fix
- [ ] New article

## Related issues

- mentioned in #5845 

## What's in this Pull Request?

Content update to include Known Issues section to document.  Call out the use of implicit authentication flow which currently does not include the "wids" claim for Azure AD roles assigned.
