### PR TITLE
Localization is only available in Workbench

### DIFF
--- a/docs/spfx/web-parts/guidance/localize-web-parts.md
+++ b/docs/spfx/web-parts/guidance/localize-web-parts.md
@@ -318,6 +318,9 @@ Another way to specify the locale to be used by the local SharePoint Workbench i
   When you open your web part's configuration, you'll see that all property pane strings are displayed in Dutch (Netherlands) rather than the default US English.
 
   ![Web part property pane string displayed in Dutch (Netherlands)](../../../images/localization-property-pane-nl-nl.png)
+  
+> [!Note]
+> The localization of the debug build is only visible in the SharePoint Workbench. For testing it in SharePoint, a production build has to be created. See the chapter "[Localization in different build types](#localization-in-different-build-types)" for further details.
 
 ## Localize web part contents
 


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

None

## What's in this Pull Request?

Contains a clarification that might help further users of the page: if you work through the article from top to bottom, the information that debug builds for SharePoint only include the default locale does not become clear until the very end. This can cause confusion when trying to preview the localization in SharePoint, if the Workbench does not work anymore due to the missing context.
