### PR TITLE
Update to the getting started docs.

### DIFF
--- a/docs/spfx/web-parts/get-started/serve-your-web-part-in-a-sharepoint-page.md
+++ b/docs/spfx/web-parts/get-started/serve-your-web-part-in-a-sharepoint-page.md
@@ -67,7 +67,7 @@ You can also follow these steps by watching this video on the SharePoint PnP You
 
 The package uses SharePoint Feature to package your web part. By default, the gulp task creates a feature for your web part.
 
-You can view the raw package contents in the **sharepoint/debug** folder. 
+You can view the raw package contents in the **sharepoint/solution/debug** folder. 
 
 The contents are then packaged into an **.sppkg** file. The package format is very similar to a SharePoint add-ins package and uses Microsoft Open Packaging Conventions to package your solution.
 


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

## What's in this Pull Request?

Update to the sharepoint/debug location of the packaged spfx solution. Change is in the docs/spfx/web-parts/get-started/serve-your-web-part-in-a-sharepoint-page file.

Current location points to **sharepoint/debug**. Gulp packages the web-part with the folder structure **sharepoint/solution/debug**.

