### PR TITLE
Fix-up markdown references to NPM packages

### DIFF
--- a/docs/spfx/extensions/get-started/build-a-hello-world-extension.md
+++ b/docs/spfx/extensions/get-started/build-a-hello-world-extension.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first SharePoint Framework Extension (Hello World part 1)
 description: Create an extension project, and then code and debug your Application Customizer.
-ms.date: 06/19/2020
+ms.date: 06/22/2020
 ms.prod: sharepoint
 localization_priority: Priority
 ms.custom: scenarios:getting-started
@@ -69,7 +69,7 @@ You can also follow the steps in this article by watching the video on the Share
 
 Open the **./src/extensions/helloWorld/HelloWorldApplicationCustomizer.ts** file.
 
-Notice that base class for the Application Customizer is imported from the **@microsoft/sp-application-base** package, which contains SharePoint framework code required by the Application Customizer.
+Notice that base class for the Application Customizer is imported from the **\@microsoft/sp-application-base** package, which contains SharePoint framework code required by the Application Customizer.
 
 The logic for your Application Customizer is contained in the `onInit()` method, which is called when the client-side extension is first activated on the page. This event occurs after `this.context` and `this.properties` are assigned. As with web parts, `onInit()` returns a promise that you can use to do asynchronous operations.
 

--- a/docs/spfx/extensions/get-started/building-simple-cmdset-with-dialog-api.md
+++ b/docs/spfx/extensions/get-started/building-simple-cmdset-with-dialog-api.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first ListView Command Set extension
 description: Create an extension project, and then code and debug your extension by using SharePoint Framework (SPFx) Extensions.
-ms.date: 06/19/2020
+ms.date: 06/22/2020
 ms.prod: sharepoint
 ms.custom: scenarios:getting-started
 ---
@@ -57,17 +57,17 @@ You can follow these steps by watching the video on the SharePoint PnP YouTube C
     ```json
     {
       "$schema": "https://developer.microsoft.com/json-schemas/spfx/command-set-extension-manifest.schema.json",
-    
+
       "id": "95688e19-faea-4ef1-8394-489bed1de2b4",
       "alias": "HelloWorldCommandSet",
       "componentType": "Extension",
       "extensionType": "ListViewCommandSet",
-    
+
       "version": "*",
       "manifestVersion": 2,
-    
+
       "requiresCustomScript": false,
-    
+
       "items": {
         "COMMAND_1": {
           "title": { "default": "Command One" },
@@ -82,7 +82,7 @@ You can follow these steps by watching the video on the SharePoint PnP YouTube C
       }
     }
     ```
-    
+
     Note the actual command definitions in the manifest file. These are the actual buttons that are exposed based on the registration target. In the default template, you find two different buttons: **Command One** and **Command Two**.
 
 > [!NOTE]
@@ -92,7 +92,7 @@ You can follow these steps by watching the video on the SharePoint PnP YouTube C
 
 Open the file **./src/extensions/helloWorld/HelloWorldCommandSet.ts**.
 
-Notice the base class for the ListView Command Set is imported from the **@microsoft/sp-listview-extensibility** package, which contains SharePoint Framework (SPFx) code required by the ListView Command Set.
+Notice the base class for the ListView Command Set is imported from the **\@microsoft/sp-listview-extensibility** package, which contains SharePoint Framework (SPFx) code required by the ListView Command Set.
 
 ```typescript
 import { override } from '@microsoft/decorators';
@@ -319,7 +319,7 @@ Possible location values that can be used with a ListView Command Set:
 
 ### Ensure that definitions are taken into account within the build pipeline
 
-Open the file **./config/package-solution.json**. 
+Open the file **./config/package-solution.json**.
 
 The **package-solution.json** file defines the package metadata as shown in the following code. To ensure that the **element.xml** file is taken into account while the solution package is created, the default scaffolding of this file is updated to include additional details for a feature definition. This feature definition is used to provision and execute the **elements.xml** file.
 

--- a/docs/spfx/extensions/get-started/using-page-placeholder-with-extensions.md
+++ b/docs/spfx/extensions/get-started/using-page-placeholder-with-extensions.md
@@ -1,7 +1,7 @@
 ---
 title: Use page placeholders from Application Customizer (Hello World part 2)
 description: Extend your Hello World extension to take advantage of page placeholders by using SharePoint Framework (SPFx) Extensions.
-ms.date: 06/19/2020
+ms.date: 06/22/2020
 ms.prod: sharepoint
 ms.custom: scenarios:getting-started
 ---
@@ -44,7 +44,7 @@ Notice that you're requesting a well-known placeholder by using the correspondin
 
 ### Modify the Application Customizer to access and modify placeholders by adding custom HTML elements
 
-1. Install the **@microsoft/sp-office-ui-fabric-core** package to enable importing from **SPFabricCore.scss**. We'll use this for defining rendering styles for our place holders.
+1. Install the **\@microsoft/sp-office-ui-fabric-core** package to enable importing from **SPFabricCore.scss**. We'll use this for defining rendering styles for our place holders.
 
     ```console
     npm install @microsoft/sp-office-ui-fabric-core
@@ -88,7 +88,7 @@ Notice that you're requesting a well-known placeholder by using the correspondin
     ```
 
 1. In Visual Studio Code (or your preferred IDE), open **./src/extensions/helloWorld/HelloWorldApplicationCustomizer.ts.**
-1. Add the `PlaceholderContent` and `PlaceholderName` to the import statement from **@microsoft/sp-application-base** by updating the import statement as follows:
+1. Add the `PlaceholderContent` and `PlaceholderName` to the import statement from **\@microsoft/sp-application-base** by updating the import statement as follows:
 
     ```typescript
     import {

--- a/docs/spfx/office-addins-create.md
+++ b/docs/spfx/office-addins-create.md
@@ -1,7 +1,7 @@
 ---
 title: Create Outlook add-ins using SharePoint Framework
 description: Create Outlook Web App add-ins using SharePoint Framework
-ms.date: 06/18/2020
+ms.date: 06/22/2020
 ms.prod: sharepoint
 localization_priority: Normal
 ---
@@ -40,7 +40,7 @@ You'll need to deploy the solution to tenant using the **tenant scoped deploymen
 
 ## Use Office JavaScript SDK (Office.js) in the web part code
 
-Before you can use the Office JavaScript SDK in your code, you'll need to include correct types for the solution. You can install latest types by adding **@types/office-js** package from the npm to your solution with following command:
+Before you can use the Office JavaScript SDK in your code, you'll need to include correct types for the solution. You can install latest types by adding **\@types/office-js** package from the npm to your solution with following command:
 
 ```console
 npm install @types/office-js --save-dev

--- a/docs/spfx/web-parts/basics/integrate-with-property-pane.md
+++ b/docs/spfx/web-parts/basics/integrate-with-property-pane.md
@@ -1,7 +1,7 @@
 ---
 title: Make your SharePoint client-side web part configurable
 description: Configure custom properties in your web part by using the property pane.
-ms.date: 06/16/2020
+ms.date: 06/22/2020
 ms.prod: sharepoint
 localization_priority: Priority
 ---
@@ -65,7 +65,7 @@ The following field types are supported:
 - Toggle
 - Custom
 
-The field types are available as modules in **@microsoft/sp-property-pane**. You need to import the objects into a module before you can use them in your web parts:
+The field types are available as modules in **\@microsoft/sp-property-pane**. You need to import the objects into a module before you can use them in your web parts:
 
 ```typescript
 import {
@@ -80,7 +80,7 @@ import {
 ```
 
 > [!NOTE]
-> The property pane objects were split out into their own module, **@microsoft/sp-property-pane**, in the SharePoint Framework v1.9 release. Prior to this, they were included in the **@microsoft/sp-webpart-base** module.
+> The property pane objects were split out into their own module, **\@microsoft/sp-property-pane**, in the SharePoint Framework v1.9 release. Prior to this, they were included in the **\@microsoft/sp-webpart-base** module.
 
 Every field type method is defined as follows, taking `PropertyPaneTextField` as an example:
 

--- a/docs/spfx/web-parts/get-started/build-a-hello-world-web-part.md
+++ b/docs/spfx/web-parts/get-started/build-a-hello-world-web-part.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first SharePoint client-side web part (Hello World part 1)
 description: Create a new web part project and preview it.
-ms.date: 06/15/2020
+ms.date: 06/22/2020
 ms.prod: sharepoint
 localization_priority: Priority
 ms.custom: scenarios:getting-started
@@ -217,7 +217,7 @@ Notice that we're executing an HTML escape on the property's value to ensure a v
 
 Let's now add a few more properties to the property pane: a checkbox, a drop-down list, and a toggle. We first start by importing the respective property pane fields from the framework.
 
-1. Scroll to the top of the file and add the following to the import section from `@microsoft/sp-property-pane`:
+1. Scroll to the top of the file and add the following to the import section from **\@microsoft/sp-property-pane**:
 
     ```typescript
     PropertyPaneCheckbox,

--- a/docs/spfx/web-parts/get-started/use-fabric-react-components.md
+++ b/docs/spfx/web-parts/get-started/use-fabric-react-components.md
@@ -1,7 +1,7 @@
 ---
 title: Use Office UI Fabric React components in your SharePoint client-side web part
 description: Build a web part that uses the DocumentCard component of Office UI Fabric React.
-ms.date: 06/16/2020
+ms.date: 06/22/2020
 ms.prod: sharepoint
 localization_priority: Priority
 ms.custom: scenarios:getting-started
@@ -28,7 +28,7 @@ The transition from Office UI Fabric to Fluent UI, and the respective React comp
 
 SharePoint Framework (SPFx) packages currently reference the original Office UI Fabric NPM Packages. These packages are currently supported & will continue to work.
 
-The primary Fluent UI React package, **@fluentui/react**, simply exports components from the **office-ui-fabric-react** package used in SharePoint Framework projects. At this time, you should continue to use the **office-ui-fabric-react** package in your SharePoint Framework projects.
+The primary Fluent UI React package, **\@fluentui/react**, simply exports components from the **office-ui-fabric-react** package used in SharePoint Framework projects. At this time, you should continue to use the **office-ui-fabric-react** package in your SharePoint Framework projects.
 
 This page will continue to refer to the Office UI Fabric packages until Microsoft recommends switching to the Fluent UI packages. The documentation links on this page may point to the Fluent UI documentation but it applies to the Office UI Fabric as well.
 
@@ -50,7 +50,7 @@ This page will continue to refer to the Office UI Fabric packages until Microsof
     cd documentcardexample-webpart
     ```
 
-1. Make sure you have the latest version of `@microsoft/generator-sharepoint` installed and create a new web part by running the Yeoman SharePoint generator:
+1. Make sure you have the latest version of **\@microsoft/generator-sharepoint** installed and create a new web part by running the Yeoman SharePoint generator:
 
     ```console
     yo @microsoft/sharepoint
@@ -70,7 +70,7 @@ This page will continue to refer to the Office UI Fabric packages until Microsof
 
     At this point, Yeoman installs the required dependencies and scaffolds the solution files.
 
-    Starting with SPFx v1.8.2 version, Yeoman will include the recommended `@microsoft/sp-office-ui-fabric-core` package version to your solution when you select the **React** as the desired web framework.
+    Starting with SPFx v1.8.2 version, Yeoman will include the recommended **\@microsoft/sp-office-ui-fabric-core** package version to your solution when you select the **React** as the desired web framework.
 
     > [!NOTE]
     > Starting with SPFx v1.8, you can use either Office UI Fabric React v5 or v6. Each version of SPFx upgrades the version of Office UI Fabric React in new projects. For example:


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- fixes #5921

## What's in this Pull Request?

- NPM packages should be bold, not use inline code formatting
- need to escape the `@` for package references
