### PR TITLE
Update markdown fenced code language errors

### DIFF
--- a/docs/apis/alm-api-for-spfx-add-ins.md
+++ b/docs/apis/alm-api-for-spfx-add-ins.md
@@ -147,7 +147,7 @@ Add-PnPApp -Path ./sharepoint-solution-package.sppkg
 
 # [Office 365 CLI](#tab/o365cli)
 
-```shell
+```console
 spo app add --filePath ./sharepoint-solution-package.sppkg
 ```
 
@@ -206,7 +206,7 @@ Publish-PnPApp -Identity xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 
 # [Office 365 CLI](#tab/o365cli)
 
-```shell
+```console
 spo app deploy --id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 ```
 
@@ -254,7 +254,7 @@ Unpublish-PnPApp -Identity xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 
 # [Office 365 CLI](#tab/o365cli)
 
-```shell
+```console
 spo app retract --id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 ```
 
@@ -290,7 +290,7 @@ Remove-PnPApp -Identity xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 
 # [Office 365 CLI](#tab/o365cli)
 
-```shell
+```console
 spo app remove --id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 ```
 
@@ -373,7 +373,7 @@ Get-PnPApp
 
 # [Office 365 CLI](#tab/o365cli)
 
-```shell
+```console
 spo app list
 ```
 
@@ -435,7 +435,7 @@ Get-PnPApp -Identity xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 
 # [Office 365 CLI](#tab/o365cli)
 
-```shell
+```console
 spo app get --id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 ```
 
@@ -480,7 +480,7 @@ Install-PnPApp -Identity xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 
 # [Office 365 CLI](#tab/o365cli)
 
-```shell
+```console
 spo app install --id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx --siteUrl <url>
 ```
 
@@ -528,7 +528,7 @@ Update-PnPApp -Identity xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 
 # [Office 365 CLI](#tab/o365cli)
 
-```shell
+```console
 spo app upgrade --id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx --siteUrl <url>
 ```
 
@@ -575,7 +575,7 @@ Uninstall-PnPApp -Identity xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 
 # [Office 365 CLI](#tab/o365cli)
 
-```shell
+```console
 spo app uninstall --id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx --siteUrl <url>
 ```
 

--- a/docs/apis/export-amr-api.md
+++ b/docs/apis/export-amr-api.md
@@ -304,7 +304,7 @@ Suggestion:
 
     **Sample source code**
 
-    ```shell
+    ```console
     $site = get-spsite https://test.sharepoint.com  # get site
     $web = get-spweb https://test.sharepoint.com  # get web
     $list = $web.GetList("Shared Documents") # get the document library under this web

--- a/docs/general-development/how-to-back-up-and-restore-a-search-service-application-in-sharepoint-using.md
+++ b/docs/general-development/how-to-back-up-and-restore-a-search-service-application-in-sharepoint-using.md
@@ -144,7 +144,7 @@ The following procedures are intended to help developers with creating a backup/
 1. Perform backups of the SSA databases and the index by following these steps:
 1. On the server with the SSA databases, execute the following command at a command line, where  _destination backup folder_ is the full path of the folder for the backup files, _backup log file_ is the full path and name of the backup log file, and _SSA manifest file_ is the path and file name of the SSA manifest file.
 
-    ```shell
+    ```console
     betest.exe /v /b /d "destination backup folder" /s "backup log file" /x "SSA manifest file"
     ```
 
@@ -157,7 +157,7 @@ The following procedures are intended to help developers with creating a backup/
 1. Verify that the file is created.
 1. On each server that has an index component, execute the following at a command line, where  _destination backup folder_ is the full path of the folder for the backup files, _backup log file_ is the full path and name of the backup log file, and _index manifest file_ is the path and file name of the index manifest.
 
-    ```shell
+    ```console
     betest.exe /v /b /d "destination backup folder" /s "backup log file" /x "index manifest file"
     ```
 
@@ -177,7 +177,7 @@ The following procedures are intended to help developers with creating a backup/
 
 1. On the same server, execute the following at a command line to restore the SSA databases, where  _destination backup folder_ is the full path of the folder for the backup files, _backup log file_ is the full path and name of the backup log file, and _SSA manifest file_ is the path and file name of the SSA manifest file.
 
-    ```shell
+    ```console
     betest.exe /v /r /d "destination backup folder" /s "backup log file" /x SSA_manifest_file
     ```
 
@@ -209,7 +209,7 @@ The following procedures are intended to help developers with creating a backup/
 
 1. On the same servers, execute the following at a command line, where  _index manifest file_ is the path and file name of the index manifest that you created in the backup procedure.
 
-    ```shell
+    ```console
     betest.exe /v /r /d "destination backup folder" /s "backup log file" /x "index manifest file"
     ```
 

--- a/docs/general-development/site-collection-app-catalog.md
+++ b/docs/general-development/site-collection-app-catalog.md
@@ -83,7 +83,7 @@ Add-PnPSiteCollectionAppCatalog -site https://contoso.sharepoint.com/sites/marke
 
 Alternatively, use the `spo site appcatalog add` command if you are using the Office 365 CLI:
 
-```shell
+```console
 spo site appcatalog add --url https://contoso.sharepoint.com/sites/marketing
 ```
 
@@ -111,7 +111,7 @@ Remove-PnPSiteCollectionAppCatalog -site https://contoso.sharepoint.com/sites/ma
 
 Alternatively, use the `spo site appcatalog remove` command if you are using the Office 365 CLI
 
-```shell
+```console
 spo site appcatalog remove --url https://contoso.sharepoint.com/sites/marketing
 ```
 

--- a/docs/general-development/social-feed-rest-api-reference-for-sharepoint.md
+++ b/docs/general-development/social-feed-rest-api-reference-for-sharepoint.md
@@ -3048,7 +3048,7 @@ The following response example represents the unlocked thread. The **Attributes*
 > [!NOTE]
 > The values of thread and post **Id** properties are too long to send in a URL, so you have to send them in the request body. As a result, even read-only operations that are logically **GET** requests must be sent as **POST** requests. For example, to get a thread, you have to send a **POST** request and pass the thread **Id** as an entity in the request body.
 
-```js
+```javascript
 var endpoint = siteUrl + '/_api/social.feed/post';
 var postId = '1.655c70c348374d48839daabc24a360f0.82baa3bdfa2f481a8185802eb9c6c6cd.5d227a6fa3894f0c9dde26876b71d619.0c37852b34d0418e91c62ac25af4be5b.4316bdaa94bf4984be5dfea1ba96954e.26.26.S-1-5-21-2127521184-1604012920-1887927527-66602';
 
@@ -3083,7 +3083,7 @@ $.ajax({
 
 
 
-```js
+```javascript
 var endpoint = <site url> + '/_api/social.feed/my/feed/post';
 var postContent = 'Posted with REST.';
 

--- a/docs/solution-guidance/Localize-UI-elements-sample-app-for-SharePoint.md
+++ b/docs/solution-guidance/Localize-UI-elements-sample-app-for-SharePoint.md
@@ -119,7 +119,7 @@ The following figure shows the start page for Scenario 1.
 
 The **AddJSLink** method is part of the JavaScriptExtensions.cs file in **OfficeDevPnP.Core**. **AddJSLink** requires that you supply a string representing the identifier to assign to the custom action, and a string containing a semicolon delimited list of URLs to the JavaScript files that you want to add to the host web. Note that this code sample adds a reference to Scripts\scenario1.js, which adds a status bar message to the host web.
 
-```js
+```javascript
 protected void btnSubmit_Click(object sender, EventArgs e)
         {
             var spContext = SharePointContextProvider.Current.GetSharePointContext(Context);
@@ -135,7 +135,7 @@ protected void btnSubmit_Click(object sender, EventArgs e)
 > [!NOTE] 
 > SharePoint uses Minimal Download Strategy to reduce the amount of data the browser downloads when users navigate between pages on a SharePoint site. In scenario1.js, the following code ensures that whether Minimal Download Strategy is used on your SharePoint site, the **RemoteManager_Inject** method is always called to run the JavaScript code to add the status bar message to the host web. For more information, see [Minimal Download Strategy overview](../general-development/minimal-download-strategy-overview.md).
 > 
-> ```js
+> ```javascript
     if ("undefined" != typeof g_MinimalDownload &amp;&amp; g_MinimalDownload &amp;&amp; (window.location.pathname.toLowerCase()).endsWith("/_layouts/15/start.aspx") &amp;&amp; "undefined" != typeof asyncDeltaManager) {
         // Register script for MDS if possible.
         RegisterModuleInit("scenario1.js", RemoteManager_Inject); //MDS registration
@@ -150,7 +150,7 @@ protected void btnSubmit_Click(object sender, EventArgs e)
 > [!NOTE] 
 > Some JavaScript files may depend on other JavaScript files to be loaded first before they can run and complete successfully. The following code construct from **RemoteManager_Inject** uses the **loadScript** function in scenario1.js to first load jQuery, and then continue running the remaining JavaScript code.
 >
-> ```js
+> ```javascript
     var jQuery = "https://ajax.aspnetcdn.com/ajax/jQuery/jquery-2.0.2.min.js";
         // Load jQuery first, and then continue running the rest of the code.
         loadScript(jQuery, function () {
@@ -195,7 +195,7 @@ Similar to Scenario 1, **btnSubmit\_Click** in scenario2.aspx.cs calls **AddJsLi
     
 - Replaces **my quicklaunch entry** with the value of the **quickLauch\_Scenario2** variable read from the JavaScript resource file.
 
-```js
+```javascript
 function RemoteManager_Inject() {
 
     var jQuery = "https://ajax.aspnetcdn.com/ajax/jQuery/jquery-2.0.2.min.js";

--- a/docs/solution-guidance/create-ux-controls-by-using-sharepoint-provider-hosted-add-ins.md
+++ b/docs/solution-guidance/create-ux-controls-by-using-sharepoint-provider-hosted-add-ins.md
@@ -51,7 +51,7 @@ The Scripts folder of the Core.PeoplePickerWeb project contains app.js and peopl
 
 The app.js file then creates and configures a people picker control.
 
-```js
+```javascript
 //Make a people picker control.
 //1. context = SharePoint Client Context object
 //2. $('#spanAdministrators') = SPAN that will 'host' the people picker control
@@ -70,7 +70,7 @@ peoplePicker.Initialize();
 
 The people picker control queries the **ClientPeoplePickerWebServiceInterface** object in the JSOM library to initiate searches for users whose names match the character strings entered.
 
-```js
+```javascript
 if (searchText.length >= parent.GetMinimalCharactersBeforeSearching()) {
                             resultDisplay = 'Searching...';
                             if (typeof resultsSearching != 'undefined') {
@@ -122,7 +122,7 @@ When you choose the **Setup term store** button, the add-in:
     
 The following code in the **TaxonomyHelper** class verifies that the required languages are enabled, and if they're not, it enables them.
 
-```js
+```javascript
 var languages = new int[] { 1031, 1033, 1036, 1053 };
             Array.ForEach(languages, l => { 
                 if (!termStore.Languages.Contains(l)) 
@@ -142,7 +142,7 @@ termGroup = termStore.CreateGroup("Taxonomy Navigation", groupId);
 
 Finally, the following code in the same **TaxonomyHelper** class creates each new term, along with labels for the German, French, and Swedish languages. It also sets a value for the **\_Sys\_Nav\_SimpleLinkUrl** property, which is equivalent to the **Simple Link or Header** property in the Term Store Management Tool. In this case, the URL for each term points back to the root site.
 
-```js
+```javascript
 var term = termSet.CreateTerm(termName, 1033, Guid.NewGuid());
 term.CreateLabel(termNameGerman, 1031, false);
 term.CreateLabel(termNameFrench, 1036, false);
@@ -156,7 +156,7 @@ Next, the add-in inserts the topnav.js file into the root folder of the host sit
 
 The following code in the topnav.js file uses JSOM to check for the user's preferred language.
 
-```js
+```javascript
 var targetUser = "i:0#.f|membership|" + _spPageContextInfo.userLoginName;
         context = new SP.ClientContext.get_current();
 var peopleManager = new SP.UserProfiles.PeopleManager(context);
@@ -167,7 +167,7 @@ var userProperty = peopleManager.getUserProfilePropertyFor(targetUser, "SPS-MUIL
 
 The add-in then determines whether the user's language preference matches one of the enabled languages. If it finds a match, the following code gets the terms and the associated labels for the user's preferred language.
 
-```js
+```javascript
 while (termEnumerator.moveNext()) {
     var currentTerm = termEnumerator.get_current();
     var label = currentTerm.getDefaultLabel(lcid);
@@ -181,7 +181,7 @@ while (termEnumerator.moveNext()) {
 
 Finally, the following code in the topnav.js file inserts links that contain the terms into the top navigational element of the host site.
 
-```js
+```javascript
 html += "<ul style='margin-top: 0px; margin-bottom: 0px;'>"
         for (var i in termItems) {
             var term = termItems[i];
@@ -230,7 +230,7 @@ The Scripts folder of the Core.TaxonomyPicker project contains app.js and taxono
 
 The app.js file then creates and configures a taxonomy picker control.
 
-```js
+```javascript
 // Load scripts for calling taxonomy APIs.
                     $.getScript(layoutsRoot + 'init.js',
                         function () {
@@ -247,7 +247,7 @@ The app.js file then creates and configures a taxonomy picker control.
 
 The taxonomy picker control uses the following code to open a **TaxonomySession** instance in the JSOM to load all the terms from the term store.
 
-```js
+```javascript
 // Get the taxonomy session by using CSOM.
             var taxSession = SP.Taxonomy.TaxonomySession.getTaxonomySession(spContext);
             //Use the default term store...this could be extended here to support additional term stores.

--- a/docs/solution-guidance/customize-the-ux-by-using-sharepoint-provider-hosted-add-ins.md
+++ b/docs/solution-guidance/customize-the-ux-by-using-sharepoint-provider-hosted-add-ins.md
@@ -43,7 +43,7 @@ This sample uses the default site pages library and existing out-of-the-box layo
 
 The sample code for the first scenario determines whether you already created the wiki page. If not, it adds the file to the site pages library and returns its URL.
 
-```js
+```javascript
 var newpage = pageLibrary.RootFolder.Files.AddTemplateFile(newWikiPageUrl, TemplateFileType.WikiPage);
 ctx.Load(newpage);
 ctx.ExecuteQuery();
@@ -54,7 +54,7 @@ wikiPageUrl = String.Format("sitepages/{0}", wikiPageName);
 
 In both scenarios, the sample adds the HTML entered via the text box on the start page by using the **AddHtmlToWikiPage** method in a helper class named **LabHelper**. This method inserts the HTML from the form inside the _WikiField_ field of the wiki page.
 
-```js
+```javascript
 public void AddHtmlToWikiPage(ClientContext ctx, Web web, string folder, string html, string page)
         {
             Microsoft.SharePoint.Client.Folder pagesLib = web.GetFolderByServerRelativeUrl(folder);
@@ -94,7 +94,7 @@ public void AddHtmlToWikiPage(ClientContext ctx, Web web, string folder, string 
 
 The sample code for the second scenario creates a new **WebPartEntity** instance. It then uses methods in a helper class to populate the web part with XML. The XML displays a promoted links list, including both [http://www.bing.com](http://www.bing.com) and the home page of the [Office 365 Developer Patterns and Practices](https://github.com/SharePoint/PnP) GitHub repository.
 
-```js
+```javascript
 WebPartEntity wp2 = new WebPartEntity();
 wp2.WebPartXml = new LabHelper().WpPromotedLinks(linksID, string.Format("{0}/Lists/{1}", 
                                                                 Request.QueryString["SPHostUrl"], "Links"), 
@@ -121,7 +121,7 @@ The helper code displays the promoted links with a table inside an **XsltListVie
 
 The **WpPromotedLinks** object on the **LabHelper** instance contains XML that defines the appearance of the web part that will be embedded into the wiki page. The **AddWebPartToWikiPage** method then inserts the newly defined web part inside a new `div` tag on the wiki page.
 
-```js
+```javascript
 XmlDocument xd = new XmlDocument();
             xd.PreserveWhitespace = true;
             xd.LoadXml(wikiField);
@@ -192,7 +192,7 @@ The [Core.Dialog](https://github.com/SharePoint/PnP/tree/dev/Samples/Core.Dialog
 
 The start page is the page that appears in the dialog box. To handle any differences in display given the display context (dialog box versus full-page), the add-in determines whether it's being displayed in a dialog box. It does this by using a query string parameter that is passed along with the links that start the dialog boxes.
 
-```js
+```javascript
 private string SetIsDlg(string isDlgValue)
         {
             var urlParams = HttpUtility.ParseQueryString(Request.QueryString.ToString());
@@ -207,7 +207,7 @@ The start page UI presents two options for creating links to the dialog box, alo
 
 When you choose the **Add menu item** button, the add-in creates a **CustomActionEntity** object that starts the dialog box. It then uses the [OfficeDevPnP Core extension](https://github.com/SharePoint/PnP-Sites-Core/tree/master/Core/OfficeDevPnP.Core) method named **AddCustomAction** to add the new custom action to the **Site Settings** menu.
 
-```js
+```javascript
 StringBuilder modelDialogScript = new StringBuilder(10);
 modelDialogScript.Append("javascript:var dlg=SP.UI.ModalDialog.showModalDialog({url: '");
 modelDialogScript.Append(String.Format("{0}", SetIsDlg("1")));
@@ -232,7 +232,7 @@ cc.Web.AddCustomAction(customAction);
 
 The **AddCustomAction** method adds the custom action to the **UserCustomActions** collection that is associated with the SharePoint site.
 
-```js
+```javascript
 var newAction = existingActions.Add();
             newAction.Description = customAction.Description;
             newAction.Location = customAction.Location;
@@ -261,7 +261,7 @@ var newAction = existingActions.Add();
 
 When you choose the **Add page with Script Editor web part** button, the add-in uses the methods **AddWikiPage** and **AddWebPartToWikiPage** to create a wiki page inside the site pages library and add a configured Script Editor web part to the page.
 
-```js
+```javascript
 string scenario1Page = String.Format("scenario1-{0}.aspx", DateTime.Now.Ticks);
 string scenario1PageUrl = cc.Web.AddWikiPage("Site Pages", scenario1Page);
 cc.Web.AddLayoutToWikiPage("SitePages", WikiPageLayout.OneColumn, scenario1Page);
@@ -276,7 +276,7 @@ cc.Web.AddWebPartToWikiPage("SitePages", scriptEditorWp, scenario1Page, 1, 1, fa
 
 The **AddWikiPage** method loads the site pages library. If the wiki page specified by the add-in [OfficeDevPnP Core](https://github.com/SharePoint/PnP-Sites-Core/tree/master/Core/OfficeDevPnP.Core) doesn't already exist, it creates the page.
 
-```js
+```javascript
 public static string AddWikiPage(this Web web, string wikiPageLibraryName, string wikiPageName)
         {
             string wikiPageUrl = "";
@@ -313,7 +313,7 @@ public static string AddWikiPage(this Web web, string wikiPageLibraryName, strin
 
 The **AddWebPartToWikiPage** method inserts the newly defined web part inside a new `<div>` tag on the wiki page. It then uses JSOM and the cross-domain library to retrieve the information that populates the list of SharePoint lists on the host web.
 
-```js
+```javascript
 function printAllListNamesFromHostWeb() {
         var context;
         var factory;
@@ -345,7 +345,7 @@ The sample's start page prompts you to add one of three strings (XX, YY, or ZZ) 
 
 The add-in has already deployed three images and a SharePoint list that contains titles and URLs for each image, along with an additional field that ties each image to one of the three strings. After you choose the **Inject customization** button, the add-in embeds the personalize.js file into the user custom actions collection.
 
-```js
+```javascript
 public void AddPersonalizeJsLink(ClientContext ctx, Web web)
         {
             string scenarioUrl = String.Format("{0}://{1}:{2}/Scripts", this.Request.Url.Scheme,
@@ -394,7 +394,7 @@ public void AddPersonalizeJsLink(ClientContext ctx, Web web)
 
 Because SharePoint team sites by default use the [Minimal Download Strategy (MDS)](../general-development/minimal-download-strategy-overview.md), the code in the personalize.js file first attempts to register itself with MDS. This way, when you load the page that contains the JavaScript, the MDS engine starts the main function (**RemoteManager_Inject**). If MDS is disabled, this function starts right away.
 
-```js
+```javascript
 // Register script for MDS, if possible.
 RegisterModuleInit("personalize.js", RemoteManager_Inject); //MDS registration
 RemoteManager_Inject(); //non-MDS run
@@ -424,7 +424,7 @@ function RemoteManager_Inject() {
 
 The **personalizeIt()** function checks HTML5 local storage before it looks up user profile information. If it goes to user profile information, it stores the information that it retrieves in HTML5 local storage.
 
-```js
+```javascript
 function personalizeIt() {
     clientContext = SP.ClientContext.get_current();
 
@@ -483,7 +483,7 @@ function personalizeIt() {
 
 The personalize.js file also contains code that checks to determine whether the local storage key has expired. This isn't built into HTML5 local storage.
 
-```js
+```javascript
 // Check to see if the key has expired
 function isKeyExpired(TimeStampKey) {
 
@@ -525,7 +525,7 @@ When you start the sample, the start page prompts you to provision all the sampl
 
 When you choose **Provision Samples**, the add-in deploys an image as well as all the SharePoint lists, list views, list items, forms, and JavaScript files that are used in each sample. The add-in creates a folder named JSLink-Samples in the Style Library, and then uploads the JavaScript files into that folder. The **UploadFileToFolder** method does the work of uploading and checking in each JavaScript file.
 
-```js
+```javascript
 public static void UploadFileToFolder(Web web, string filePath, Folder folder)
         {
             using (FileStream fs = new FileStream(filePath, FileMode.Open))
@@ -555,7 +555,7 @@ Sample 1 shows how to apply formatting to a list column based on the field value
 
 The following JavaScript overrides the default field display and creates a new display template for the **Priority** list field. The technique in the anonymous function that loads the contextual information about the field whose display you want to override is used in all the samples.
 
-```js
+```javascript
 (function () {
 
     // Create object that has the context information about the field that you want to render differently.
@@ -599,7 +599,7 @@ Sample 2 shows you how to truncate long text stored in the **Body** field of an 
 
 The following JavaScript shortens the **Body** field text and causes the full text to appear as a popup via the **title** attribute on the **span** tag.
 
-```js
+```javascript
 function bodyFiledTemplate(ctx) {
 
     var bodyValue = ctx.CurrentItem[ctx.CurrentFieldSchema.Name];
@@ -631,7 +631,7 @@ Sample 3 shows you how to display an image next to a document name inside a docu
 
 The following JavaScript checks the **Confidential** field value and then customizes the **Name** field display based on the value of another field. The sample uses the image that is uploaded when you choose **Provision Samples**. 
 
-```js
+```javascript
 function linkFilenameFiledTemplate(ctx) {
 
     var confidential = ctx.CurrentItem["Confidential"];
@@ -662,7 +662,7 @@ Sample 4 shows you how to display a bar chart in the **% Complete** field of a t
 
 The following code creates the bar chart display and associates it with the view and display forms (**percentCompleteViewFiledTemplate**) and then with the new and edit forms (**percentCompleteEditFiledTemplate**).
 
-```js
+```javascript
 // This function provides the rendering logic for View and Display forms.
 function percentCompleteViewFiledTemplate(ctx) {
 
@@ -701,7 +701,7 @@ Sample 5 shows you how to change the rendering template for a list view. This vi
 
 The following code sets up the template and registers it with the list template. It sets up the overall layout, and then uses the **OnPostRender** event handler to register the JavaScript function that executes when the list is rendered. This function associates the event with the CSS and event handling that implements the accordion functionality.
 
-```js
+```javascript
 (function () {
 
     // jQuery library is required in this sample.
@@ -756,7 +756,7 @@ Sample 6 shows you how to use regular expressions to validate field values suppl
 
 The following code sets up the template with a placeholder for displaying the error message and registers the callback functions that fire whenever the user tries to submit the forms. The first callback returns the value of the **Email** column, and the second callback uses regular expressions to validate the string value.
 
-```js
+```javascript
 function emailFiledTemplate(ctx) {
 
     var formCtx = SPClientTemplates.Utility.GetFormContextForCurrentField(ctx);
@@ -814,7 +814,7 @@ Sample seven shows you how to make list item edit form fields read-only. The rea
 
 The following code example modifies the **Title**, **AssignedTo**, and **Priority** fields in the list item edit form so that they show the field values only with no editing controls. The code shows how to handle the parsing requirements for different field types.
 
-```js
+```javascript
 function readonlyFieldTemplate(ctx) {
 
     // Reuse SharePoint JavaScript libraries.
@@ -922,7 +922,7 @@ This sample deploys as the edit and new form for a list called **CSR-Hide-Contro
 
 The following code finds the **Predecessors** field in the HTML of the form and hides it. The field remains present in the HTML, but the user can't see it in the browser.
 
-```js
+```javascript
 (function () {
 
     // jQuery library is required in this sample.
@@ -968,7 +968,7 @@ An add-in script part is like a web part in that you can add it to a SharePoint 
 
 The start page includes a **Run Scenario** button that deploys the add-in script part to the Web Part Gallery. The following code example constructs a **FileCreationInformationObject** instance that contains the contents of the .webpart file and then uploads the new file into the Web Part Gallery. Note that you can also run this code automatically when the add-in part installs or as part of the site collection provisioning process.
 
-```js
+```javascript
 var spContext = SharePointContextProvider.Current.GetSharePointContext(Context);
 using (var clientContext = spContext.CreateUserClientContextForSPHost())
 {
@@ -1014,7 +1014,7 @@ After you finish this step, you can locate the **User profile information** add-
 
 When you view the add-in script part in edit mode, you'll see that it embeds the JavaScript file that is running remotely. The userprofileinformation.js script uses the JSON to get user profile information from the host site. 
 
-```js
+```javascript
 function sharePointReady() {
   clientContext = SP.ClientContext.get_current();
 
@@ -1080,7 +1080,7 @@ The sample displays this user's information on the page. It also adds a page, al
 
 The sample adds a new page layout by uploading a file to the Master Page Gallery and assigning it the page layout content type. The following code takes the path to a *.aspx file (which you can deploy as a resource in your Visual Studio project) and adds it as a page layout in the Master Page Gallery.
 
-```js
+```javascript
 // Get the path to the file that you are about to deploy.
             List masterPageGallery = web.GetCatalog((int)ListTemplateType.MasterPageCatalog);
             Folder rootFolder = masterPageGallery.RootFolder;
@@ -1139,7 +1139,7 @@ Scenario 2 shows you how to deploy and set master pages and themes for the host 
 
 The sample adds a new master page by uploading a *.master file to the Master Page Gallery and assigning it the master page content type. The following code takes the path to a *.master file (which you can deploy as a resource in your Visual Studio project) and adds it as a master page in the Master Page Gallery.
 
-```js
+```javascript
 string fileName = Path.GetFileName(sourceFilePath);
 
             // Get the path to the file that you are about to deploy.
@@ -1191,7 +1191,7 @@ string fileName = Path.GetFileName(sourceFilePath);
 
 The next step is to set the URL of the new master page as the value for both the **MasterUrl** and **CustomMasterUrl** properties of the **Web** object that represents the site. The sample handles this with a single method that fetches the URL of the new master page in the Master Page Gallery and then assigns that value to the **Web.MasterUrl** and **Web.CustomMasterUrl** properties.
 
-```js
+```javascript
 // Assign master page to the host web.
                 clientContext.Web.SetMasterPagesForSiteByName("contoso.master", "contoso.master");
 
@@ -1201,7 +1201,7 @@ The next step is to set the URL of the new master page as the value for both the
 
 When you choose **Deploy theme and use it**, the sample deploys and applies a custom theme to the host site. The sample sets the color palette, background image, and font scheme of the theme by adding a new theme with those values (which you can deploy as resources inside your Visual Studio project) to the Theme Gallery. The following code creates the new theme.
 
-```js
+```javascript
 List themesOverviewList = web.GetCatalog((int)ListTemplateType.DesignCatalog);
            web.Context.Load(themesOverviewList);
            web.Context.ExecuteQuery(); 
@@ -1230,7 +1230,7 @@ List themesOverviewList = web.GetCatalog((int)ListTemplateType.DesignCatalog);
 
 The next step is to set this new theme as the theme for the site. The following code does this by fetching the theme from the Theme Gallery and then applying its values to the host site.
 
-```js
+```javascript
  CamlQuery query = new CamlQuery();
                 // Find the theme by themeName.
                 string camlString = string.Format(CAML_QUERY_FIND_BY_FILENAME, themeName);
@@ -1279,7 +1279,7 @@ Scenario 3 shows you how to limit the options that users have when they apply te
 
 The sample sets both the default and available page layouts by passing the associated *.aspx files to methods to extension methods, as shown in the code.
 
-```js
+```javascript
                 List<string> pageLayouts = new List<string>();
                 pageLayouts.Add("ContosoLinksBelow.aspx");
                 pageLayouts.Add("ContosoLinksRight.aspx");
@@ -1294,7 +1294,7 @@ The sample sets both the default and available page layouts by passing the assoc
 
 The sample sets the available site templates by doing something similar. In this case, it passes the **WebTemplateEntity** instances that define each site template to an extension method called **SetAvailableWebTemplates**.
 
-```js
+```javascript
 List<WebTemplateEntity> templates = new List<WebTemplateEntity>();
                 templates.Add(new WebTemplateEntity() { LanguageCode = "1035", TemplateName = "STS#0" });
                 templates.Add(new WebTemplateEntity() { LanguageCode = "", TemplateName = "STS#0" });
@@ -1309,7 +1309,7 @@ All three of these extension methods&mdash;**SetAvailablePageLayouts**, **SetDef
 
 Of the three methods, **SetAvailableWebTemplates** shows the full pattern.
 
-```js
+```javascript
 public static void SetAvailableWebTemplates(this Web web, List<WebTemplateEntity> availableTemplates)
         {
             string propertyValue = string.Empty;

--- a/docs/solution-guidance/implement-a-sharepoint-site-classification-solution.md
+++ b/docs/solution-guidance/implement-a-sharepoint-site-classification-solution.md
@@ -233,7 +233,7 @@ You can add an indicator to a site page to show its classification. The Core.Sit
 
 The following method is defined in the Core.SiteClassificationWeb project, scripts, and classifier.js. The images are stored in a Microsoft Azure website. You will have to change the hard-coded URLs to match your environment.
 
-```js
+```javascript
 function setClassifier() {
     if (!classified)
     {

--- a/docs/solution-guidance/improve-performance-in-sharepoint-provider-hosted-add-ins.md
+++ b/docs/solution-guidance/improve-performance-in-sharepoint-provider-hosted-add-ins.md
@@ -25,7 +25,7 @@ The app.js file, which is located in the Scripts folder of the web project, defi
 
 The following function sets the cookie and its expiration date.
 
-```js
+```javascript
 function setCookie(key, value, expiry, path, domain, secure) {
     var todaysDate = new Date();
     todaysDate.setTime(todaysDate.getTime());
@@ -58,7 +58,7 @@ The start page of the HTML5 local storage sample displays information from the *
 
 The app.js file, which is located in the Scripts folder of the web project, defines the behavior of the **Save for later** button. The add-in first verifies that local storage is enabled by using the following function.
 
-```js
+```javascript
 isHtml5StorageSupported = function () {
     try {
         return 'localStorage' in window &amp;&amp; window['localStorage'] !== null;
@@ -74,7 +74,7 @@ isHtml5StorageSupported = function () {
 
 If local storage is supported, the function determines whether the user profile information is already stored there. If it isn't, it uses JSOM to look up the **About Me** information, to store it locally, and then to display the information in the browser. The following code stores the **About Me** information in a key named `aboutMeValue`.
 
-```js
+```javascript
 var aboutMeValue = personProperties.get_userProfileProperties()['AboutMe'];
     $('#aboutMeText').val(aboutMeValue);
 
@@ -91,7 +91,7 @@ var aboutMeValue = personProperties.get_userProfileProperties()['AboutMe'];
 
 The **Clear the cache** button removes that key, looks up the **About Me** information in your user profile, and creates a fresh local storage key to store that information. The add-in doesn't set an expiration time by default, but the app.js file does contain the following function, which sets an expiration time for the cached data.
 
-```js
+```javascript
 function setLocalStorageKeyExpiry(key) {
 
     // Check for expiration config values.

--- a/docs/solution-guidance/modern-experience-customizations-provisioning-sites.md
+++ b/docs/solution-guidance/modern-experience-customizations-provisioning-sites.md
@@ -140,7 +140,7 @@ Alternatively, the [Office 365 CLI](https://pnp.github.io/office365-cli/) can be
 
 The following bash script will create a "modern" team site and then return the actual SharePoint site URL for further manipulation. Once you have access to the URL of the created site, you can use it to automate other operations on the created site.
 
-```bash
+```console
 #!/usr/bin/env bash
 # Connect to SharePoint Online
 # This command will prompt a sign-in confirmation message to authenticate
@@ -240,7 +240,7 @@ New-PnPTenantSite -Url $_url -Description $_title -Title $_title -Template STS#3
 Alternatively, the [Office 365 CLI](https://pnp.github.io/office365-cli/cmd/graph/o365group/o365group-add/?utm_source=msft_docs&utm_medium=page&utm_campaign=Provisioning+modern+team+sites+programmatically) can be used to create a Microsoft 365 group, which will let you easily authenticate with the Microsoft Graph and then create the new group.
 The example below shows how it can be done using the [Office 365 CLI immersive mode](https://pnp.github.io/office365-cli/user-guide/using-cli/#start-the-cli-in-the-immersive-mode?utm_source=msft_docs&utm_medium=page&utm_campaign=Provisioning+modern+team+sites+programmatically).
 
-```bash
+```console
 # Use the Office 365 CLI immersive mode by typing o365 in the terminal
 # Connect to Microsoft Graph using the Office 365 CLI
 # This command will prompt a sign-in confirmation message to authenticate
@@ -330,7 +330,7 @@ $web.Title
 
 Alternatively, the [Office 365 CLI](https://pnp.github.io/office365-cli/cmd/spo/site/site-add/?utm_source=msft_docs&utm_medium=page&utm_campaign=Provisioning+modern+team+sites+programmatically) can be used to create "modern" Communication site. The following bash script will create the site and then return the actual SharePoint site URL for further manipulation. Once you have access to the URL you can use it to automate other operations on the created site.
 
-```bash
+```console
 #!/usr/bin/env bash
 # Connect to SharePoint Online
 # This command will prompt a sign-in confirmation message to authenticate

--- a/docs/sp-add-ins/access-sharepoint-data-from-add-ins-using-the-cross-domain-library.md
+++ b/docs/sp-add-ins/access-sharepoint-data-from-add-ins-using-the-cross-domain-library.md
@@ -311,7 +311,7 @@ executor.executeAsync(
 
 The following code example shows how to change the context site using JSOM:
 
-```js
+```javascript
 context = new SP.ClientContext(appweburl);
 factory = new SP.ProxyWebRequestExecutorFactory(appweburl);
 context.set_webRequestExecutorFactory(factory);

--- a/docs/sp-add-ins/complete-basic-operations-using-javascript-library-code-in-sharepoint.md
+++ b/docs/sp-add-ins/complete-basic-operations-using-javascript-library-code-in-sharepoint.md
@@ -48,7 +48,7 @@ The following code example performs these tasks to add a reference to the JavaSc
 - Continues the flow in the **execOperation** function.
 
 
-```js
+```javascript
 <script 
     src="//ajax.aspnetcdn.com/ajax/4.0/1/MicrosoftAjax.js" 
     type="text/javascript">
@@ -116,7 +116,7 @@ The following markup performs these tasks to add a reference to the JavaScript o
 - References the SP.Runtime.js file by using a URL relative to the add-in web.
 - References the SP.js file by using a URL relative to the add-in web.
 
-```js
+```javascript
 <script 
     src="//ajax.aspnetcdn.com/ajax/4.0/1/MicrosoftAjax.js" 
     type="text/javascript">
@@ -150,7 +150,7 @@ Use the web property of the **ClientContext** class to specify the properties of
 
 The following example displays the title and description of the specified website, although all other properties that are returned by default become available after you load the website object and execute the query.
 
-```js
+```javascript
 
 function retrieveWebSite(siteUrl) {
     var clientContext = new SP.ClientContext(siteUrl);
@@ -181,7 +181,7 @@ function onQueryFailed(sender, args) {
 
 To reduce unnecessary data transference between client and server, you might want to return only specified properties of the website object, not all of its properties. In this case, use LINQ query or lambda expression syntax with the **load(clientObject)** method to specify which properties to return from the server. In the following example, only the title and creation date of the website object become available after **executeQueryAsync(succeededCallback, failedCallback)** is called.
 
-```js
+```javascript
 function retrieveWebSiteProperties(siteUrl) {
     var clientContext = new SP.ClientContext(siteUrl);
     this.oWebsite = clientContext.get_web();
@@ -214,7 +214,7 @@ function onQueryFailed(sender, args) {
 
 To modify a website, you set its properties and call the **update()** method, similarly to how the server object model functions. However, in the client object model, you must call **executeQueryAsync(succeededCallback, failedCallback)** to request batch processing of all commands that you specify. The following example changes the title and description of a specified website.
 
-```js
+```javascript
 function updateWebSite(siteUrl) {
     var clientContext = new SP.ClientContext(siteUrl);
     this.oWebsite = clientContext.get_web();
@@ -254,7 +254,7 @@ Working with list objects using JavaScript is similar to working with website ob
 
 To return all the lists of a website, load the list collection through the **load(clientObject)** method, and then call **executeQueryAsync(succeededCallback, failedCallback)**. The following example displays the URL of the website and the date and time that the list was created.
 
-```js
+```javascript
 function retrieveAllListProperties(siteUrl) {
     var clientContext = new SP.ClientContext(siteUrl);
     var oWebsite = clientContext.get_web();
@@ -291,7 +291,7 @@ function onQueryFailed(sender, args) {
 
 The previous example returns all properties of the lists in a website. To reduce unnecessary data transference between client and server, you can use LINQ query expressions to specify which properties to return. In JavaScript, you specify **Include** as part of the query string that is passed to the **load(clientObject)** method to specify which properties to return. The following example uses this approach to return only the title and ID of each list in the collection.
 
-```js
+```javascript
 function retrieveSpecificListProperties(siteUrl) {
     var clientContext = new SP.ClientContext(siteUrl);
     var oWebsite = clientContext.get_web();
@@ -329,7 +329,7 @@ function onQueryFailed(sender, args) {
 
 As the following example shows, you can use the **loadQuery(clientObjectCollection, exp)** method instead of the **load(clientObject)** method to store the return value in another collection instead of storing it in the lists property.
 
-```js
+```javascript
 function retrieveSpecificListPropertiesToCollection(siteUrl) {
     var clientContext = new SP.ClientContext(siteUrl);
     var oWebsite = clientContext.get_web();
@@ -365,7 +365,7 @@ function onQueryFailed(sender, args) {
 
 As the following example shows, you can nest **Include** statements in a JavaScript query to return metadata for both a list and its fields. The example returns all fields from all lists within a website and displays the title and internal name of all fields whose internal name contains the string "name".
 
-```js
+```javascript
 function retrieveAllListsAllFields(siteUrl) {
     var clientContext = new SP.ClientContext(siteUrl);
     var oWebsite = clientContext.get_web();
@@ -421,7 +421,7 @@ Creating, updating, and deleting lists through the client object model works sim
 
 To create a list object using JavaScript, use the **ListCreationInformation** object to define its properties, and then pass this object to the **add(parameters)** function of the **ListCollection** object. The following example creates a new announcements list.
 
-```js
+```javascript
 function createList(siteUrl) {
     var clientContext = new SP.ClientContext(siteUrl);
     var oWebsite = clientContext.get_web();
@@ -454,7 +454,7 @@ function onQueryFailed(sender, args) {
 
 If you need to update the list after it has been created, you can set list properties and call the **update()** function before calling **executeQueryAsync(succeededCallback, failedCallback)**, as shown in the following modifications of the previous example.
 
-```js
+```javascript
 .
 .
 .
@@ -477,7 +477,7 @@ clientContext.executeQueryAsync(
 
 Use the **add(field)** or **addFieldAsXml(schemaXml, addToDefaultView, options)** function of the **FieldCollection** object to add a field to the field collection of a list. The following example creates a field and then updates it before calling **executeQueryAsync(succeededCallback, failedCallback)**.
 
-```js
+```javascript
 function addFieldToList(siteUrl) {
     var clientContext = new SP.ClientContext(siteUrl);
 
@@ -517,7 +517,7 @@ function onQueryFailed(sender, args) {
 
 To delete a list, call the **deleteObject()** function of the list object, as shown in the following example.
 
-```js
+```javascript
 function deleteList(siteUrl) {
     var clientContext = new SP.ClientContext(siteUrl);
     var oWebsite = clientContext.get_web();
@@ -556,7 +556,7 @@ You can manipulate folders to organize your content by using the JavaScript obje
 To create a folder, you use a **ListItemCreationInformation** object, set the underlying object type to **SP.FileSystemObjectType.folder**, and pass it as a parameter to the **addItem(parameters)** function of the **List** object. Set properties on the list item object that this method returns, and then call the **update()** function, as shown in the following example.
 
 
-```js
+```javascript
 function createFolder(resultpanel) {
     var clientContext;
     var oWebsite;
@@ -599,7 +599,7 @@ function createFolder(resultpanel) {
 
 To update the folder name, you can write to the **FileLeafRef** property and call the **update()** function so that changes take effect when you call the **executeQueryAsync** method.
 
-```js
+```javascript
 function updateFolder(resultpanel) {
     var clientContext;
     var oWebsite;
@@ -637,7 +637,7 @@ function updateFolder(resultpanel) {
 
 To delete a folder, call the **deleteObject()** function on the object. The following example uses the **getFolderByServerRelativeUrl** method to retrieve the folder from the document library and then deletes the item.
 
-```js
+```javascript
 function deleteFolder(resultpanel) {
     var clientContext;
     var oWebsite;
@@ -685,7 +685,7 @@ You can manipulate files by using the JavaScript object model. The following sec
 
 To create files, you use a **FileCreationInformation** object, set the URL attribute, and append content as a base64 encoded array of bytes, as shown in this example.
 
-```js
+```javascript
 function createFile(resultpanel) {
     var clientContext;
     var oWebsite;
@@ -734,7 +734,7 @@ function createFile(resultpanel) {
 
 To read a file's content, you perform a **GET** operation on the file's URL, as shown in the following example.
  
-```js
+```javascript
 function readFile(resultpanel) {
     var clientContext;
     var oWebsite;
@@ -773,7 +773,7 @@ function readFile(resultpanel) {
 
 To update the file's content, you can use a **FileCreationInformation** object, and set the overwrite attribute to true by using the **set_overwrite()** method, as shown in this example.
  
-```js
+```javascript
 function updateFile(resultpanel) {
     var clientContext;
     var oWebsite;
@@ -824,7 +824,7 @@ function updateFile(resultpanel) {
 
 To delete a file, call the **deleteObject()** function on the object. The following example uses the **getFileByServerRelativeUrl** method to retrieve the file from the document library, and then deletes the item.
  
-```js
+```javascript
 function deleteFile(resultpanel) {
     var clientContext;
     var oWebsite;
@@ -871,7 +871,7 @@ To return items from a list by using JavaScript, use the **getItemById(id)** fun
 
 The **getItems(query)** function enables you to define a Collaborative Application Markup Language (CAML) query that specifies which items to return. You can pass an undefined **CamlQuery** object to return all items from the list, or use the **set_viewXml** function to define a CAML query and return items that meet specific criteria. The following example displays the ID, in addition to the Title and Body column values, of the first 100 items in the Announcements list, starting with list items whose collection ID is greater than 10.
  
-```js
+```javascript
 function retrieveListItems(siteUrl) {
     var clientContext = new SP.ClientContext(siteUrl);
     var oList = clientContext.get_web().get_lists().getByTitle('Announcements');
@@ -920,7 +920,7 @@ Four properties of **ListItem** objects are not available by default when you re
 > [!NOTE] 
 > When you use LINQ to create queries against the client object model, you are using  [LINQ to Objects](https://msdn.microsoft.com/library/bb397919), not the [LINQ to SharePoint provider](https://msdn.microsoft.com/library/ee535491), which can only be used when you write code against the server object model.
 
-```js
+```javascript
 function retrieveListItemsInclude(siteUrl) {
     var clientContext = new SP.ClientContext(siteUrl);
     var oList = clientContext.get_web().get_lists().getByTitle('Announcements');
@@ -982,7 +982,7 @@ Creating, updating, or deleting list items through the client object model works
 To create list items, you create a **ListItemCreationInformation** object, set its properties, and pass it as a parameter to the **addItem(parameters)** function of the **List** object. Set properties on the list item object that this method returns, and then call the **update()** function, as shown in the following example.
 
 
-```js
+```javascript
 function createListItem(siteUrl) {
     var clientContext = new SP.ClientContext(siteUrl);
     var oList = clientContext.get_web().get_lists().getByTitle('Announcements');
@@ -1016,7 +1016,7 @@ function onQueryFailed(sender, args) {
 
 To set most list item properties, you can use a column indexer to make an assignment, and call the **update()** function so that changes take effect when you call **executeQueryAsync(succeededCallback, failedCallback)**. The following example sets the title of the third item in the Announcements list.
 
-```js
+```javascript
 function updateListItem(siteUrl) {
     var clientContext = new SP.ClientContext(siteUrl);
     var oList = clientContext.get_web().get_lists().getByTitle('Announcements');
@@ -1047,7 +1047,7 @@ function onQueryFailed(sender, args) {
 
 To delete a list item, call the **deleteObject()** function on the object. The following example uses the **getItemById(id)** function to return the second item from the list, and then deletes the item. SharePoint maintains the integer IDs of items within collections, even if they have been deleted. So, for example, the second item in a list might not have 2 as its identifier. A **ServerException** is returned if the **deleteObject()** function is called for an item that does not exist.
 
-```js
+```javascript
 function deleteListItem(siteUrl) {
     this.itemId = 2;
     var clientContext = new SP.ClientContext(siteUrl);
@@ -1074,7 +1074,7 @@ function onQueryFailed(sender, args) {
 
 If you want to retrieve, for example, the new item count that results from a delete operation, include a call to the update() method to refresh the list. In addition, you must load either the list object itself or the **itemCount** property on the list object before executing the query. If you want to retrieve both a start and end count of the list items, you must execute two queries and return the item count twice, as shown in the following modification of the previous example.
 
-```js
+```javascript
 function deleteListItemDisplayCount(siteUrl) {
     this.clientContext = new SP.ClientContext(siteUrl);
     this.oList = clientContext.get_web().get_lists().getByTitle('Announcements');
@@ -1124,7 +1124,7 @@ function onQueryFailed(sender, args) {
 
 While developing your add-in, you might need to access the host web to interact with items in it. Use the **AppContextSite** object to reference the host web or other SharePoint sites, as shown in the following example. For a full code sample, see [Get the host web title using the cross-domain library (JSOM)](https://code.msdn.microsoft.com/office/SharePoint-2013-Get-the-563f2a3d).
 
-```js
+```javascript
 function execCrossDomainRequest(appweburl, hostweburl) {
     // context: The ClientContext object provides access to
     //      the web and lists objects.

--- a/docs/sp-add-ins/complete-basic-operations-using-sharepoint-rest-endpoints.md
+++ b/docs/sp-add-ins/complete-basic-operations-using-sharepoint-rest-endpoints.md
@@ -68,7 +68,7 @@ This request would look a little different if you are writing your add-in in Jav
 
 The following code demonstrates how this request would look if you are using the cross-domain library and want to receive the OData representation of the lists as XML instead of JSON. (Because Atom is the default response format, you don't have to include an **Accept** header.) For more information about using the cross-domain library, see [Access SharePoint data from add-ins using the cross-domain library](access-sharepoint-data-from-add-ins-using-the-cross-domain-library.md).
 
-```js
+```javascript
 var executor = new SP.RequestExecutor(appweburl);
 executor.executeAsync(
   {
@@ -126,7 +126,7 @@ If you're using the JavaScript cross-domain library, SP.RequestExecutor handles 
 
 If you're creating a SharePoint-hosted SharePoint Add-in, you don't have to make a separate HTTP request to retrieve the form digest value. Instead, you can retrieve the value in JavaScript code from the SharePoint page (if the page uses the default master page), as shown in the following example, which uses JQuery and creates a list.
 
-```js
+```javascript
 jQuery.ajax({
         url: "http://<site url>/_api/web/lists",
         type: "POST",
@@ -146,7 +146,7 @@ jQuery.ajax({
 
 The following example shows how to update the list that is created in the previous example. The example changes the title of the list, uses JQuery, and assumes that you are doing this operation in a SharePoint-hosted add-in.
 
-```js
+```javascript
 jQuery.ajax({
         url: "http://<site url>/_api/web/lists/GetByTitle('Test')",
         type: "POST",
@@ -181,7 +181,7 @@ The following example shows the opening `<entry>` tag for the XML node that cont
 
 The following example shows how to create a site in JavaScript.
 
-```js
+```javascript
 jQuery.ajax({
     url: "http://<site url>/_api/web/webinfos/add",
     type: "POST",
@@ -269,7 +269,7 @@ Cross-domain library requests use this format when they access data on the add-i
 
 SharePoint Add-ins can get the add-in web URL and host web URL from the query string of the add-in page, as shown in the following code example. The example also shows how to reference the cross-domain library, which is defined in the SP.RequestExecutor.js file on the host web. The example assumes that your add-in launches from SharePoint. For guidance about setting your SharePoint context correctly when your add-in does not launch from SharePoint, see [Authorization Code OAuth flow for SharePoint Add-ins](authorization-code-oauth-flow-for-sharepoint-add-ins.md).
 
-```js
+```javascript
 var hostweburl;
 var appweburl;
 

--- a/docs/sp-add-ins/create-a-custom-proxy-page-for-the-cross-domain-library-in-sharepoint.md
+++ b/docs/sp-add-ins/create-a-custom-proxy-page-for-the-cross-domain-library-in-sharepoint.md
@@ -194,7 +194,7 @@ To read data from the remote service, you must do the following:
 
 6. Copy the following code and paste it in the **PlaceHolderMain** content tag.
         
-    ```js
+    ```javascript
     <!-- The page dynamically loads the cross-domain library's
         js file, rescript acts as the placeholder. -->
     <script 

--- a/docs/sp-add-ins/customize-a-list-view-in-sharepoint-add-ins-using-client-side-rendering.md
+++ b/docs/sp-add-ins/customize-a-list-view-in-sharepoint-add-ins-using-client-side-rendering.md
@@ -113,7 +113,7 @@ The following figure shows a client-side rendered view of an announcements list.
 
     - Registers the templates.
 
-    ```js
+    ```javascript
     
     (function () {
         // Initialize the variable that stores the objects.

--- a/docs/sp-add-ins/highlight-content-and-enhance-the-functionality-of-sharepoint-hosted-sharepoint.md
+++ b/docs/sp-add-ins/highlight-content-and-enhance-the-functionality-of-sharepoint-hosted-sharepoint.md
@@ -26,7 +26,7 @@ In this case, the information and actions are relatively simple, but you can alr
 
 This example uses the `SP.SOD.executeFunc` method to ensure that the script file loads before you run any code that depends on it.
 
-```js
+```javascript
 SP.SOD.executeFunc("callout.js", "Callout", function () {
     });
 ```
@@ -41,7 +41,7 @@ You can, for example, create or get a `div` element on your page and pass it as 
 
 This example shows you how to create the simplest possible callout control with only the two required members and a title string.
 
-```js
+```javascript
 var calloutPageElement = document.createElement("div");
 var callout = CalloutManager.createNew({
    ID: "unique identifier",
@@ -53,13 +53,13 @@ var callout = CalloutManager.createNew({
 
 This particular callout appears and displays a title at the top of the control whenever a user selects the page element. You use the optional members to customize the control's appearance, behavior, positioning, and actions in some very powerful ways. The callout control also has a set method that you can use to set a value for any parameter after you create an instance of the control.
 
-```js
+```javascript
 callout.set({openOptions:{event: "hover"}});
 ```
 
 You can also set values for all of the callout members in a `CalloutOptions` object, and then pass that object to the `createNew` method.
 
-```js
+```javascript
 var calloutPageElement = document.createElement("div");
 var calloutOptions = new CalloutOptions();
 calloutOptions.ID = unique identifier;
@@ -129,7 +129,7 @@ You can use these methods to customize the behavior of the callout control.
 
 You add actions after you've created an instance of the callout control. A callout action can consist of either a single action or a menu of actions. You can add up to three actions to a callout control. After you have created a callout action, you add it to the `CalloutControl` object with its `addAction` method. This sample action opens a new window in your browser after the user selects the text.
  
-```js
+```javascript
 //Create CalloutAction
 var calloutAction = new CalloutAction({
             text: "Open window"
@@ -146,7 +146,7 @@ var calloutAction = new CalloutAction({
 
 You can also set values for all of the `CalloutAction` members in a `CalloutActionOptions` object and pass that object to the `CalloutAction` constructor.
 
-```js
+```javascript
 //Create CalloutAction
 var calloutActionOptions = new CalloutActionOptions();
 calloutActionOptions.text = "Open window";
@@ -185,7 +185,7 @@ When a callout action contains a menu instead of a single action, the user sees 
  
 You can create as many menu entries as you want and add them to the callout action by passing them in an array as the value of the `menuEntries` member of the `CalloutAction` object.
 
-```js
+```javascript
 //Create two menu entries.
 var menuEntry1 = new CalloutActionMenuEntry("Entry One", calloutActionCallbackFunction, "/_layouts/images/DOC16.GIF");
 var menuEntry2 = new CalloutActionMenuEntry("Some Other Entry", calloutActionCallbackFunction, "/_layouts/images/XLS16.GIF");
@@ -243,7 +243,7 @@ The following section describes how to use the `calloutPositioningProxy` object 
 
 The `calloutPositioningProxy` object contains methods and properties that you can use to override the positioning logic that the callout control uses by default. For example, if you want the control to appear below and to the right of the `launchPoint` element all the time, you write a positioning algorithm that looks like the following.
 
-```js
+```javascript
 function alwaysGoDownAndRight(calloutPositioningProxy)  {
     calloutPositioningProxy.moveDownAndRight();
 } 
@@ -252,14 +252,14 @@ function alwaysGoDownAndRight(calloutPositioningProxy)  {
 
 You would then pass that function as the value of the  `Callout` object's `positionAlgorithm` member. You can do that when you create the `Callout`, or later by setting the value.
 
-```js
+```javascript
 callout.set({positionAlgorithm: alwaysGoDownAndRight});
 
 ```
 
 You can always take a look at the default positioning logic by launching your browser's JavaScript console (the Internet Explorer F12 Developer Tools, for example).
 
-```js
+```javascript
 CalloutOptions.prototype.positionAlgorithm.toString()
 ```
 
@@ -290,7 +290,7 @@ You can use these methods in the  `CalloutPositioningProxy` object to write your
 
 This positioning algorithm makes the control go above or below the text. The  `isRTL` property of the `CalloutPositioningProxy` tells you whether the text is displaying a right-to-left language. You check for this property to ensure that the control is always positioned correctly in relation to the text on the page.
 
-```js
+```javascript
 function examplePositionAlgorithm(calloutPositioningProxy) {
     if (!calloutPositioningProxy.isRTL) {
         calloutPositioningProxy.moveDownAndRight();
@@ -311,7 +311,7 @@ callout.set({positionAlgorithm: examplePositionAlgorithm});
 
 This positioning algorithm changes the default direction of the control to `downAndRight` instead of `upAndRight`, but it uses the default algorithm if there are any collisions.
 
-```js
+```javascript
 function tryDownAndRightThenGoDefault(calloutPositioningProxy) {
     if (!calloutPositioningProxy.isRTL)
         calloutPositioningProxy.moveDownAndRight();

--- a/docs/sp-add-ins/localize-sharepoint-add-ins.md
+++ b/docs/sp-add-ins/localize-sharepoint-add-ins.md
@@ -165,7 +165,7 @@ The following image shows the localized custom list in English.
 
 4. For each localizable string in each of your custom pages, declare a variable in the file with a name that identifies the purpose of the string, and assign it a value that is appropriate for the language. The following is the contents of the Resources.en-US.js file.
         
-    ```js
+    ```javascript
         var instructionstitle = "Instructions:";
         var step01 = "Go to any document library in the host web.";
         var step02 = "Go to the Library tab.";
@@ -201,7 +201,7 @@ The following image shows the localized custom list in English.
     > The word "INVARIANT" has been added to the first of the invariant strings. You would not do this in a production add-in, but while you are testing, it is a useful way of seeing at a glance whether invariant language strings are being used or whether the Resources._LL-CC_.js file for the language that happens to be your invariant language was loaded.
 
 
-```js
+```javascript
     <h2 id="instructionsheading">INVARIANT Instructions</h2>
         <ol>
             <li id="step01">Go to any document library in the host web.</li>
@@ -327,7 +327,7 @@ If there are localizable string values in your web application's JavaScript, you
 
 1. After you have the chrome control working, return to the `renderChrome` method where you set the chrome options.
         
-    ```js
+    ```javascript
         function renderChrome() {
             var options = {
                 "appIconUrl": "siteicon.png",
@@ -354,7 +354,7 @@ If there are localizable string values in your web application's JavaScript, you
 
 2. As noted in the comments, there are at least three localizable strings. Replace each of these with a variable name that you declare in a later step. 
     
-    ```js
+    ```javascript
         function renderChrome() {
             var options = {
                 "appIconUrl": "siteicon.png",
@@ -381,7 +381,7 @@ If there are localizable string values in your web application's JavaScript, you
 
 3. Add a JavaScript file named ChromeStrings.js to the web application project. It should declare the variables you used in the preceding step and assign them each a value in the invariant language. 
     
-    ```js
+    ```javascript
     var chromeAppTitle = "My SharePoint add-in";
     var chromeAccountLinkName = "Account settings";
     var chromeContactUsLinkName = "Contact us";
@@ -390,7 +390,7 @@ If there are localizable string values in your web application's JavaScript, you
 
 4. For each language for which you are localizing the add-in, add another JavaScript file with the name ChromeStrings._LL-CC_.js, where _LL-CC_ is the language ID. *The base of the file name, in this case "ChromeStrings," must be exactly the same as you used for the invariant language file.*  Copy the contents of the invariant language file into each of the localized files, and replace the values with translated versions.
     
-    ```js
+    ```javascript
     var chromeAppTitle = "Mi aplicación SharePoint";
     var chromeAccountLinkName = "Preferencias";
     var chromeContactUsLinkName = "Contacto";
@@ -399,7 +399,7 @@ If there are localizable string values in your web application's JavaScript, you
 
 5. In any page file where the script SP.UI.controls.js is called, add a call to the ChromeStrings.js above it. For example, if the call to SP.UI.controls.js is loaded in an intermediate file called ChromeLoader.js, the markup in the page at this point should look similar to the following.
     
-    ```js
+    ```javascript
     <Scripts>
         <asp:ScriptReference Path="Scripts/ChromeStrings.js" />
         <asp:ScriptReference Path="Scripts/ChromeLoader.js" />
@@ -408,7 +408,7 @@ If there are localizable string values in your web application's JavaScript, you
 
 6. Add a **ResourceUICultures** attribute to the **ScriptReference** element that calls your strings. Its value is a comma-delimited list of the languages that you are supporting.
     
-    ```js
+    ```javascript
     <Scripts>
         <asp:ScriptReference Path="Scripts/ChromeStrings.js" ResourceUICultures="en-US,es-ES" />
         <asp:ScriptReference Path="Scripts/ChromeLoader.js" />

--- a/docs/sp-add-ins/query-a-remote-service-using-the-web-proxy-in-sharepoint.md
+++ b/docs/sp-add-ins/query-a-remote-service-using-the-web-proxy-in-sharepoint.md
@@ -97,7 +97,7 @@ The following figure shows the browser window with data from the remote service 
     
     - Handles any errors, rendering the error message in the SharePoint webpage.
  
-    ```js
+    ```javascript
     Categories from the Northwind database exposed as an OData service: 
         
     <!-- Placeholder for the remote content -->
@@ -212,7 +212,7 @@ The following figure shows the browser window with data from the remote service 
     
     - Handles any errors, rendering the error message in the SharePoint webpage.
     
-    ```js
+    ```javascript
     Categories from the Northwind database exposed as an OData service: 
         
     <!-- Placeholder for the remote content -->

--- a/docs/sp-add-ins/set-custom-permissions-on-a-list-by-using-the-rest-interface.md
+++ b/docs/sp-add-ins/set-custom-permissions-on-a-list-by-using-the-rest-interface.md
@@ -36,7 +36,7 @@ The following examples represent the contents of the App.js file in a SharePoint
 
 ### Example 1: Cross-domain library requests
 
-```js
+```javascript
 'use strict';
 
 // Change placeholder values before you run this code.
@@ -164,7 +164,7 @@ function errorHandler(xhr, ajaxOptions, thrownError) {
 
 ### Example 2: jQuery AJAX requests
 
-```js
+```javascript
 // Change placeholder values before you run this code.
 var siteUrl = 'http://server/site';
 var listTitle = 'List 1';

--- a/docs/sp-add-ins/upload-a-file-by-using-the-rest-api-and-jquery.md
+++ b/docs/sp-add-ins/upload-a-file-by-using-the-rest-api-and-jquery.md
@@ -57,7 +57,7 @@ The following code example uses the SharePoint REST API and jQuery AJAX requests
 > [!NOTE]
 > You need to meet the requirements listed in the section [Running the code examples](#running-the-code-examples) to use this example.
 
-```js
+```javascript
 'use strict';
 
 var appWebUrl, hostWebUrl;
@@ -222,7 +222,7 @@ The following code example uses the SharePoint REST API and jQuery AJAX requests
 > [!NOTE]
 > You need to meet the requirements listed in the section [Running the code examples](#running-the-code-examples) to use this example.
 
-```js
+```javascript
 'use strict';
 
 jQuery(document).ready(function () {

--- a/docs/sp-add-ins/use-the-client-side-people-picker-control-in-sharepoint-hosted-sharepoint-add-in.md
+++ b/docs/sp-add-ins/use-the-client-side-people-picker-control-in-sharepoint-hosted-sharepoint-add-in.md
@@ -124,7 +124,7 @@ The first example shows the page markup for the **PlaceHolderMain asp:Content** 
 
 The following example shows the **script from the App.js file**. This script initializes and renders the picker, queries it for user information, and then gets the user ID by using the JavaScript object model.
 
-```js
+```javascript
 
 // Run your custom code when the DOM is ready.
 $(document).ready(function () {

--- a/docs/sp-add-ins/use-the-experimental-desktop-list-view-widget-in-sharepoint-add-ins.md
+++ b/docs/sp-add-ins/use-the-experimental-desktop-list-view-widget-in-sharepoint-add-ins.md
@@ -293,7 +293,7 @@ Depending on your preference, you might want to use JavaScript instead of HTML t
 
 Use the following JavaScript code to instantiate the List View.
 
-```js
+```javascript
 new Office.Controls.ListView(
     document.getElementById("ListViewDiv"), {
         listUrl: Office.Samples.ListViewBasic.appWebUrl + "/_api/web/lists/getbytitle('Announcements')"
@@ -324,7 +324,7 @@ If you're using HTML markup to declare the widget, you can use the following syn
 
 If you're declaring the widget using JavaScript, use the following syntax to specify a view.
 
-```js
+```javascript
 new Office.Controls.ListView(
     document.getElementById("ListViewDiv"), {
         listUrl: "list URL",

--- a/docs/sp-add-ins/use-the-experimental-people-picker-widget-in-sharepoint-add-ins.md
+++ b/docs/sp-add-ins/use-the-experimental-people-picker-widget-in-sharepoint-add-ins.md
@@ -248,7 +248,7 @@ Depending on your preference, you might want to use JavaScript instead of HTML t
 
 Use the following JavaScript code to instantiate the People Picker.
 
-```js
+```javascript
 new Office.Controls.PeoplePicker(
     document.getElementById("PeoplePickerDiv"), {});
 ```
@@ -276,7 +276,7 @@ You can specify options for the widget by using the **data-office-options** attr
 
 The following code shows how to specify options when you declare the PeoplePicker widget using JavaScript.
 
-```js
+```javascript
 new Office.Controls.PeoplePicker(
     document.getElementById("PeoplePickerDiv"), {
         allowMultipleSelections: true,

--- a/docs/sp-add-ins/use-the-sharepoint-javascript-apis-to-work-with-sharepoint-data.md
+++ b/docs/sp-add-ins/use-the-sharepoint-javascript-apis-to-work-with-sharepoint-data.md
@@ -49,7 +49,7 @@ Even though SharePoint-hosted SharePoint Add-ins can't have server-side code, yo
 1. Open **Add-in.js** and delete its content, if there's any.
 1. Add the following lines to the file.
 
-    ```js
+    ```javascript
     'use strict';
     
       var clientContext = SP.ClientContext.get_current();
@@ -71,7 +71,7 @@ Even though SharePoint-hosted SharePoint Add-ins can't have server-side code, yo
 
    Begin by creating a method to get the list items from the server. Add the following code to the file.
 
-    ```js
+    ```javascript
     function purgeCompletedItems() {
 
       var camlQuery = new SP.CamlQuery();
@@ -85,19 +85,19 @@ Even though SharePoint-hosted SharePoint Add-ins can't have server-side code, yo
 
 1. When these lines are sent to the server and executed there, they create a collection of list items, but the script must bring that collection down to the client. This is done with a call to the `SP.ClientContext.load` function, so add the following line to the end of the method.
 
-    ```js
+    ```javascript
     clientContext.load(completedItems);
     ```
 
 1. Add a call of `executeQueryAsync`. This method has two parameters, both of which are callback functions. The first runs if the server successfully executes all the commands in the batch. The second runs if the server fails for any reason. You create these two functions in later steps. Add the following line to the end of the method.
 
-    ```js
+    ```javascript
     clientContext.executeQueryAsync(deleteCompletedItems, onGetCompletedItemsFail);
     ```
 
 1. Finally, add the following line to the end of the method.
 
-    ```js
+    ```javascript
     return false;
     ```
 
@@ -114,7 +114,7 @@ Even though SharePoint-hosted SharePoint Add-ins can't have server-side code, yo
 
    The error message isn't literally true, because the item isn't deleted from anything until the `deleteObject` calls are bundled and sent to the server, but the JSOM is designed to mimic the exception throws that would occur on the server (where code shouldn't change a collection size while the collection is being enumerated). However, arrays have a fixed size, so calling `deleteObject` on an item in an array deletes the item from the list, but does not change the size of the array.
 
-    ```js
+    ```javascript
     function deleteCompletedItems() {
 
       var itemArray = new Array();
@@ -138,7 +138,7 @@ Even though SharePoint-hosted SharePoint Add-ins can't have server-side code, yo
 
    The line `location.reload(true);` causes the page to reload from the server. This is a convenience because the list view web part on the page still shows the completed items until the page is refreshed. The Add-in.js file is reloaded too, but that doesn't cause a problem because it won't do so in a way that interrupts an ongoing JavaScript function.
 
-    ```js
+    ```javascript
     function onDeleteCompletedItemsSuccess() {
       alert('Completed orientations have been deleted.');
       location.reload(true);
@@ -147,7 +147,7 @@ Even though SharePoint-hosted SharePoint Add-ins can't have server-side code, yo
 
 1. Add the following two callback-on-failure functions to the file.
 
-    ```js
+    ```javascript
     // Failure callbacks
 
     function onGetCompletedItemsFail(sender, args) {

--- a/docs/sp-add-ins/working-with-folders-and-files-with-rest.md
+++ b/docs/sp-add-ins/working-with-folders-and-files-with-rest.md
@@ -257,7 +257,7 @@ Contents of binary file
 
 The following code sample shows how to **create a file by using this REST endpoint and the JSOM cross-domain library**.
 
-```js
+```javascript
 function uploadFileBinary() {
   XDomainTestHelper.clearLog();
   var requestExecutor;

--- a/docs/spfx/connect-to-anonymous-apis.md
+++ b/docs/spfx/connect-to-anonymous-apis.md
@@ -17,7 +17,7 @@ When building SharePoint Framework solutions, you might want to consume public A
 
 The easiest way, to connect to anonymous APIs in your SharePoint Framework solutions, is by using the HttpClient provided as a part of the SharePoint Framework. For example, to get dummy information from the Typicode service, you would execute:
 
-```ts
+```typescript
 this.context.httpClient
   .get('https://jsonplaceholder.typicode.com/todos/1', HttpClient.configurations.v1)
   .then((res: HttpClientResponse): Promise<any> => {
@@ -30,7 +30,7 @@ this.context.httpClient
 
 Similarly to the SPHttpClient you use for connecting to SharePoint APIs, the HttpClient offers you similar capabilities for performing the most common web requests. If necessary, you can use its options, to configure requests. For example, to specify request headers, you would use the following code:
 
-```ts
+```typescript
 this.context.httpClient
   .get('https://jsonplaceholder.typicode.com/todos/1', HttpClient.configurations.v1,
     {

--- a/docs/spfx/connect-to-sharepoint.md
+++ b/docs/spfx/connect-to-sharepoint.md
@@ -14,7 +14,7 @@ In your SharePoint Framework solutions, you will likely want to interact with da
 
 SharePoint Framework offers the SPHttpClient that you can use to connect to SharePoint REST APIs. A ready-to-use instance of the SPHttpClient is available on the web part/extension context and you can use it to perform all kinds of web request. Following code snippet shows how you would use the SPHttpClient to retrieve the title of the current site:
 
-```ts
+```typescript
 this.context.spHttpClient
   .get(`${this.context.pageContext.web.absoluteUrl}/_api/web?$select=Title`, SPHttpClient.configurations.v1)
   .then((res: SPHttpClientResponse): Promise<{ Title: string; }> => {
@@ -27,7 +27,7 @@ this.context.spHttpClient
 
 The SPHttpClient offers basic functionality for performing the most common web requests. It allows you also, to configure your request by for example specifying request headers. For example, if you wanted to issue a web request without retrieving metadata, you'd use the following code:
 
-```ts
+```typescript
 this.context.spHttpClient
   .get(`${this.context.pageContext.web.absoluteUrl}/_api/web?$select=Title`,
     SPHttpClient.configurations.v1,
@@ -52,7 +52,7 @@ When using the SPHttpClient there are a few things that you should take into acc
 
 By default, the SPHttpClient uses OData v4 specification, which requires using `odata.metadata` instead of just `odata` to control the response metadata. If you use the `odata` directive in OData v4 mode, you will get an error, like: _The HTTP header ACCEPT is missing or its value is invalid._. It is  possible to set the SPHttpClient to OData v3.0 mode, by setting the `odata-version` request header to empty value:
 
-```ts
+```typescript
 this.context.spHttpClient
   .get(`${this.context.pageContext.web.absoluteUrl}/_api/web?$select=Title`,
     SPHttpClient.configurations.v1,
@@ -86,7 +86,7 @@ The SPHttpClient offers basic support for communicating with the SharePoint REST
 
 [PnPjs](https://pnp.github.io/pnpjs/) is an open-source JavaScript library for communicating with SharePoint and Office 365. It exposes a fluent API that allows you to easily consume SharePoint and Office 365 REST APIs in a type-safe way. To retrieve a the title of the current site using PnPjs, you would execute the following code:
 
-```ts
+```typescript
 sp.web
   .select('Title')
   .get<{Title: string;}>()

--- a/docs/spfx/css-recommendations.md
+++ b/docs/spfx/css-recommendations.md
@@ -157,7 +157,7 @@ The CSS class names in CSS modules are generated dynamically, which makes it imp
 
 #### todoList.module.scss.js
 
-```js
+```javascript
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 /* tslint:disable */

--- a/docs/spfx/debug-modern-pages.md
+++ b/docs/spfx/debug-modern-pages.md
@@ -59,13 +59,13 @@ When you add a new SharePoint Framework extension to your project, the SharePoin
 
 Next to the default configuration, the SharePoint Framework Yeoman generator will create an entry for each extension that you add to your project. Each entry contains a URL of the modern page that should be used to test the particular extension, the list of extensions that should be loaded and for each extension, the list of properties that should be set on them. To use the particular serve configuration, execute in the command line:
 
-```shell
+```console
 gulp serve --config=<name>
 ```
 
 for example:
 
-```shell
+```console
 gulp serve --config=helloWorld
 ```
 
@@ -83,7 +83,7 @@ By default, when debug scripts are enabled and allowed once on a page, they will
 
 If you're working with a version of the SharePoint Framework older than 1.3.0, and you want to debug an extension on a modern page, you have to manually construct the URL with the required parameters. First, start the local gulp server, by in the command line changing the working directory to your project folder and then executing:
 
-```shell
+```console
 gulp serve --nobrowser
 ```
 
@@ -156,7 +156,7 @@ Once you confirm, the page will load with the extensions you specified in your s
 
 To test the local versions of your SharePoint Framework client-side web parts on modern SharePoint pages in your tenant, first, start the local gulp server, by changing the working directory to your project folder and executing in the command line:
 
-```shell
+```console
 gulp serve --nobrowser
 ```
 
@@ -186,7 +186,7 @@ Using the SharePoint workbench, you can only test web parts from your solution. 
 
 If you build your SPFx webpart solution without the --ship parameter as following
 
-```shell
+```console
 gulp bundle
 gulp package-solution
 ```
@@ -195,7 +195,7 @@ the packages generated will reference the code from your local computer (https:/
 
 You can then start your local server  by running
 
-```shell
+```console
 gulp serve --nobrowser
 ```
 

--- a/docs/spfx/dynamic-data.md
+++ b/docs/spfx/dynamic-data.md
@@ -21,7 +21,7 @@ Dynamic data in the SharePoint Framework is based on the source-notification mod
 
 Every dynamic data source implements the `IDynamicDataCallables` interface. Following, is an example of a web part that displays a list of upcoming events. For each event, it includes some information such as its name, description, and location. The events web part exposes information about the selected event to other components on the page in two ways: the complete event information and the location address.
 
-```ts
+```typescript
 import {
   IDynamicDataPropertyDefinition,
   IDynamicDataCallables
@@ -157,7 +157,7 @@ In the example code, the web part displays upcoming events in a list. Each time,
 
 Web parts can consume data exposed by dynamic data sources present on the page. Following is the code of a web part showing on a map the location of the event selected in the events list web part showed previously.
 
-```ts
+```typescript
 import { DynamicProperty } from '@microsoft/sp-component-base';
 import {
   DynamicDataSharedDepth,
@@ -329,7 +329,7 @@ SharePoint Framework offers standard UI for connecting web parts to dynamic data
 
 Each web part property, for which the data can be retrieved from a dynamic data source, should be defined as `DynamicProperty<T>` where the `T` type denotes the type of data stored in the property, for example:
 
-```ts
+```typescript
 /**
  * Map web part properties
  */
@@ -349,7 +349,7 @@ In this example, the address is a string, but other types of data such as boolea
 
 For each dynamic property, you have to specify the type of data it holds. This is necessary, so that the instance of the web part added to a page can be properly serialized. For each dynamic web part property, in the `propertiesMetadata` getter, specify the `dynamicPropertyType` value:
 
-```ts
+```typescript
 protected get propertiesMetadata(): IWebPartPropertiesMetadata {
   return {
     // Specify the web part properties data type to allow the address
@@ -377,7 +377,7 @@ To allow users to connect web parts to dynamic data sources available on the pag
 
 In its simplest form, the UI could be defined as follows:
 
-```ts
+```typescript
 protected getPropertyPaneConfiguration(): IPropertyPaneConfiguration {
   return {
     pages: [
@@ -406,7 +406,7 @@ For each set of dynamic properties, add a new group using the `PropertyPaneDynam
 
 If your dynamic data field set consists of multiple dynamic properties, you can specify how the connection data is shared using the `sharedConfiguration.depth`  property:
 
-```ts
+```typescript
 groupFields: [
   PropertyPaneDynamicFieldSet({
     label: 'Address',
@@ -433,7 +433,7 @@ When building web parts, you can allow users to connect web parts to other compo
 
 To allow users to choose if they want to load data from a dynamic property or enter the value themselves in the web part properties, you can define the web part properties group as a `IPropertyPaneConditionalGroup` group.
 
-```ts
+```typescript
 protected getPropertyPaneConfiguration(): IPropertyPaneConfiguration {
   return {
     pages: [

--- a/docs/spfx/extensions/get-started/query-suggestion-tutorial-building.md
+++ b/docs/spfx/extensions/get-started/query-suggestion-tutorial-building.md
@@ -26,19 +26,19 @@ Be sure you have completed the procedures in the following articles before you b
 
 1. Create a new project directory in your favorite location:
 
-    ```shell
+    ```console
     md query-extension
     ```
 
 1. Go to the project directory:
 
-    ```shell
+    ```console
     cd query-extension
     ```
 
 1. Create a new client-side web part solution by running the Yeoman SharePoint Generator:
 
-    ```shell
+    ```console
     yo @microsoft/sharepoint --plusbeta
     ```
 
@@ -67,7 +67,7 @@ Be sure you have completed the procedures in the following articles before you b
 
 1. Next, enter the following to open the web part project in Visual Studio Code:
 
-    ```shell
+    ```console
     code .
     ```
 

--- a/docs/spfx/office-ui-fabric-integration.md
+++ b/docs/spfx/office-ui-fabric-integration.md
@@ -300,7 +300,7 @@ Solutions build with *no JavaScript framework* option.
 1. Add `@uifabric/styling` package to your `package.json`
 1. Make code changes similar to below code, to get the required icon into your code:
 
-```ts
+```typescript
   import { getIconClassName } from '@uifabric/styling';
 
   return `<i class="${getIconClassName('Mail')}" />`;
@@ -311,7 +311,7 @@ Solutions build with *React* option or by using *React* in general.
 1. Add `office-ui-fabric-react` package to your `package.json`, if not already added.
 2. Make code changes similar to below code, to get the required icon into your code:
 
-```ts
+```typescript
   import { Icon } from 'office-ui-fabric-react/lib/Icon';
 
   <Icon iconName='Mail' />

--- a/docs/spfx/office-ui-fabric-integration.md
+++ b/docs/spfx/office-ui-fabric-integration.md
@@ -92,7 +92,7 @@ We recommend that you use the versions of the Office UI Fabric React package inc
 
 After the Fabric React package is installed, you can import the required components from the Fabric React bundle.
 
-```js
+```javascript
 //import Button component from Fabric React Button bundle
 import { Button } from 'office-ui-fabric-react/lib/Button';
 
@@ -178,7 +178,7 @@ The rest of the page would contain unscoped Office UI Fabric Core styles. This w
 
 *Overriding* Fabric Core styles would not be supported.  
 
-```js
+```javascript
 // Sample of how the scoping would work.
 import { SPComponentLoader } from '@microsoft/sp-loader';
 

--- a/docs/spfx/subscribe-to-list-notifications.md
+++ b/docs/spfx/subscribe-to-list-notifications.md
@@ -24,7 +24,7 @@ To subscribe to changes to files stored in a SharePoint Document Library, create
 
 Following, is an example of a list subscription for a Document Library located in the current site:
 
-```ts
+```typescript
 import { ListSubscriptionFactory, IListSubscription } from '@microsoft/sp-list-subscription';
 import { Guid } from '@microsoft/sp-core-library';
 
@@ -60,7 +60,7 @@ Depending on your solution, you might need to provide additional configuration w
 
 If you use SharePoint in a multi-geography tenancy, you need to provide the domain where the particular site collection lives in. You can do it, using the `domain` property, for example:
 
-```ts
+```typescript
 this._listSubscriptionFactory.createSubscription({
   domain: this.properties.siteDomain,
   siteId: Guid.parse(this.properties.siteId),
@@ -78,7 +78,7 @@ In some cases, you might want to get notified when the component that you're bui
 
 The list subscription API, exposes two additional callbacks which you can implement to respond to the subscription status. The following code illustrates the case, where the component will be notified when the subscription has been established and when it was disconnected.
 
-```ts
+```typescript
 private createListSubscription(): void {
   this._listSubscriptionFactory.createSubscription({
     domain: this.properties.siteDomain,

--- a/docs/spfx/tenant-properties.md
+++ b/docs/spfx/tenant-properties.md
@@ -94,7 +94,7 @@ Get-PnPStorageEntity
 
 # [Office 365 CLI](#tab/o365cli)
 
-```shell
+```console
 spo storageentity list
 ```
 
@@ -144,7 +144,7 @@ Get-PnPStorageEntity -Key <key>
 
 # [Office 365 CLI](#tab/o365cli)
 
-```shell
+```console
 spo storageentity get --key <key>
 ```
 
@@ -178,7 +178,7 @@ Set-PnPStorageEntity -Key <key> -Value <value>
 
 # [Office 365 CLI](#tab/o365cli)
 
-```shell
+```console
 spo storageentity set --key <key> --value <value>
 ```
 
@@ -212,7 +212,7 @@ Remove-PnPStorageEntity -Key <key>
 
 # [Office 365 CLI](#tab/o365cli)
 
-```shell
+```console
 spo storageentity remove --key <key>
 ```
 

--- a/docs/spfx/toolchain/implement-ci-cd-with-azure-devops.md
+++ b/docs/spfx/toolchain/implement-ci-cd-with-azure-devops.md
@@ -115,7 +115,7 @@ You also need to configure your project to leverage jest when typing commands. T
 
 To write your first unit test, create a new file `src/webparts/webPartName/tests/webPartName.spec.ts` and add the following content:
 
-```TS
+```typescript
 import 'jest'
 
 describe("webPartName", () => {

--- a/docs/spfx/toolchain/implement-ci-cd-with-azure-devops.md
+++ b/docs/spfx/toolchain/implement-ci-cd-with-azure-devops.md
@@ -73,7 +73,7 @@ The SharePoint Framework does not provide a testing framework by default (since 
 
 By default SharePoint Framework projects does not include a testing Framework. We will leverage Jest in this sample.
 
-```shell
+```console
 npm i jest jest-junit @voitanos/jest-preset-spfx-react16 -D
 ```
 

--- a/docs/spfx/toolchain/integrate-gulp-tasks-in-build-pipeline.md
+++ b/docs/spfx/toolchain/integrate-gulp-tasks-in-build-pipeline.md
@@ -21,7 +21,7 @@ One common task you can add to the SharePoint Framework toolchain is to integrat
 ## Gulp tasks
 Normally gulp tasks are defined in the `gulpfile.js` as:
 
-```js
+```javascript
 gulp.task('somename', function() {
   // Do stuff
 });
@@ -33,7 +33,7 @@ When working with the SharePoint Framework toolchain, it is necessary to define 
 
 SharePoint Framework uses a [common build toolchain](sharepoint-framework-toolchain.md#common-build-tool-packages) that consists of a set of npm packages that share common build tasks. Hence, the default tasks are defined in the common package as opposed to your client-side project's `gulpfile.js`. To see the available tasks, you can execute the following command in a console within your project directory:
 
-```js
+```javascript
 gulp --tasks
 ```
 
@@ -53,7 +53,7 @@ Open the `gulpfile.js` in your code editor. The default code initializes the Sha
 
 To add your custom gulp task, add a new subtask to the SharePoint Framework build pipeline by using the [`build.subTask`](https://github.com/Microsoft/web-build-tools/blob/master/core-build/gulp-core-build/README.md#defining-a-custom-task) function:
 
-```js
+```javascript
 let helloWorldSubtask = build.subTask('log-hello-world-subtask', function(gulp, buildOptions, done) {
   this.log('Hello, World!');   
   // use functions from gulp task here
@@ -65,7 +65,7 @@ let helloWorldSubtask = build.subTask('log-hello-world-subtask', function(gulp, 
 
 In the case of a stream, you return the stream:
 
-```js
+```javascript
 let helloWorldSubtask = build.subTask('log-hello-world-subtask', function(gulp, buildOptions, done) {
   return gulp.src('images/*.png')
              .pipe(gulp.dest('public'));
@@ -75,7 +75,7 @@ let helloWorldSubtask = build.subTask('log-hello-world-subtask', function(gulp, 
 ### Register your task with gulp command line
 After the custom task is defined, you can register this custom task with the gulp command line by using the `build.task` function:
 
-```js
+```javascript
 // Register the task with gulp command line
 let helloWorldTask = build.task('hello-world', helloWorldSubtask);
 ```
@@ -87,7 +87,7 @@ let helloWorldTask = build.task('hello-world', helloWorldSubtask);
 
 Now you can execute your custom command in the command line as follows:
 
-```js
+```javascript
 gulp hello-world
 ```
 
@@ -126,7 +126,7 @@ You can also add this custom task to be executed before or after certain availab
 
 The SharePoint Framework tasks are available in the default build rig. The build rig is a collection of tasks defined for a specific purpose, in our case, building client-side packages. You can access this default rig by using the `build.rig` object and then get access to the pre- and post-task functions:
  
-```js
+```javascript
 // execute before the TypeScript subtask
 build.rig.addPreBuildTask(helloWorldTask);
 
@@ -145,7 +145,7 @@ You can download the completed sample at [samples/js-extend-gulp/](https://aka.m
 
 In the [image resize task's documentation](https://www.npmjs.com/package/gulp-image-resize#example), it shows how to use this custom task:
 
-```js
+```javascript
 var gulp = require('gulp');
 var imageResize = require('gulp-image-resize');
  
@@ -165,7 +165,7 @@ gulp.task('default', function () {
 
 We use this information to add this task in our project by using the `build.subTask` and `build.task` functions:
 
-```js
+```javascript
 var imageResize = require('gulp-image-resize');
 
 let imageResizeSubTask = build.subTask('image-resize-subtask', function(gulp, buildOptions, done){
@@ -187,7 +187,7 @@ Because we are defining the stream, we return the stream in the `build.subTask` 
 
 Now, you can execute this task from the gulp command line as follows:
 
-```js
+```javascript
 gulp resize-images
 ```
 

--- a/docs/spfx/toolchain/optimize-builds-for-production.md
+++ b/docs/spfx/toolchain/optimize-builds-for-production.md
@@ -49,7 +49,7 @@ npm install webpack-bundle-analyzer --save-dev
 
 Next, change the contents of the **gulpfile.js** file in your project to:
 
-```js
+```javascript
 'use strict';
 
 const gulp = require('gulp');

--- a/docs/spfx/toolchain/provision-sharepoint-assets.md
+++ b/docs/spfx/toolchain/provision-sharepoint-assets.md
@@ -274,7 +274,7 @@ The configurations defined in the `package-solution.json` is what maps the XML f
 
 After you have defined your feature in the `package-solution.json` and created the respective feature XML files, you can use the following gulp task to package the SharePoint items along with your `.sppkg` package.
 
-```js
+```javascript
 gulp package-solution
 ```
 

--- a/docs/spfx/use-aad-tutorial.md
+++ b/docs/spfx/use-aad-tutorial.md
@@ -34,7 +34,7 @@ If you're already familiar with how to create SharePoint Framework solutions, yo
 
 If you have an old version of the SharePoint Framework generator, you need to update it to version 1.4.1 or later. To do that, run the following command to globally install the latest version of the package.
 
-```shell
+```console
 npm install -g @microsoft/generator-sharepoint
 ```
 
@@ -44,7 +44,7 @@ Next, create a new SharePoint Framework solution:
 
 1. Run the Yeoman generator to scaffold a new solution.
 
-   ```shell
+   ```console
    yo @microsoft/sharepoint
    ```
 
@@ -58,7 +58,7 @@ Next, create a new SharePoint Framework solution:
 
 1. Start Visual Studio Code (or your favorite code editor) within the context of the current folder.
 
-   ```shell
+   ```console
    code .
    ```
 
@@ -591,13 +591,13 @@ You're now ready to build, bundle, package, and deploy the solution.
 
 1. Run the gulp commands to verify that the solution builds correctly.
 
-    ```shell
+    ```console
     gulp build
     ```
 
 1. Use the following command to bundle and package the solution.
 
-    ```shell
+    ```console
     gulp bundle
     gulp package-solution
     ```
@@ -632,7 +632,7 @@ You're now ready to build, bundle, package, and deploy the solution.
 
 1. Run your solution by using the following gulp command.
 
-    ```shell
+    ```console
     gulp serve --nobrowser
     ```
 

--- a/docs/spfx/use-aadhttpclient-enterpriseapi-multitenant.md
+++ b/docs/spfx/use-aadhttpclient-enterpriseapi-multitenant.md
@@ -352,13 +352,13 @@ In the code editor, open the **src\webparts\orders\OrdersWebPart.ts** file.
 
 In the top section of the file, reference the **AadHttpClient** and **HttpClientResponse** classes, by adding the following code snippet:
 
-```ts
+```typescript
 import { AadHttpClient, HttpClientResponse } from '@microsoft/sp-http';
 ```
 
 To the **OrdersWebPart** class, add a new class variable named `ordersClient`:
 
-```ts
+```typescript
 export default class OrdersWebPart extends BaseClientSideWebPart<IOrdersWebPartProps> {
   private ordersClient: AadHttpClient;
 
@@ -368,7 +368,7 @@ export default class OrdersWebPart extends BaseClientSideWebPart<IOrdersWebPartP
 
 Next, in the **OrdersWebPart** class, override the **onInit** method to create an instance of the AadHttpClient:
 
-```ts
+```typescript
 export default class OrdersWebPart extends BaseClientSideWebPart<IOrdersWebPartProps> {
   private ordersClient: AadHttpClient;
 
@@ -391,7 +391,7 @@ The URI passed into the `getClient()` method is the Application ID URI of the Az
 
 Finally, extend the **render** method to load and display orders retrieved from the enterprise API:
 
-```ts
+```typescript
 export default class OrdersWebPart extends BaseClientSideWebPart<IOrdersWebPartProps> {
   private ordersClient: AadHttpClient;
 

--- a/docs/spfx/use-aadhttpclient-enterpriseapi.md
+++ b/docs/spfx/use-aadhttpclient-enterpriseapi.md
@@ -290,13 +290,13 @@ In the code editor, open the **src\webparts\orders\OrdersWebPart.ts** file:
 
 In the top section of the file, reference the **AadHttpClient** and **HttpClientResponse** classes, by adding the following code snippet:
 
-```ts
+```typescript
 import { AadHttpClient, HttpClientResponse } from '@microsoft/sp-http';
 ```
 
 To the **OrdersWebPart** class, add a new class variable named `ordersClient`:
 
-```ts
+```typescript
 export default class OrdersWebPart extends BaseClientSideWebPart<IOrdersWebPartProps> {
   private ordersClient: AadHttpClient;
 
@@ -306,7 +306,7 @@ export default class OrdersWebPart extends BaseClientSideWebPart<IOrdersWebPartP
 
 Next, in the **OrdersWebPart** class, override the **onInit** method to create an instance of the AadHttpClient:
 
-```ts
+```typescript
 export default class OrdersWebPart extends BaseClientSideWebPart<IOrdersWebPartProps> {
   private ordersClient: AadHttpClient;
 
@@ -329,7 +329,7 @@ The GUID passed as the second parameter of the **AadHttpClient** constructor, is
 
 Finally, extend the **render** method to load and display orders retrieved from the enterprise API:
 
-```ts
+```typescript
 export default class OrdersWebPart extends BaseClientSideWebPart<IOrdersWebPartProps> {
   private ordersClient: AadHttpClient;
 

--- a/docs/spfx/use-developer-dashboard.md
+++ b/docs/spfx/use-developer-dashboard.md
@@ -32,7 +32,7 @@ When building SharePoint Framework components, you can use the built-in logger t
 
 Following, is how you would log a verbose message to the SharePoint Framework developer dashboard:
 
-```ts
+```typescript
 // [...] shortened for brevity
 import { Log } from '@microsoft/sp-core-library';
 

--- a/docs/spfx/web-parts/basics/working-with-requestdigest.md
+++ b/docs/spfx/web-parts/basics/working-with-requestdigest.md
@@ -53,7 +53,7 @@ The benefit of using the DigestCache service over manually obtaining a valid req
 
 1. Import the **DigestCache** and **IDigestCache** types from the **\@microsoft/sp-http** package:
 
-    ```ts
+    ```typescript
     // ...
     import { IDigestCache, DigestCache } from '@microsoft/sp-http';
 
@@ -64,7 +64,7 @@ The benefit of using the DigestCache service over manually obtaining a valid req
 
 1. Whenever you need a valid request digest token, retrieve a reference to the DigestCache service, and call its **fetchDigest** method:
 
-    ```ts
+    ```typescript
     // ...
     import { IDigestCache, DigestCache } from '@microsoft/sp-http';
 

--- a/docs/spfx/web-parts/basics/working-with-requestdigest.md
+++ b/docs/spfx/web-parts/basics/working-with-requestdigest.md
@@ -11,7 +11,7 @@ When executing non-GET REST requests to the SharePoint API, you must add a valid
 
 In classic pages, SharePoint includes a request digest token on the page in a hidden field named **__REQUESTDIGEST**. One of the most common approaches to work with the request digest is to obtain it from that field and add it to the request, for example:
 
-```js
+```javascript
 var digest = $('#__REQUESTDIGEST').val();
 $.ajax({
     url: '/_api/web/...'

--- a/docs/spfx/web-parts/get-started/deploy-web-part-to-cdn.md
+++ b/docs/spfx/web-parts/get-started/deploy-web-part-to-cdn.md
@@ -75,13 +75,13 @@ Note, however, that you have not yet deployed the files.
 
 1. Create a new project directory in your preferred location:
 
-    ```shell
+    ```console
     md azurehosted-webpart
     ```
 
 1. Go to the project directory:
 
-    ```shell
+    ```console
     cd azurehosted-webpart
     ```
 
@@ -112,7 +112,7 @@ Note, however, that you have not yet deployed the files.
 
 1. Enter the following to open the web part project in Visual Studio Code:
 
-    ```shell
+    ```console
     code .
     ```
 
@@ -209,13 +209,13 @@ Before uploading the assets to CDN, you need to build them.
 
 1. Switch to the console and execute the following `gulp` task:
 
-    ```shell
+    ```console
     gulp bundle --ship
     ```
 
     This builds the minified assets required to upload to the CDN provider. The `--ship` indicates the build tool to build for distribution. You should also notice that the output of the build tools indicate the Build Target is SHIP.
 
-    ```shell
+    ```console
     Build target: SHIP
     [21:23:01] Using gulpfile ~/apps/azurehosted-webpart/gulpfile.js
     [21:23:01] Starting gulp
@@ -229,7 +229,7 @@ Before uploading the assets to CDN, you need to build them.
 1. Switch to the console of the **azurehosted-webpart** project directory.
 1. Enter the gulp task to deploy the assets to your storage account:
 
-    ```shell
+    ```console
     gulp deploy-azure-storage
     ```
 
@@ -244,7 +244,7 @@ Because you changed the web part bundle, you need to redeploy the package to the
 1. Switch to the console of the **azurehosted-webpart** project directory.
 1. Enter the gulp task to package the client-side solution, this time with the `--ship` flag set. This forces the task to pick up the CDN base path configured in the previous step:
 
-    ```shell
+    ```console
     gulp package-solution --ship
     ```
 
@@ -276,7 +276,7 @@ Because you changed the web part bundle, you need to redeploy the package to the
 
 To deploy the assets to your favorite CDN provider, you can copy the files from **temp\deploy** folder. To generate assets for distribution, run the following gulp command as we did before with the **--ship** parameter:
 
-```shell
+```console
 gulp bundle --ship
 ```
 

--- a/docs/spfx/web-parts/get-started/office-addins-tutorial.md
+++ b/docs/spfx/web-parts/get-started/office-addins-tutorial.md
@@ -30,19 +30,19 @@ Starting with the SharePoint Framework v1.10, you can also implement your Office
 
 1. Create a new project directory in your favorite location:
 
-   ```shell
+   ```console
     md outlook-add-in
    ```
 
 1. Go to the project directory:
 
-    ```shell
+    ```console
     cd outlook-add-in
     ```
 
 1. Create a new client-side web part solution by running the Yeoman SharePoint Generator:
 
-    ```shell
+    ```console
     yo @microsoft/sharepoint --plusbeta
     ```
 
@@ -67,7 +67,7 @@ Starting with the SharePoint Framework v1.10, you can also implement your Office
 
 1. Next, enter the following to open the web part project in Visual Studio Code:
 
-    ```shell
+    ```console
     code .
     ```
 
@@ -85,7 +85,7 @@ Manifest file contains by default definition to expose your add-in as a tool pan
 
 In the console, enter the following to install the types for the Office JavaScript SDK from the npm:
 
-```shell
+```console
 npm install @types/office-js --save-dev
 ```
 
@@ -147,13 +147,13 @@ Ensure that your console is activated in the root folder of the solution, which 
 
 1. Execute the following commands to build bundle your solution. This executes a release build of your project by using a dynamic label as the host URL for your assets.
 
-    ```shell
+    ```console
     gulp bundle --ship
     ```
 
 1. Execute the following task to package your solution. This creates an updated **outlook-add-in.sppkg** package on the **sharepoint/solution** folder.
 
-    ```shell
+    ```console
     gulp package-solution --ship
     ```
 

--- a/docs/spfx/web-parts/guidance/build-client-side-web-parts-with-angular-1-x.md
+++ b/docs/spfx/web-parts/guidance/build-client-side-web-parts-with-angular-1-x.md
@@ -803,7 +803,7 @@ To allow users to configure the value of your newly added property, you have to 
 
 5. Provide the actual values for the newly defined strings. In the code editor, open the **loc/en-us.js** file, and change its contents to:
 
-  ```js
+  ```javascript
   define([], function() {
     return {
       "PropertyPaneDescription": "Manage configuration of the To do web part",

--- a/docs/spfx/web-parts/guidance/connect-to-api-secured-with-aad.md
+++ b/docs/spfx/web-parts/guidance/connect-to-api-secured-with-aad.md
@@ -247,7 +247,7 @@ The current ADAL JS functionality is unsuitable for use in web parts. Use the fo
 
 **WebPartAuthenticationContext.js**
 
-```js
+```javascript
 const AuthenticationContext = require('adal-angular');
 
 AuthenticationContext.prototype._getItemSuper = AuthenticationContext.prototype._getItem;

--- a/docs/spfx/web-parts/guidance/connect-to-api-secured-with-aad.md
+++ b/docs/spfx/web-parts/guidance/connect-to-api-secured-with-aad.md
@@ -107,7 +107,7 @@ If your SharePoint Framework solution requires permissions to specific resources
 
 Following is how you would use the AadTokenProvider to retrieve an access token for an enterprise API secured with Azure AD and use it to do a web request using jQuery:
 
-```ts
+```typescript
 // ...
 import * as $ from 'jquery';
 import { AadTokenProvider } from '@microsoft/sp-http';
@@ -352,7 +352,7 @@ For ADAL JS to work correctly in SharePoint Framework web parts, you have to con
 
 1. Define a custom interface that extends the standard ADAL JS `Config` interface to expose additional properties on the configuration object.
 
-    ```ts
+    ```typescript
     export interface IAdalConfig extends adal.Config {
       popUp?: boolean;
       callback?: (error: any, token: string) => void;
@@ -364,7 +364,7 @@ For ADAL JS to work correctly in SharePoint Framework web parts, you have to con
 
 1. Load the ADAL JS patch, the custom configuration interface, and your configuration object into the main component of your web part.
 
-    ```ts
+    ```typescript
     import * as AuthenticationContext from 'adal-angular';
     import adalConfig from '../AdalConfig';
     import { IAdalConfig } from '../../IAdalConfig';
@@ -373,7 +373,7 @@ For ADAL JS to work correctly in SharePoint Framework web parts, you have to con
 
 1. In the constructor of your component, extend the ADAL JS configuration with additional properties and use it to create a new instance of the `AuthenticationContext` class.
 
-    ```ts
+    ```typescript
     export default class UpcomingMeetings extends React.Component<IUpcomingMeetingsProps, IUpcomingMeetingsState> {
       private authCtx: adal.AuthenticationContext;
     

--- a/docs/spfx/web-parts/guidance/localize-web-parts.md
+++ b/docs/spfx/web-parts/guidance/localize-web-parts.md
@@ -173,7 +173,7 @@ You can broaden the appeal of your SharePoint Framework client-side web part by 
 
 1. Update the US English locale file by opening the **./src/webparts/greeting/loc/en-us.js** file and changing its code to:
 
-    ```js
+    ```javascript
     define([], function() {
       return {
         "PropertyPaneDescription": "Greeting web part configuration",
@@ -285,7 +285,7 @@ You can override this behavior by creating a locale file named **default.js** wi
 
 1. In the **./src/webparts/greetings/loc** folder, create a new file named **nl-nl.js**, and enter the following code:
 
-    ```js
+    ```javascript
     define([], function() {
       return {
         "PropertyPaneDescription": "Instellingen van het begroeting webonderdeel",
@@ -393,7 +393,7 @@ The last step is to provide localized versions for the new string in all locales
 
 1. In the code editor, open the **./src/webparts/greeting/loc/en-us.js** file, and change its code to:
 
-    ```js
+    ```javascript
     define([], function() {
       return {
         "PropertyPaneDescription": "Greeting web part configuration",
@@ -406,7 +406,7 @@ The last step is to provide localized versions for the new string in all locales
 
 1. Open the **./src/webparts/greeting/loc/nl-nl.js** file, and change its code to:
 
-    ```js
+    ```javascript
     define([], function() {
       return {
         "PropertyPaneDescription": "Instellingen van het begroeting webonderdeel",
@@ -442,7 +442,7 @@ Finding out about all these issues late in the project will likely lead to delay
 
 1. In the **./src/webparts/greeting/loc** folder, add a new file named **qps-ploc.js**, and paste the following code:
 
-    ```js
+    ```javascript
     define([], function() {
       return {
         "PropertyPaneDescription": "[!!! Gřèèƭïñϱ ωèβ ƥářƭ çôñƒïϱúřáƭïôñ ℓôřè₥ ïƥƨú !!!]",
@@ -761,7 +761,7 @@ Now that you can retrieve the information about the languages enabled on the cur
 
     **./src/webparts/greeting/loc/en-us.js**
 
-    ```js
+    ```javascript
     define([], function() {
       return {
         "PropertyPaneDescription": "Greeting web part configuration",
@@ -773,7 +773,7 @@ Now that you can retrieve the information about the languages enabled on the cur
 
     **./src/webparts/greeting/loc/nl-nl.js**
 
-    ```js
+    ```javascript
     define([], function() {
       return {
         "PropertyPaneDescription": "Instellingen van het begroeting webonderdeel",
@@ -785,7 +785,7 @@ Now that you can retrieve the information about the languages enabled on the cur
 
     **./src/webparts/greeting/loc/qps-ploc.js**
 
-    ```js
+    ```javascript
     define([], function() {
       return {
         "PropertyPaneDescription": "[!!! Gřèèƭïñϱ ωèβ ƥářƭ çôñƒïϱúřáƭïôñ ℓôřè₥ ïƥƨú !!!]",

--- a/docs/spfx/web-parts/guidance/localize-web-parts.md
+++ b/docs/spfx/web-parts/guidance/localize-web-parts.md
@@ -61,7 +61,7 @@ You can broaden the appeal of your SharePoint Framework client-side web part by 
 
 1. In the code editor, open the **./src/webparts/greeting/GreetingWebPart.ts** file, and update the definition of the `IGreetingWebPartProps` interface to the following code:
 
-    ```ts
+    ```typescript
     export interface IGreetingWebPartProps {
       greeting: string;
     }
@@ -69,7 +69,7 @@ You can broaden the appeal of your SharePoint Framework client-side web part by 
 
 1. In the same file, change the **GreetingWebPart** class to:
 
-    ```ts
+    ```typescript
     export default class GreetingWebPart extends BaseClientSideWebPart<IGreetingWebPartProps> {
 
       public render(): void {
@@ -113,7 +113,7 @@ You can broaden the appeal of your SharePoint Framework client-side web part by 
 
 1. Update the main React component by opening the **./src/webparts/greeting/components/Greeting.tsx** file and changing its code to:
 
-    ```ts
+    ```typescript
     import * as React from 'react';
     import styles from './Greeting.module.scss';
     import { IGreetingProps } from './IGreetingProps';
@@ -158,7 +158,7 @@ You can broaden the appeal of your SharePoint Framework client-side web part by 
 
 1. Update the localization TypeScript type definition file by opening the **./src/webparts/greeting/loc/mystrings.d.ts** file and changing its code to:
 
-    ```ts
+    ```typescript
     declare interface IGreetingWebPartStrings {
       PropertyPaneDescription: string;
       DisplayGroupName: string;
@@ -330,13 +330,13 @@ The default web part provided with the scaffolded SharePoint Framework project h
 1. In the code editor, open the **./src/webparts/greeting/components/Greetings.tsx** file.
 1. In the top section of the file, directly after the last `import` statement, add a reference to the localized strings:
 
-    ```ts
+    ```typescript
     import * as strings from 'GreetingWebPartStrings';
     ```
 
 1. Replace the contents of the **Greeting** class with the following code:
 
-    ```ts
+    ```typescript
     // ...
     export default class Greeting extends React.Component<IGreetingProps, {}> {
       public render(): JSX.Element {
@@ -372,7 +372,7 @@ Having replaced the string with a reference, the next step is to add that string
 
 - In the code editor, open the **./src/webparts/greetings/loc/mystrings.d.ts** file, and change its code to:
 
-    ```ts
+    ```typescript
     declare interface IGreetingWebPartStrings {
       PropertyPaneDescription: string;
       DisplayGroupName: string;
@@ -496,7 +496,7 @@ However, the currently used language is returned as a string, for example, **en-
 1. In the code editor, open the **./src/webparts/greeting/GreetingWebPart.ts** file.
 1. Add a new class variable named **locales** in the existing **GreetingWebPart** with the following code:
 
-    ```ts
+    ```typescript
     export default class GreetingWebPart extends BaseClientSideWebPart<IGreetingWebPartProps> {
       private locales = {
         1025: 'ar-SA',
@@ -560,7 +560,7 @@ However, the currently used language is returned as a string, for example, **en-
 
 1. Add two class methods that allow you to get the LCID from the locale name, and the locale name from the LCID:
 
-    ```ts
+    ```typescript
     export default class GreetingWebPart extends BaseClientSideWebPart<IGreetingWebPartProps> {
       // ...
 
@@ -612,14 +612,14 @@ Originally, the Greeting web part had the **greeting** property defined where th
 1. Open the **./src/webparts/greeting/GreetingWebPart.ts** file.
 1. Remove the **greeting** property from the `IGreetingWebPartProps` interface definition:
 
-    ```ts
+    ```typescript
     export interface IGreetingWebPartProps {
     }
     ```
 
 1. Because the main React component should display a greeting, open the **./src/webparts/greeting/components/IGreetingProps.ts** file, and change the **IGreetingProps** interface to:
 
-    ```ts
+    ```typescript
     export interface IGreetingProps {
       greeting: string;
     }
@@ -638,7 +638,7 @@ The first step is to load the information about all languages enabled on the cur
 1. In the code editor, open the **./src/webparts/greeting/GreetingWebPart.ts** file.
 1. Add a new class variable named **supportedLanguageIds**:
 
-    ```ts
+    ```typescript
     export default class GreetingWebPart extends BaseClientSideWebPart<IGreetingWebPartProps> {
       // ...
       private supportedLanguageIds: number[];
@@ -650,7 +650,7 @@ The first step is to load the information about all languages enabled on the cur
 
 1. Add the following imports just above the **GreetingWebPart**.
 
-    ```ts
+    ```typescript
     import {
       SPHttpClient,
       SPHttpClientResponse
@@ -659,7 +659,7 @@ The first step is to load the information about all languages enabled on the cur
 
 1. In the **GreetingWebPart** class, add a new method named **getSupportedLanguageIds**:
 
-    ```ts
+    ```typescript
     export default class GreetingWebPart extends BaseClientSideWebPart<IGreetingWebPartProps> {
       // ...
 
@@ -693,7 +693,7 @@ Now that you can retrieve the information about the languages enabled on the cur
 1. In the code editor, open the **./src/webparts/greeting/GreetingWebPart.ts** file.
 1. Add a new class variable named **greetingFields** to the **GreetingWebPart** class:
 
-    ```ts
+    ```typescript
     export default class GreetingWebPart extends BaseClientSideWebPart<IGreetingWebPartProps> {
       // ...
       private greetingFields: IPropertyPaneField<any>[] = [];
@@ -703,7 +703,7 @@ Now that you can retrieve the information about the languages enabled on the cur
 
 1. Change the **import** statement for the **\@microsoft/sp-webpart-base** package to:
 
-    ```ts
+    ```typescript
     import {
       BaseClientSideWebPart,
       IPropertyPaneConfiguration,
@@ -714,7 +714,7 @@ Now that you can retrieve the information about the languages enabled on the cur
 
 1. Change the **propertyPaneSettings** getter to get the list of text fields from the newly added **greetingFields** class variable:
 
-    ```ts
+    ```typescript
     export default class GreetingWebPart extends BaseClientSideWebPart<IGreetingWebPartProps> {
       // ...
 
@@ -744,7 +744,7 @@ Now that you can retrieve the information about the languages enabled on the cur
 
 1. In the code editor, open the **./src/webparts/greeting/loc/mystrings.d.ts** file, and change its code to:
 
-    ```ts
+    ```typescript
     declare interface IGreetingWebPartStrings {
       PropertyPaneDescription: string;
       GreetingGroupName: string;
@@ -797,7 +797,7 @@ Now that you can retrieve the information about the languages enabled on the cur
 
 1. In the **./src/webparts/greeting/GreetingWebPart.ts** file, override the **onPropertyPaneConfigurationStart** method by using the following code:
 
-    ```ts
+    ```typescript
     export default class GreetingWebPart extends BaseClientSideWebPart<IGreetingWebPartProps> {
       // ...
       protected onPropertyPaneConfigurationStart(): void {
@@ -836,7 +836,7 @@ Originally, the web part showed the same greeting for all users no matter what t
 
 1. In the **./src/webparts/greeting/GreetingWebPart.ts** file, change the web part's **render** method to:
 
-    ```ts
+    ```typescript
     export default class GreetingWebPart extends BaseClientSideWebPart<IGreetingWebPartProps> {
       // ...
 
@@ -852,7 +852,7 @@ Originally, the web part showed the same greeting for all users no matter what t
 
 1. In the **GreetingWebPart**, add a new method named **getGreeting**:
 
-    ```ts
+    ```typescript
     export default class GreetingWebPart extends BaseClientSideWebPart<IGreetingWebPartProps> {
       // ...
 

--- a/docs/spfx/web-parts/guidance/migrate-angular-1-x-applications-to-sharepoint-framework.md
+++ b/docs/spfx/web-parts/guidance/migrate-angular-1-x-applications-to-sharepoint-framework.md
@@ -777,7 +777,7 @@ At this point the AngularJS application works correctly and is wrapped in a Shar
 
 6. In the **./src/webparts/toDo/loc/en-us.js** file, add translations for the newly added strings:
 
-  ```js
+  ```javascript
   define([], function() {
     return {
       "PropertyPaneDescription": "Description",

--- a/docs/spfx/web-parts/guidance/migrate-jquery-datatables-script-to-spfx.md
+++ b/docs/spfx/web-parts/guidance/migrate-jquery-datatables-script-to-spfx.md
@@ -240,7 +240,7 @@ The next step is to define the Moment.js plug-in for DataTables so that dates in
 
 1. In the **./src/webparts/itRequests** folder, create a new file named **moment-plugin.js**, and paste the following code:
 
-    ```js
+    ```javascript
     // UMD
     (function (factory) {
         "use strict";
@@ -312,7 +312,7 @@ The last step is to include the code that initiates the data table and loads the
 
 1. In the **./src/webparts/itRequests** folder, create a new file named **script.js**, and paste the following code:
 
-    ```js
+    ```javascript
     $(document).ready(function () {
         $('#requests').DataTable({
             'ajax': {
@@ -415,7 +415,7 @@ The following steps illustrate how to extend the existing solution to allow user
 
 4. Open the **./src/webparts/itRequests/loc/en-us.js** file, and change its contents to:
 
-    ```js
+    ```javascript
     define([], function() {
     return {
         "PropertyPaneDescription": "IT Requests settings",

--- a/docs/spfx/web-parts/guidance/migrate-jquery-fullcalendar-script-to-spfx.md
+++ b/docs/spfx/web-parts/guidance/migrate-jquery-fullcalendar-script-to-spfx.md
@@ -266,7 +266,7 @@ The last step is to include the code that initiates the FullCalendar jQuery plug
 
 1.  In the **./src/webparts/tasksCalendar** folder, create a new file named **script.js**, and paste in the following code:
 
-  ```js
+  ```javascript
   var moment = require('moment');
 
   var PATH_TO_DISPFORM = window.webAbsoluteUrl + "/Lists/Tasks/DispForm.aspx";
@@ -464,7 +464,7 @@ The following steps illustrate how to extend the existing solution to allow user
 
 4. Open the **./src/webparts/tasksCalendar/loc/en-us.js** file, and change its contents to:
 
-  ```js
+  ```javascript
   define([], function() {
     return {
       "PropertyPaneDescription": "Tasks calendar settings",
@@ -881,7 +881,7 @@ Now that you have type definitions for all libraries installed in the project, y
   
   Compare plain JavaScript:
 
-  ```js
+  ```javascript
   var restQuery = "/_api/Web/Lists/GetByTitle('" + TASK_LIST + "')/items?$select=ID,Title,\
   Status,StartDate,DueDate,AssignedTo/Title&$expand=AssignedTo&\
   $filter=((DueDate ge '" + startDate + "' and DueDate le '" + endDate + "')or(StartDate ge '" + startDate + "' and StartDate le '" + endDate + "'))";

--- a/docs/transform/modernize-scanner.md
+++ b/docs/transform/modernize-scanner.md
@@ -159,25 +159,25 @@ Following scan options are available:
 
 Below option is the default usage of the tool for most customers: you specify the mode, your tenant name, and the created client id and secret:
 
-```shell
+```console
 SharePoint.Modernization.Scanner.exe -t <tenant> -i <clientid> -s <clientsecret>
 ```
 
 A real life sample:
 
-```shell
+```console
 SharePoint.Modernization.Scanner.exe -t contoso -i 7a5c1615-997a-4059-a784-db2245ec7cc1 -s eOb6h+s805O/V3DOpd0dalec33Q6ShrHlSKkSra1FFw=
 ```
 
 The above use will run all scanning options, but you can also target the scan via the `Mode` parameter (-m):
 
-```shell
+```console
 SharePoint.Modernization.Scanner.exe -m <mode> -t <tenant> -i <clientid> -s <clientsecret>
 ```
 
 A real life sample:
 
-```shell
+```console
 SharePoint.Modernization.Scanner.exe -m GroupifyOnly -t contoso -i 7a5c1615-997a-4059-a784-db2245ec7cc1 -s eOb6h+s805O/V3DOpd0dalec33Q6ShrHlSKkSra1FFw=
 ```
 


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- fixes #5926

## What's in this Pull Request?

- replace invalid fenced code references with supported languages from MSDocs
- replace `bash` & `shell` fenced code > `console
- replace `ts` > `typescript`
- replace `js` > `javascript`