### PR TITLE
Add "which baseline packages" question to extension projects

### DIFF
--- a/docs/spfx/extensions/get-started/build-a-hello-world-extension.md
+++ b/docs/spfx/extensions/get-started/build-a-hello-world-extension.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first SharePoint Framework Extension (Hello World part 1)
 description: Create an extension project, and then code and debug your Application Customizer.
-ms.date: 06/22/2020
+ms.date: 06/25/2020
 ms.prod: sharepoint
 localization_priority: Priority
 ms.custom: scenarios:getting-started
@@ -39,6 +39,7 @@ You can also follow the steps in this article by watching the video on the Share
 1. When prompted, enter the following values (*select the default option for all prompts omitted below*):
 
     - **What is your solution name?**: app-extension
+    - **Which baseline packages do you want to target for your component(s)?** SharePoint Online only (latest)
     - **Which type of client-side component to create?**: Extension
     - **What is your Application Customizer name?** HelloWorld
     - **What is your Application Customizer description?** HelloWorld description

--- a/docs/spfx/extensions/get-started/building-simple-cmdset-with-dialog-api.md
+++ b/docs/spfx/extensions/get-started/building-simple-cmdset-with-dialog-api.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first ListView Command Set extension
 description: Create an extension project, and then code and debug your extension by using SharePoint Framework (SPFx) Extensions.
-ms.date: 06/22/2020
+ms.date: 06/25/2020
 ms.prod: sharepoint
 ms.custom: scenarios:getting-started
 ---
@@ -37,6 +37,7 @@ You can follow these steps by watching the video on the SharePoint PnP YouTube C
 1. When prompted, enter the following values (*select the default option for all prompts omitted below*):
 
     - **What is your solution name?**: command-extension
+    - **Which baseline packages do you want to target for your component(s)?** SharePoint Online only (latest)
     - **Which type of client-side component to create?**: Extension
     - **Which type of client-side extension to create?** ListView Command Set
     - **What is your Command Set name?** HelloWorld

--- a/docs/spfx/extensions/get-started/building-simple-field-customizer.md
+++ b/docs/spfx/extensions/get-started/building-simple-field-customizer.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first Field Customizer extension
 description: Create an extension project, and then code and debug your extension by using SharePoint Framework (SPFx) Extensions.
-ms.date: 06/19/2020
+ms.date: 06/25/2020
 ms.prod: sharepoint
 ms.custom: scenarios:getting-started
 ---
@@ -37,6 +37,7 @@ You can follow these steps by watching the video on the SharePoint PnP YouTube C
 1. When prompted, enter the following values (*select the default option for all prompts omitted below*):
 
     - **What is your solution name?**: field-extension
+    - **Which baseline packages do you want to target for your component(s)?** SharePoint Online only (latest)
     - **Which type of client-side component to create?**: Extension
     - **Which type of client-side extension to create?** Field Customizer
     - **What is your Application Customizer name?** HelloWorld


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- fixes #5937

## What's in this Pull Request?

- previously removed the 2nd question in the SPFx generator
- added back to specify "SPO" as the option to select so the user sees the extension component type
