### PR TITLE
Docs wrong - returning true shows a column; false hides it.

### DIFF
--- a/docs/declarative-customization/list-form-conditional-show-hide.md
+++ b/docs/declarative-customization/list-form-conditional-show-hide.md
@@ -55,7 +55,7 @@ For example, the following formula checks if the value for the *Category* column
 =if([$Category]=='Product Management','true', 'false')
 ```
 
-Returning _true_ results in hiding the column in the form while returning _false_ does not.
+Returning _true_ results in showing the column in the form while returning _false_ will hide it.
 
 The column is represented by specifying the **internal name** of the field surrounded by square brackets and preceded by a dollar sign: [$InternalName]. For example, to get the value of a field with an internal name of "ProductName", use [$ProductName].
 


### PR DESCRIPTION
Documentation states "Returning _true_ results in hiding the column in the form while returning _false_ does not." 

This isn't correct. Returning 'true' will show the column, and 'false' will hide it.

## Category

- [X] Content fix
- [ ] New article
