### PR TITLE
Update TOC to reflect page title change

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -125,7 +125,7 @@
     href: spfx/sharepoint-framework-overview.md
   - name: Getting started
     items:
-    - name: Set up Office 365 tenant
+    - name: Set up Microsoft 365 tenant
       href: spfx/set-up-your-developer-tenant.md
     - name: Set up development environment
       href: spfx/set-up-your-development-environment.md


### PR DESCRIPTION
Updates the TOC link title from 'Setup Office 365 tenant' to 'Setup Microsoft 365 tenant' to match the content page that it is linked to.