### PR TITLE
Update export-amr-api.md

### DIFF
--- a/docs/apis/export-amr-api.md
+++ b/docs/apis/export-amr-api.md
@@ -194,7 +194,10 @@ This function returns the changeToken associates with this query. By specifying 
 
 #### Manifest Output
 
-After the asyncMigrationRead function prepare execution, the final manifest will be placed in the container specified, under a folder named **JobId**. Manifest export package structure will be like the *createMigration* Import Package structure. The general output structure is summarized in table below.
+After the *asyncMigrationRead* function prepares execution, the final manifest will be placed in the container specified, under a folder named **JobId**. The manifest export package structure will be like the *createMigration* Import Package structure. The general output structure is summarized in table below.
+
+>[!Note]
+>Once the AMR package reaches 25MB, it will split into multiple packages per request.
 
 Below is an example on how to query the folder:
 

--- a/docs/apis/export-amr-api.md
+++ b/docs/apis/export-amr-api.md
@@ -1,6 +1,6 @@
 ---
 title: "SharePoint Migration Export (Asynchronous Metadata Read) API"
-ms.date: 04/17/2020
+ms.date: 07/31/2020
 ms.reviewer: 
 ms.author: jhendr
 author: JoanneHendrickson

--- a/docs/apis/export-amr-api.md
+++ b/docs/apis/export-amr-api.md
@@ -197,7 +197,7 @@ This function returns the changeToken associates with this query. By specifying 
 After the *asyncMigrationRead* function prepares execution, the final manifest will be placed in the container specified, under a folder named **JobId**. The manifest export package structure will be like the *createMigration* Import Package structure. The general output structure is summarized in table below.
 
 >[!Note]
->Once the AMR package reaches 25MB, it will split into multiple packages per request.
+>Once the AMR manifest package reaches 25MB, it will split into multiple packages per request.
 
 Below is an example on how to query the folder:
 


### PR DESCRIPTION
## Category

- [X] Content fix

update to document that the AMR manifest splits into multiple packages after 25MB