### PR TITLE
Fix url for spfx preview docs

### DIFF
--- a/includes/snippets/developer-preview-notice.md
+++ b/includes/snippets/developer-preview-notice.md
@@ -1,3 +1,3 @@
 
 > [!NOTE]
-> This feature is currently in developer preview feature. In order to use features in developer preview, ensure you use the `--plusbeta` version of the package. For more information, see: [Try SharePoint Framework preview capabilities](/sharepoint/dev/spfx/try-preview-capabilities.mdtry-preview-capabilities.md).
+> This feature is currently in developer preview feature. In order to use features in developer preview, ensure you use the `--plusbeta` version of the package. For more information, see: [Try SharePoint Framework preview capabilities](/sharepoint/dev/spfx/try-preview-capabilities.md).


### PR DESCRIPTION
Fixed broken link to preview documentation.

## Category

- [x] Content fix
- [ ] New article

Fixed broken link in this snippet.

To reproduce, open this page: https://docs.microsoft.com/en-us/sharepoint/dev/spfx/office-addins-create 

Then try to click on the link that says: "Try SharePoint Framework preview capabilities", the target url is broken.