### PR TITLE
fix link to tutorial in environment setup

### DIFF
--- a/docs/spfx/set-up-your-development-environment.md
+++ b/docs/spfx/set-up-your-development-environment.md
@@ -100,7 +100,7 @@ You should be using a modern web browser like [Microsoft Edge](https://www.micro
 
 The SharePoint Framework's local webserver, used when testing your custom solutions from your development environment, uses HTTPS by default. This is implemented using a development self-signed SSL certificate. Self-signed SSL certificates are not trusted by your developer environment. You must first configure your development environment to trust the certificate.
 
-A utility task is included in every SharePoint Framework project in the form of a gulp task. You can elect to do this now, or wait until you create your first project as covered in the [Build your first SharePoint client-side web part (Hello World part 1): Preview the web part]([Build your first SharePoint client-side web part (Hello World part 1)](web-parts/get-started/build-a-hello-world-web-part.md)) tutorial.
+A utility task is included in every SharePoint Framework project in the form of a gulp task. You can elect to do this now, or wait until you create your first project as covered in the [Build your first SharePoint client-side web part (Hello World part 1)](web-parts/get-started/build-a-hello-world-web-part.md) tutorial.
 
 Once a project has been created with the Yeoman generator for the SharePoint Framework, execute the following command from within the root folder of the project.
 

--- a/docs/spfx/set-up-your-development-environment.md
+++ b/docs/spfx/set-up-your-development-environment.md
@@ -1,7 +1,7 @@
 ---
 title: Set up your SharePoint Framework development environment
 description: Use Visual Studio or your own custom development environment to build SharePoint Framework solutions. You can use a Mac, PC, or Linux.
-ms.date: 07/02/2020
+ms.date: 07/31/2020
 ms.prod: sharepoint
 localization_priority: Priority
 ms.custom: scenarios:getting-started


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

None that I could find.

## What's in this Pull Request?

This PR fixes an issue in the link to the SPFx 'getting started' tutorial in the [setting up your environment](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/set-up-your-development-environment#trusting-the-self-signed-developer-certificate) section of the docs. The link was not formatted properly and appears incorrectly in the markdown.

