### PR TITLE
Add requirement for domElement and context in SPFx app store guidance

### DIFF
--- a/docs/spfx/publish-to-marketplace-checklist.md
+++ b/docs/spfx/publish-to-marketplace-checklist.md
@@ -31,6 +31,10 @@ When testing your application against checks described in the following section,
 
 Following checks must be passed. If one or more checks from this category failed, your application will be rejected and you will be instructed to fix the reported issues.
 
+### Ensure SharePoint Framework Contract Conformance
+
+Your webpart or customizer must only manipulate the DOM element provided through the "domElement" property. This element and the provided context object are the only approved ways to add functionality into sites through your app. Directly manipulating the page DOM will result in rejection of your solution.
+
 ### Under normal circumstances solution should work as intended
 
 Under normal circumstances, all components (web parts and extensions) in your solution should work as intended. Preferably, before submitting your application for approval, you should verify that it's working as expected on multiple tenants and using different user accounts to ensure that it doesn't depend on any specific configuration. If your solution requires specific settings, mention it explicitly in your solution's description.

--- a/docs/spfx/publish-to-marketplace-checklist.md
+++ b/docs/spfx/publish-to-marketplace-checklist.md
@@ -1,7 +1,7 @@
 ---
 title: Prepare your SharePoint Framework application for publishing to the Marketplace
 description: Tips & tricks to help you get your SharePoint Framework application published in the Marketplace
-ms.date: 07/21/2020
+ms.date: 07/31/2020
 ms.prod: sharepoint
 localization_priority: Priority
 ---
@@ -33,7 +33,7 @@ Following checks must be passed. If one or more checks from this category failed
 
 ### Ensure SharePoint Framework Contract Conformance
 
-Your webpart or customizer must only manipulate the DOM element provided through the "domElement" property. This element and the provided context object are the only approved ways to add functionality into sites through your app. Directly manipulating the page DOM will result in rejection of your solution.
+Your webpart or customizer must only manipulate the DOM element provided through the `domElement` property. This element and the provided context object are the only approved ways to add functionality into sites through your app. Directly manipulating the page DOM will result in rejection of your solution.
 
 ### Under normal circumstances solution should work as intended
 


### PR DESCRIPTION
Adds a section to explicitly call out the requirement to only manipulate the DOM via the provided domElement and context.

## Category

- [X] Content fix
- [ ] New article

## Related issues

none

## What's in this Pull Request?

Adds a section discussing the requirement to only manipulate the page via the supplied DOM element and context.
