### PR TITLE
Fixing framework selection label

### DIFF
--- a/docs/spfx/web-parts/get-started/build-a-hello-world-web-part.md
+++ b/docs/spfx/web-parts/get-started/build-a-hello-world-web-part.md
@@ -56,7 +56,7 @@ You can also follow these steps by watching this video on the SharePoint PnP You
 
     - **What is your Web part name?**: HelloWorld
     - **What is your Web part description?**: HelloWorld description
-    - **Which framework would you like to use?**: No JavaScript web framework
+    - **Which framework would you like to use?**: No JavaScript framework
 
 At this point, Yeoman creates the project scaffolding (folders & files) and installs the required dependencies by running `npm install`. This usually takes 1-3 minutes depending on your internet connection.
 


### PR DESCRIPTION
The official label of the framework selection is 'No JavaScript framework' ad not 'No JavaScript web framework'

## Category

- [x] Content fix
- [ ] New article

## What's in this Pull Request?
Content update in framework selection. It is labelled as 'No JavaScript Framework' and not 'No JavaScript web framework'

<img width="275" alt="Screenshot 2020-08-06 at 10 11 13" src="https://user-images.githubusercontent.com/5503835/89507973-86ea7000-d7cd-11ea-90af-882569c4163d.png">

