### PR TITLE
Correct the typo - framework option should be 'No JavaScript framework'

### DIFF
--- a/docs/spfx/extensions/get-started/query-suggestion-tutorial-building.md
+++ b/docs/spfx/extensions/get-started/query-suggestion-tutorial-building.md
@@ -1,7 +1,7 @@
 ---
 title: Building a query suggestion extension using SharePoint Framework
 description: Tutorial on creating a query suggestion extension with SharePoint Framework
-ms.date: 01/28/2020
+ms.date: 08/19/2020
 ms.prod: sharepoint
 localization_priority: Normal
 ---
@@ -59,7 +59,7 @@ Be sure you have completed the procedures in the following articles before you b
 
     * Enter **MyQueryExtension** for the extension name, and then select Enter.
     * Enter **My first query extension** as the description of the extension, and then select Enter. 
-    * Accept the default **No JavaScript web framework** option for the framework, and then select Enter to continue.
+    * Accept the default **No JavaScript framework** option for the framework, and then select Enter to continue.
 
     ![Yeoman prompts](../../../images/query-extension-yeoman.png)
 

--- a/docs/spfx/web-parts/get-started/using-microsoft-graph-apis.md
+++ b/docs/spfx/web-parts/get-started/using-microsoft-graph-apis.md
@@ -1,7 +1,7 @@
 ---
 title: Building SharePoint Framework solutions, which use Microsoft Graph
 description: Getting started tutorial on using Microsoft Graph with SharePoint Framework solutions
-ms.date: 06/18/2020
+ms.date: 08/19/2020
 localization_priority: Priority
 ms.prod: sharepoint
 ---
@@ -42,7 +42,7 @@ Before you start, complete the procedures in the following articles to ensure th
     - **Do you want to allow the tenant admin the choice of being able to deploy the solution to all sites immediately without running any feature deployment or adding apps in sites?**: Yes
     - **Which type of client-side component to create?**: WebPart
     - **What is your Web part name?**: MyFirstGraphWebPart
-    - **Which framework would you like to use?**: No JavaScript web framework
+    - **Which framework would you like to use?**: No JavaScript framework
 
     At this point, Yeoman installs the required dependencies and scaffolds the solution files. Creation of the solution might take a few minutes. Yeoman scaffolds the project to include your **MyFirstGraphWebPart** web part as well.
 

--- a/docs/spfx/web-parts/guidance/build-client-side-web-parts-with-angular-1-x.md
+++ b/docs/spfx/web-parts/guidance/build-client-side-web-parts-with-angular-1-x.md
@@ -1,7 +1,7 @@
 ---
 title: Tutorial - Build SharePoint Framework client-side web parts with AngularJS
 description: Use AngularJS to build a client-side web part to manage To Do items and style it using Office UI Fabric.
-ms.date: 01/29/2018
+ms.date: 08/19/2020
 ms.prod: sharepoint
 localization_priority: Priority
 ---
@@ -44,7 +44,7 @@ The source of the working web part is available on GitHub at [samples/angular-to
 
   - **angular-todo** as your solution name
   - **Use the current folder** for the location to place the files
-  - **No JavaScript web framework** as the starting point to build the web part
+  - **No JavaScript framework** as the starting point to build the web part
   - **To do** as your web part name
   - **Simple management of to do tasks** as your web part description
 

--- a/docs/spfx/web-parts/guidance/migrate-angular-1-x-applications-to-sharepoint-framework.md
+++ b/docs/spfx/web-parts/guidance/migrate-angular-1-x-applications-to-sharepoint-framework.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate AngularJS applications to SharePoint Framework
 description: Migrate an existing AngularJS application styled using ngOfficeUIFabric to a SharePoint Framework client-side web part.
-ms.date: 07/21/2020
+ms.date: 08/19/2020
 ms.prod: sharepoint
 localization_priority: Priority
 ---
@@ -50,7 +50,7 @@ Before you start migrating your AngularJS application, create and set up a new S
     - **Which type of client-side component to create?**: Web Part
     - **What is your Web part name?**: To do
     - **What is your Web part description?**: Simple management of to do tasks
-    - **Which framework would you like to use?**: No JavaScript web framework
+    - **Which framework would you like to use?**: No JavaScript framework
 
 1. Open your project folder in your code editor. In this tutorial, you'll use Visual Studio Code.
 

--- a/docs/spfx/web-parts/guidance/migrate-jquery-datatables-script-to-spfx.md
+++ b/docs/spfx/web-parts/guidance/migrate-jquery-datatables-script-to-spfx.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate jQuery and DataTables solution built using Script Editor web part to SharePoint Framework
 description: Migrate a SharePoint customization using DataTables to build powerful data overviews of data coming from SharePoint and external APIs.
-ms.date: 06/28/2018
+ms.date: 08/19/2020
 ms.prod: sharepoint
 localization_priority: Priority
 ---
@@ -160,7 +160,7 @@ Transforming this customization to the SharePoint Framework offers a number of b
     - **Which type of client-side component to create?**: Web Part
     - **What is your Web part name?**: IT requests
     - **What is your Web part description?**: Shows overview of IT support requests
-    - **Which framework would you like to use?**: No JavaScript web framework
+    - **Which framework would you like to use?**: No JavaScript framework
 
 1. Open your project folder in your code editor. In this tutorial, you'll use Visual Studio Code.
 

--- a/docs/spfx/web-parts/guidance/migrate-jquery-fullcalendar-script-to-spfx.md
+++ b/docs/spfx/web-parts/guidance/migrate-jquery-fullcalendar-script-to-spfx.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate jQuery and FullCalendar solution built using Script Editor web part to SharePoint Framework
 description: Migrate a SharePoint customization by using FullCalendar built with the Script Editor web part to the SharePoint Framework.
-ms.date: 06/30/2020
+ms.date: 08/19/2020
 ms.prod: sharepoint
 localization_priority: Priority
 ---
@@ -199,7 +199,7 @@ First, you migrate the solution to the SharePoint Framework with as few changes 
     - **Which type of client-side component to create?**: WebPart
     - **What is your Web part name?**: Tasks calendar
     - **What is your Web part description?**: Shows tasks in the calendar view
-    - **Which framework would you like to use?**: No JavaScript web framework
+    - **Which framework would you like to use?**: No JavaScript framework
 
 1. Open your project folder in your code editor. In this tutorial, you'll use Visual Studio Code.
 

--- a/docs/spfx/web-parts/guidance/reference-third-party-css-styles.md
+++ b/docs/spfx/web-parts/guidance/reference-third-party-css-styles.md
@@ -1,7 +1,7 @@
 ---
 title: Reference third-party CSS styles in SharePoint Framework web parts
 description: Two approaches to including third-party CSS styles in web parts, and how each approach affects the resulting web part bundle.
-ms.date: 01/29/2018
+ms.date: 08/19/2018
 ms.prod: sharepoint
 localization_priority: Priority
 ---
@@ -42,7 +42,7 @@ To build rich SharePoint Framework client-side web parts, you can leverage many 
 
   - **js-thirdpartycss** as your solution name
   - **Use the current folder** for the location to place the files
-  - **no javaScript web framework** as the starting point to build the web part
+  - **No JavaScript framework** as the starting point to build the web part
   - **jQuery accordion** as your web part name
   - **Shows jQuery accordion** as your web part description
 


### PR DESCRIPTION
## Category

- [X] Content fix
- [ ] New article
- [ ] Example checked item (*delete this line*)

## What's in this Pull Request?

> Correct the typo - framework option should be 'No JavaScript framework' (not 'No JavaScript **web** framework')