### PR TITLE
Removed the markdown extension from the page link

### DIFF
--- a/includes/snippets/open-source/pnp-provisioning-engine.md
+++ b/includes/snippets/open-source/pnp-provisioning-engine.md
@@ -1,3 +1,3 @@
 
 > [!NOTE]
-> The [PnP Provisioning Framework](/sharepoint/dev/solution-guidance/pnp-provisioning-framework.md) & [PnP Provisioning Engine](/sharepoint/dev/solution-guidance/Introducing-the-PnP-Provisioning-Engine.md) are open-source solutions with active community providing support for it. There is no SLA for the open-source tool support from Microsoft.
+> The [PnP Provisioning Framework](/sharepoint/dev/solution-guidance/pnp-provisioning-framework) & [PnP Provisioning Engine](/sharepoint/dev/solution-guidance/Introducing-the-PnP-Provisioning-Engine) are open-source solutions with active community providing support for it. There is no SLA for the open-source tool support from Microsoft.


### PR DESCRIPTION

## Category

- [x] Content fix
- [ ] New article

Links to these pages are broken when viewed from: 
1- https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/pnp-provisioning-framework
2- https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/pnp-remote-provisioning

Removed .md extension
