### PR TITLE
Fixed URL to a docs.microsoft.com document

### DIFF
--- a/includes/snippets/developer-preview-notice.md
+++ b/includes/snippets/developer-preview-notice.md
@@ -1,3 +1,3 @@
 
 > [!NOTE]
-> This feature is currently in developer preview feature. In order to use features in developer preview, ensure you use the `--plusbeta` version of the package. For more information, see: [Try SharePoint Framework preview capabilities](/sharepoint/dev/spfx/try-preview-capabilities.md).
+> This feature is currently in developer preview feature. In order to use features in developer preview, ensure you use the `--plusbeta` version of the package. For more information, see: [Try SharePoint Framework preview capabilities](/sharepoint/dev/spfx/try-preview-capabilities).


### PR DESCRIPTION
The link was with the ending .MD, while on the site the resource has the following URL: https://docs.microsoft.com/en-us/sharepoint/dev/spfx/try-preview-capabilities (without .MD, indeed). I'm not sure if this is a typo in this document or a more general bug in the engine managing remapping of links, which occurs when the document is included into another .MD file (like it is for this specific document). I bet the second option.
Thanks.

## Category

- [x] Content fix
- [ ] New article
- [ ] Example checked item (*delete this line*)

## What's in this Pull Request?

A fix to the content.