### PR TITLE
Removing PnP PowerShell supportability notice

### DIFF
--- a/docs/declarative-customization/site-design-powershell.md
+++ b/docs/declarative-customization/site-design-powershell.md
@@ -43,8 +43,6 @@ The following cmdlets are available for managing site designs and site scripts f
 - [Set-SPOSiteDesign](https://docs.microsoft.com/powershell/module/sharepoint-online/Set-SPOSiteDesign?view=sharepoint-ps)
 - [Set-SPOSiteScript](https://docs.microsoft.com/powershell/module/sharepoint-online/Set-SPOSiteScript?view=sharepoint-ps)
 
-[!INCLUDE [pnp-powershell](../../includes/snippets/open-source/pnp-powershell.md)]
-
 ## See also
 
 - [JSON schema reference](site-design-json-schema.md)

--- a/docs/declarative-customization/site-design-powershell.md
+++ b/docs/declarative-customization/site-design-powershell.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint site design - PowerShell cmdlets
 description: Use PowerShell cmdlets to create, retrieve, and remove site designs and site scripts.
-ms.date: 06/05/2020
+ms.date: 09/28/2020
 localization_priority: Priority
 ---
 


### PR DESCRIPTION
## Category

- [X] Content fix
- [ ] New article
-
## Related issues

N/A

## What's in this Pull Request?

Removing PnP PowerShell supportability notice as it doesn't make sense to include this with the SPO Management Shell, which is being supported by Microsoft.