### PR TITLE
Update validate-web-part-property-values.md

### DIFF
--- a/docs/spfx/web-parts/guidance/validate-web-part-property-values.md
+++ b/docs/spfx/web-parts/guidance/validate-web-part-property-values.md
@@ -171,7 +171,7 @@ In this step, you implement validation logic that checks if the list with the na
     }
     ```
 
-1. In the code editor, open the **./src/webparts/listInfo/IListInfoWebPartProps.ts** file, and extend the interface definition with the `listName` property of type string.
+1. In the code editor, open the **./src/webparts/listInfo/ListInfoWebPart.ts** file, and extend the interface definition with the `listName` property of type string.
 
     ```typescript
     export interface IListInfoWebPartProps {
@@ -219,7 +219,7 @@ In this step, you implement validation logic that checks if the list with the na
 1. Add the missing `ListNameFieldLabel` resource string by changing the code of the **./src/webparts/listInfo/loc/mystrings.d.ts** file to:
 
     ```typescript
-    declare interface IListInfoStrings {
+    declare interface IListInfoWebPartStrings {
       PropertyPaneDescription: string;
       BasicGroupName: string;
       DescriptionFieldLabel: string;
@@ -227,7 +227,7 @@ In this step, you implement validation logic that checks if the list with the na
     }
 
     declare module 'listInfoStrings' {
-      const strings: IListInfoStrings;
+      const strings: IListInfoWebPartStrings;
       export = strings;
     }
     ```


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- fixes #3687 

## What's in this Pull Request?

1. Changing the instructions as I assume the default yo @microsoft/sharepoint files and setup for this tutorial page have changed. There is no IListInfoWebPartProps.ts file.
2. Instructions for the string usage file is a typo or again the files set was changed. Needs to be IListInfoWebPartStrings, not IListInfoStrings.