### PR TITLE
Update column-formatting.md

### DIFF
--- a/docs/declarative-customization/column-formatting.md
+++ b/docs/declarative-customization/column-formatting.md
@@ -922,7 +922,7 @@ Any other value will result in an error.
 
 `Button` elements can be used to launch a specific action on the parent item.  Every `button` element has a required property, `customRowAction`, that specifies an `action` that's taken when the button is clicked. This action must be one of the following values:
 
-- **defaultClick**: buttons with this action will do the same thing as clicking the list item in an uncustomized view. Below is an example of a button that, when clicked, simulates a click on the item, which results in opening the file.
+- **defaultClick**: buttons with this action will do the same thing as clicking the list item in an uncustomized view. Below is an example of a button that, when clicked, simulates a click on the item, which results in opening the list item. Adding this example button to a document library simulates a click on the file or folder, which results in the file or folder being opened.
 
 ```JSON
 {

--- a/docs/declarative-customization/column-formatting.md
+++ b/docs/declarative-customization/column-formatting.md
@@ -1,7 +1,7 @@
 ---
 title: Use column formatting to customize SharePoint
 description: Customize how fields in SharePoint lists and libraries are displayed by constructing a JSON object that describes the elements that are displayed when a field is included in a list view, and the styles to be applied to those elements.
-ms.date: 10/26/2020
+ms.date: 11/18/2020
 localization_priority: Priority
 ---
 


### PR DESCRIPTION
Clarified the behavior of the defaultClick customRowAction when it is added to a list or a document library.

## Category

- [x] Content fix
- [ ] New article


## Related issues

- fixes #6405


## What's in this Pull Request?

Updates the defaultClick button example to clarify its use in lists and document libraries.


