### PR TITLE
Update use-aadhttpclient.md

### DIFF
--- a/docs/spfx/use-aadhttpclient.md
+++ b/docs/spfx/use-aadhttpclient.md
@@ -55,12 +55,10 @@ One way to see the available applications in Azure AD is by navigating to the [A
 
     ![The 'Properties' link highlighted on the application blade in the Azure AD portal](../images/webapipermissions-aadportal-graphpropertieslink.png)
 
-1. From the list of properties, copy the value of the **Object ID** property, which you need to request additional permission scopes to the Microsoft Graph. Alternatively, you can copy the application's **Name** and use it in the permission request instead.
+1. From the list of properties, copy the value of the **Object ID** property, which you may need to request additional permission scopes to the Microsoft Graph or revoke permissions already granted. Alternatively, you can copy the application's **Name** and use it in the permission request instead.
 
     ![The value of the 'Object ID' property copied to the clipboard in the Azure AD portal](../images/webapipermissions-aadportal-graphobjectidcopied.png)
 
- > [!NOTE]
- > While the **Object ID** is unique for each tenant, the application's **Name** is the same across all tenants. If you want to build your solution once and deploy it to different tenants, you should use the application's **Name** when requesting additional permissions in your solution.
 
 ### Use Azure PowerShell
 


### PR DESCRIPTION
I removed the NOTE starting on line 62 of the markup because it is confusing in the context of the placement.  We never actually give an example of using the ObjectID to request permissions, and instead focus primarily on the use of the Application Name to request permissions, and in the case of the Application Manifest, we even call out that you CANNOT using the ObjectID.  The only example we give of using the ObjectID is to REVOKE permissions.

I also, slightly changed the verbiage in the numbered item 5 in that section.  Probably someone should review this and if there was a legitimate need for the note and the comment about using ObjectID to request permission scopes, rephrase it, because it has confused at least one customer who thought the note referred to how to construct the AadHttpClient in the Typescript code.

## Category

- [x] Content fix
- [ ] New article

## What's in this Pull Request?

Removed a note that caused one of my customer quite some confusion and slightly changed some verbiage to make it more consistent with the guidance in the rest of the article.


