### PR TITLE
Improve key deletion script and consistency

### DIFF
--- a/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
+++ b/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
@@ -1,7 +1,7 @@
 ---
 title: Replace an expiring client secret in a SharePoint Add-in
 description: Add a new client secret for a SharePoint Add-in that is registered with AppRegNew.aspx.
-ms.date: 1/18/2020
+ms.date: 11/10/2020
 ms.prod: sharepoint
 localization_priority: Priority
 ---

--- a/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
+++ b/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
@@ -66,9 +66,9 @@ Ensure the following before you begin:
     $newClientSecret = [System.Convert]::ToBase64String($bytes)
     $dtStart = [System.DateTime]::Now
     $dtEnd = $dtStart.AddYears(1)
-    New-MsolServicePrincipalCredential -AppPrincipalId $clientId -Type Symmetric -Usage Sign -Value $newClientSecret -StartDate (Get-Date) -EndDate $dtEnd
-    New-MsolServicePrincipalCredential -AppPrincipalId $clientId -Type Symmetric -Usage Verify -Value $newClientSecret -StartDate (Get-Date) -EndDate $dtEnd
-    New-MsolServicePrincipalCredential -AppPrincipalId $clientId -Type Password -Usage Verify -Value $newClientSecret -StartDate (Get-Date) -EndDate $dtEnd
+    New-MsolServicePrincipalCredential -AppPrincipalId $clientId -Type Symmetric -Usage Sign -Value $newClientSecret -StartDate $dtStart -EndDate $dtEnd
+    New-MsolServicePrincipalCredential -AppPrincipalId $clientId -Type Symmetric -Usage Verify -Value $newClientSecret -StartDate $dtStart -EndDate $dtEnd
+    New-MsolServicePrincipalCredential -AppPrincipalId $clientId -Type Password -Usage Verify -Value $newClientSecret -StartDate $dtStart -EndDate $dtEnd
     $newClientSecret
     ```
 

--- a/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
+++ b/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
@@ -64,9 +64,11 @@ Ensure the following before you begin:
     $rand.GetBytes($bytes)
     $rand.Dispose()
     $newClientSecret = [System.Convert]::ToBase64String($bytes)
-    New-MsolServicePrincipalCredential -AppPrincipalId $clientId -Type Symmetric -Usage Sign -Value $newClientSecret -StartDate (Get-Date) -EndDate (Get-Date).AddYears(1)
-    New-MsolServicePrincipalCredential -AppPrincipalId $clientId -Type Symmetric -Usage Verify -Value $newClientSecret -StartDate (Get-Date) -EndDate (Get-Date).AddYears(1)
-    New-MsolServicePrincipalCredential -AppPrincipalId $clientId -Type Password -Usage Verify -Value $newClientSecret -StartDate (Get-Date) -EndDate (Get-Date).AddYears(1)
+    $dtStart = [System.DateTime]::Now
+    $dtEnd = $dtStart.AddYears(1)
+    New-MsolServicePrincipalCredential -AppPrincipalId $clientId -Type Symmetric -Usage Sign -Value $newClientSecret -StartDate (Get-Date) -EndDate $dtEnd
+    New-MsolServicePrincipalCredential -AppPrincipalId $clientId -Type Symmetric -Usage Verify -Value $newClientSecret -StartDate (Get-Date) -EndDate $dtEnd
+    New-MsolServicePrincipalCredential -AppPrincipalId $clientId -Type Password -Usage Verify -Value $newClientSecret -StartDate (Get-Date) -EndDate $dtEnd
     $newClientSecret
     ```
 
@@ -128,7 +130,7 @@ For expired client secrets, first you must delete all of the expired secrets for
     connect-msolservice -credential $msolcred
     ```
 
-1. Get **ServicePrincipals** and keys. Printing **$keys** returns three records. Replace each **KeyId** in **KeyId1**, **KeyId2**, and **KeyId3**. You also see the **EndDate** of each key. Confirm whether your expired key appears there.
+1. Get **ServicePrincipals** and keys. Printing **$keys** returns three records. You also see the **EndDate** of each key. Confirm whether your expired key appears there.
 
     > [!NOTE]
     > The **clientId** needs to match your expired **clientId**. It's recommended to delete all keys, both expired and unexpired, for this **clientId**.
@@ -136,7 +138,13 @@ For expired client secrets, first you must delete all of the expired secrets for
     ```powershell
     $clientId = "27c5b286-62a6-45c7-beda-abbaea6eecf2"
     $keys = Get-MsolServicePrincipalCredential -AppPrincipalId $clientId
-    Remove-MsolServicePrincipalCredential -KeyIds @("KeyId1"," KeyId2"," KeyId3") -AppPrincipalId $clientId
+    $keys
+    ```
+
+1. Remove all keys once you have confirmed that they are indeed expired.
+
+    ```powershell
+    Remove-MsolServicePrincipalCredential -KeyIds $keys.KeyId -AppPrincipalId $clientId
     ```
 
 1. Generate a new **ClientSecret** for this **clientID**. It uses the same **clientId** as set in the preceding step. The new **ClientSecret** is valid for three years.


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## What's in this Pull Request?

This proposed change addresses a few issues in the document:

- There was an inconsistency between the one-year client secret script and the three-year script - namely that the first script adds 1 year to the current date on three different lines, while the second calculates the end date first, and uses it. I have made the first script consistent with the second, which is the cleaner and DRY-er of the two.
- The information about deleting old keys was confusing and more complicated than it needed to be:
  - It instructed the user to manually copy & paste the key ids in their script, but the line where they needed to be pasted was listed immediately after the line that retrieved them, and lacked anything to even output them to the console so they could be copied.
  - Manually copy/pasting them is not even necessary when the $keys variable can be used to pass them into `Remove-MsolServicePrincipalCredential`.

These changes should hopefully make this document a bit clearer.