### PR TITLE
Change reference to right method

### DIFF
--- a/docs/features/groupify/groupify-csom.md
+++ b/docs/features/groupify/groupify-csom.md
@@ -23,7 +23,7 @@ You also need to reference the [Microsoft.SharePointOnline.CSOM](https://www.nug
 
 ## CSOM code example
 
-The following example shows how to create a __Microsoft.Online.SharePoint.TenantAdministration.Tenant__ object and call the __GetAllTenantThemes__ method to return a list of themes. 
+The following example shows how to create a __Microsoft.Online.SharePoint.TenantAdministration.Tenant__ object and call the __CreateGroupForSite__ method to return a list of themes. 
 
 > [!NOTE]
 > * The URL used to create the context object includes the _-admin_ suffix, because **TenantAdministration** methods work with the admin site.
@@ -50,7 +50,7 @@ ctx.ExecuteQuery();
 
 ## Methods in Microsoft.Online.SharePoint.TenantAdministration.Tenant class
 
-Use the following methods to customize the set of available themes for a SharePoint tenant administration site. You can add a new custom theme, update an existing theme, or delete a theme, and you can retrieve a specific theme or all themes. You can also hide or restore the default themes that come with SharePoint.
+Use the following methods to create a new Microsoft 365 Group and attach it to an existing site.
 
 ### CreateGroupForSite method
 

--- a/docs/features/groupify/groupify-csom.md
+++ b/docs/features/groupify/groupify-csom.md
@@ -1,7 +1,7 @@
 ---
 title: Connect to new Microsoft 365 group - CSOM development
 description: Client-side object model development for connecting to a new Microsoft 365 group operation.
-ms.date: 10/21/2020
+ms.date: 11/18/2020
 localization_priority: Priority
 ---
 


### PR DESCRIPTION
Changed article reference from "GetAllTenantThemes" to "CreateGroupForSite" methods.
Changed Microsoft.Online.SharePoint.TenantAdministration.Tenant class description that was also talking about themes instead talking about Create Group for site.

## Category

- [x] Content fix
- [ ] New article

## Related issues

## What's in this Pull Request?

Updating documentation that was describing the wrong method. Article describes code to create Microsoft 365 group for a site, however there are references to Tenant Themes method.