### PR TITLE
Updated LogoUrl parameter value

### DIFF
--- a/docs/features/hub-site/create-hub-site-with-powershell.md
+++ b/docs/features/hub-site/create-hub-site-with-powershell.md
@@ -1,7 +1,7 @@
 ---
 title: Create SharePoint hub sites using PowerShell
 description: Example code for creating a SharePoint hub site by using PowerShell.
-ms.date: 06/23/2020
+ms.date: 11/18/2020
 localization_priority: Priority
 ---
 

--- a/docs/features/hub-site/create-hub-site-with-powershell.md
+++ b/docs/features/hub-site/create-hub-site-with-powershell.md
@@ -65,7 +65,7 @@ The hub site doesn't have a logo or description yet. We also want to constrain i
    ```powershell
     Set-PnPHubSite 
      -Identity https://contoso.sharepoint.com/sites/marketing 
-     -LogoUrl https://contoso.sharepoint.com/marketing/SiteAssets/mylogo.jpg 
+     -LogoUrl https://contoso.sharepoint.com/sites/marketing/SiteAssets/mylogo.jpg 
      -Description "Main hub site for collaboration on marketing activities across Contoso"
    ```
 


### PR DESCRIPTION
On instruction to set Hub Site properties, the parameter "LogoUrl" is pointing to a different URL, mentioned on step 1 (`https://contoso.sharepoint.com/sites/marketing/SiteAssets`)

## Category

- [x] Content fix
- [ ] New article

## Related issues

## What's in this Pull Request?

On instruction to set Hub Site properties, the parameter "LogoUrl" is pointing to a different URL, mentioned on step 1 (`https://contoso.sharepoint.com/sites/marketing/SiteAssets`)
