### PR TITLE
Update single-part-app-pages.md

### DIFF
--- a/docs/spfx/web-parts/single-part-app-pages.md
+++ b/docs/spfx/web-parts/single-part-app-pages.md
@@ -64,7 +64,7 @@ Set-PnPClientSidePage -Identity "Page" -LayoutType SingleWebPartAppPage
 
 ```console
 m365 login
-m365 spo listitem set --webUrl https://contoso.sharepoint.com/sites/marketing --listTitle 'Site Pages' --id 3 --PageLayoutType SingleWebPartAppPage
+m365 spo apppage add --title "Contoso" --webUrl "https://contoso.sharepoint.com" --webPartData $webPartData --addToQuickLaunch
 ```
 
 > Refer to the [CLI for Microsoft 365 documentation](https://pnp.github.io/cli-microsoft365/cmd/spo/listitem/listitem-set/) for complete details and examples on this command.


### PR DESCRIPTION
Changed the CLI command to apppage add.

## Category

- [x] Content fix
- [ ] New article


## What's in this Pull Request?

On the single app part pages, changed the CLI command from "m365 spo listitem" set to "m365 spo apppage add".

This seems to be the new way of adding apppages - although to be fair, I have the impression that the CreateFullAppPage api that is used by the CLI is not rolled out to all tenants. 

On the other hand, the method described in the old version never worked for me.