### PR TITLE
revert previous commit, replacing text with valid link

### DIFF
--- a/docs/spfx/web-parts/basics/add-an-external-library.md
+++ b/docs/spfx/web-parts/basics/add-an-external-library.md
@@ -1,7 +1,7 @@
 ---
 title: Add an external library to your SharePoint client-side web part
 description: Bundle a JavaScript external library and share libraries.
-ms.date: 01/22/2021
+ms.date: 01/25/2021
 ms.prod: sharepoint
 localization_priority: Priority
 ---
@@ -123,6 +123,11 @@ In this example, you'll load jQuery from CDN. You don't need to install the NPM 
 ## Load a non-AMD module
 
 Some scripts follow the legacy JavaScript pattern of storing the library on the global namespace. This pattern is now deprecated in favor of [Universal Module Definitions (UMD)](https://github.com/umdjs/umd)/[Asynchronous Module Definitions (AMD)](https://en.wikipedia.org/wiki/Asynchronous_module_definition) or [ES6 modules](https://github.com/lukehoban/es6features/blob/master/README.md#modules). However, you might need to load such libraries in your web part.
+
+> [!TIP]
+> It's difficult to determine manually whether the script that you're trying to load is an AMD or a non-AMD script. This is especially the case if the script that you're trying to load is minified.
+>
+> If your script is hosted on a publicly accessible URL, you can use the free [Rencore SharePoint Framework Script Check](https://rencore.com/script-check/) tool to determine the type of script for you. Additionally, this tool lets you know whether the hosting location from which you're loading the script is properly configured. This tool is also available in the VS Code extension [Rencore SPFx Script Check](https://marketplace.visualstudio.com/items?itemName=RencoreGmbH.vscode-spfx-script-check)
 
 To load a non-AMD module, you add an additional property to the entry in your **config.json** file.
 


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- fixes #6623

## What's in this PR?

- previous commit removed tip in doc due to a broken link
- maintainer of link updated referenced issue with the correct link
- this commit adds the tip back with the corrected link

