### PR TITLE
Update list item Rest API: fixed the content-type value

### DIFF
--- a/docs/sp-add-ins/working-with-lists-and-list-items-with-rest.md
+++ b/docs/sp-add-ins/working-with-lists-and-list-items-with-rest.md
@@ -589,7 +589,7 @@ The following example shows how to update a list item.
 POST https://{site_url}/_api/web/lists/GetByTitle('Test')/items({item_id})
 Authorization: "Bearer " + accessToken
 Accept: "application/json;odata=verbose"
-Content-Type: "application/json"
+Content-Type: "application/json;odata=verbose"
 Content-Length: {length of request body as integer}
 If-Match: "{etag or *}"
 X-HTTP-Method: "MERGE"


### PR DESCRIPTION
The content-type for the Update list item REST API was incorrect in the documentation example [here](https://docs.microsoft.com/en-us/sharepoint/dev/sp-add-ins/working-with-lists-and-list-items-with-rest#update-list-item). This PR fixes the example 

## Category

- [x] Content fix

## Related issues

- fixes #6636 

## What's in this Pull Request?

Updated the content-type header value in the example to the correct value: `"application/json;odata=verbose"`, instead of: `"application/json"`, which does not work. 
