### PR TITLE
Update site-creation-rest.md

### DIFF
--- a/docs/apis/site-creation-rest.md
+++ b/docs/apis/site-creation-rest.md
@@ -47,8 +47,9 @@ body:
     "Classification":"Low Business Impact",
     "Description":"Description",
     "WebTemplate":"SITEPAGEPUBLISHING#0",
-    "SiteDesignId":"6142d2a0-63a5-4ba0-aede-d9fefca2c767",
-    "Owner":"owner@yourtenant.onmicrosoft.com"
+    "SiteDesignId":"00000000-0000-0000-0000-000000000000",
+    "Owner":"owner@yourtenant.onmicrosoft.com",
+    "WebTemplateExtensionID":"6142d2a0-63a5-4ba0-aede-d9fefca2c767"
   }
 }
 ```

--- a/docs/apis/site-creation-rest.md
+++ b/docs/apis/site-creation-rest.md
@@ -1,7 +1,7 @@
 ---
 title: Create Modern SharePoint Sites using REST
 description: Create and get the status of a new modern SharePoint site by using the REST interface.
-ms.date: 06/05/2020
+ms.date: 02/05/2021
 ms.prod: sharepoint
 localization_priority: Priority
 ---


### PR DESCRIPTION
Custom Site Design ID as retrieved with Get-SPoSiteDesign should be used in WebTemplateExtensionID  and SiteDesignID  should be 00000000-0000-0000-0000-000000000000

## Category

- [ ] Content fix
- [ ] New article
- [x] Example checked item (*delete this line*)

## Related issues

- fixes #issuenumber
- partially #issuenumber
- mentioned in #issuenumber

## What's in this Pull Request?

If a custom SiteDesign Id is used as described, the property WebTemplateExtensionID does not make it in the web propertybag and the custom template is not applied. corrected Json sample

## Submission guidelines


