### PR TITLE
Update column-formatting.md

### DIFF
--- a/docs/declarative-customization/column-formatting.md
+++ b/docs/declarative-customization/column-formatting.md
@@ -472,7 +472,7 @@ Here's the same sample from above, using the Excel-style expression syntax:
             "elmType": "span",
             "attributes": {
                 "class": "=if([$After] > [$Before], 'sp-field-trending--up', 'sp-field-trending--down')",
-                "iconName": "=if([$After] > [$Before], 'SortUp', "=if([$After] < [$Before], 'SortDown', ''))"
+                "iconName": "=if([$After] > [$Before], 'SortUp', "if([$After] < [$Before], 'SortDown', ''))"
             }
         },
         {

--- a/docs/declarative-customization/column-formatting.md
+++ b/docs/declarative-customization/column-formatting.md
@@ -1,7 +1,7 @@
 ---
 title: Use column formatting to customize SharePoint
 description: Customize how fields in SharePoint lists and libraries are displayed by constructing a JSON object that describes the elements that are displayed when a field is included in a list view, and the styles to be applied to those elements.
-ms.date: 12/29/2020
+ms.date: 02/19/2021
 localization_priority: Priority
 ---
 


### PR DESCRIPTION
removed a `=` from the trending arrows sample.

## Category

- [x] Content fix
- [ ] New article
