### PR TITLE
Removed background-image from list of supported  CSS properties.

### DIFF
--- a/docs/declarative-customization/column-formatting.md
+++ b/docs/declarative-customization/column-formatting.md
@@ -1065,7 +1065,6 @@ An optional property that specifies style attributes to apply to the element spe
 ```JS
 'background-color'
 'fill'
-'background-image'
 'border'
 'border-bottom'
 'border-bottom-color'


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues
- No related issues

## What's in this Pull Request?
Removed `background-image` from the list of CSS properties supported with custom column formatting. 

This `background-image` CSS property requires the use of the '**(**' character, which is  prohibited from use in the formatting schema and results in an error when used.

