### PR TITLE
Update migrate-from-classic-workflows-to-power-automate-flows.md

### DIFF
--- a/docs/business-apps/power-automate/guidance/migrate-from-classic-workflows-to-power-automate-flows.md
+++ b/docs/business-apps/power-automate/guidance/migrate-from-classic-workflows-to-power-automate-flows.md
@@ -1,6 +1,7 @@
 ---
 title: Guidance - Migrate from classic workflows to Power Automate flows in SharePoint
-ms.date: 07/21/2020
+description: This article specifically provides guidance about how to plan for transitioning from classic SharePoint Workflows to Power Automate flows.
+ms.date: 06/22/2021
 search.app: 
   - Flow
 search.appverid: met150

--- a/docs/business-apps/power-automate/guidance/migrate-from-classic-workflows-to-power-automate-flows.md
+++ b/docs/business-apps/power-automate/guidance/migrate-from-classic-workflows-to-power-automate-flows.md
@@ -228,4 +228,4 @@ While the following lists show some of the most common workflow capabilities, Po
 | Share workflows with users | Not available | Yes |
 | Save a copy of workflow to create a copy of the workflow | Not available | Yes |
 | Workflow versioning | Not available | No |
-| Create a workflow with elevated permissions | Yes, by granting permissions to workflow app and then using App Step action and SharePoint Add-ins | Not available
+| Create a workflow with elevated permissions | Yes, by granting permissions to workflow app and then using App Step action and SharePoint Add-ins | Yes, child workflows in a solution can run as the Flow publisher account granting the elevanted permissions of the author account

--- a/docs/business-apps/power-automate/guidance/migrate-from-classic-workflows-to-power-automate-flows.md
+++ b/docs/business-apps/power-automate/guidance/migrate-from-classic-workflows-to-power-automate-flows.md
@@ -48,7 +48,7 @@ Using Microsoft Power Automate, SharePoint users can use the SharePoint Connecto
 
 To create and author flows, users primarily use [Power Automate website](https://flow.microsoft.com) while users can also [create flows from within SharePoint](https://support.microsoft.com/office/create-a-flow-for-a-list-or-library-in-sharepoint-or-onedrive-a9c3e03b-0654-46af-a254-20252e580d01?ui=en-us&rs=en-us&ad=us) or using the [Power Automate mobile app](/power-automate/mobile-create-flow).
 
-To learn more about building workflows using Power Automate in SharePoint, start here: Business apps and Business process [automation in SharePoint](../../introduction-to-sharepoint-business-process-integration).
+To learn more about building workflows using Power Automate in SharePoint, start here: Business apps and Business process [automation in SharePoint](../../introduction-to-sharepoint-business-process-integration.md).
 
 
 ## Pain points in moving between classic workflows in SharePoint and Power Automate flows
@@ -71,7 +71,7 @@ Approvals are the most common workflow scenario when it comes to automating busi
 - [Sequential approvals](/power-automate/sequential-modern-approvals)
 - [Parallel approvals](/power-automate/parallel-modern-approvals)
 
-SharePoint approvals such as [page approvals](../../power-automate/guidance/customize-page-approvals), [document approvals](../../power-automate/guidance/require-doc-approval), and [hub association approvals](https://support.microsoft.com/office/set-up-your-sharepoint-hub-site-e2daed64-658c-4462-aeaf-7d1a92eba098#bkmk_managesiteassociationapprovals) are all integrated and powered by Power Automate flows, providing users the flexibility to customize the business process for each of the approval scenarios.
+SharePoint approvals such as [page approvals](../../power-automate/guidance/customize-page-approvals.md), [document approvals](../../power-automate/guidance/require-doc-approval.md), and [hub association approvals](https://support.microsoft.com/office/set-up-your-sharepoint-hub-site-e2daed64-658c-4462-aeaf-7d1a92eba098#bkmk_managesiteassociationapprovals) are all integrated and powered by Power Automate flows, providing users the flexibility to customize the business process for each of the approval scenarios.
 
 ## Authoring classic workflows and flows
 
@@ -83,7 +83,7 @@ See the following tables that compare the workflow terminologies, triggers, and 
 
 While the following lists show some of the most common workflow capabilities, Power Automate offers many more features, and is actively updated with new features. We highly recommend visiting the following Power Automate websites for guided learning:
 
-- [SharePoint Power Automate Documentation](../../power-automate/sharepoint-connector-actions-triggers)
+- [SharePoint Power Automate Documentation](../../power-automate/sharepoint-connector-actions-triggers.md)
 - [Learn Power Automate](/learn/browse/?products=power-automate&term=Power%20Automate&terms=Power%20Automate)
 - [Power Automate Documentation](/power-automate/?utm_source=flow-sidebar&utm_medium=web)
 

--- a/docs/business-apps/power-automate/guidance/migrate-from-classic-workflows-to-power-automate-flows.md
+++ b/docs/business-apps/power-automate/guidance/migrate-from-classic-workflows-to-power-automate-flows.md
@@ -38,7 +38,7 @@ Users primarily use SharePoint Designer to author and publish workflows in Share
 
 Since the release of classic workflows, SharePoint and Microsoft 365 apps have evolved to provide compelling, flexible and more performant experiences. Modern experiences in SharePoint integrate with rest of the Microsoft 365 apps and services driving security, productivity, and collaboration.
 
-[Power Automate](https://docs.microsoft.com/power-automate/getting-started) helps users and businesses to create automated workflows between your favorite apps and services to get notifications, collect data, automate business policies and more.
+[Power Automate](/power-automate/getting-started) helps users and businesses to create automated workflows between your favorite apps and services to get notifications, collect data, automate business policies and more.
 
 > [!VIDEO https://www.youtube.com/embed/hCuxuUaGC6Y]
 
@@ -48,7 +48,7 @@ Using Microsoft Power Automate, SharePoint users can use the SharePoint Connecto
 
 - Start approval when a new file is added in a library.
 
-To create and author flows, users primarily use [Power Automate website](https://flow.microsoft.com/en-us/) while users can also [create flows from within SharePoint](https://support.microsoft.com/office/create-a-flow-for-a-list-or-library-in-sharepoint-or-onedrive-a9c3e03b-0654-46af-a254-20252e580d01?ui=en-us&rs=en-us&ad=us) or using the [Power Automate mobile app](https://docs.microsoft.com/power-automate/mobile-create-flow).
+To create and author flows, users primarily use [Power Automate website](https://flow.microsoft.com) while users can also [create flows from within SharePoint](https://support.microsoft.com/office/create-a-flow-for-a-list-or-library-in-sharepoint-or-onedrive-a9c3e03b-0654-46af-a254-20252e580d01?ui=en-us&rs=en-us&ad=us) or using the [Power Automate mobile app](/power-automate/mobile-create-flow).
 
 To learn more about building workflows using Power Automate in SharePoint, start here: Business apps and Business process [automation in SharePoint](https://docs.microsoft.com/sharepoint/dev/business-apps/introduction-to-sharepoint-business-process-integration).
 
@@ -68,11 +68,11 @@ While these pain points do exist, you can see there are workarounds for each of 
 
 Approvals are the most common workflow scenario when it comes to automating business processes in SharePoint. Transitioning to Power Automate flows, approvals can be streamlined for data in SharePoint, Dynamics 365, forms, SQL, and so on. You can create approvals in your workflow, and view sent and received requests in a unified Actions center. Power Automate approvals enable users to customize flows and create approvals for the following types:
 
-- [Single approvals](https://docs.microsoft.com/power-automate/modern-approvals)
+- [Single approvals](/power-automate/modern-approvals)
 
-- [Sequential approvals](https://docs.microsoft.com/power-automate/sequential-modern-approvals)
+- [Sequential approvals](/power-automate/sequential-modern-approvals)
 
-- [Parallel approvals](https://docs.microsoft.com/power-automate/parallel-modern-approvals)
+- [Parallel approvals](/power-automate/parallel-modern-approvals)
 
 SharePoint approvals such as [page approvals](https://docs.microsoft.com/sharepoint/dev/business-apps/power-automate/guidance/customize-page-approvals), [document approvals](https://docs.microsoft.com/sharepoint/dev/business-apps/power-automate/guidance/require-doc-approval), and [hub association approvals](https://support.microsoft.com/office/set-up-your-sharepoint-hub-site-e2daed64-658c-4462-aeaf-7d1a92eba098#bkmk_managesiteassociationapprovals) are all integrated and powered by Power Automate flows, providing users the flexibility to customize the business process for each of the approval scenarios.
 
@@ -90,7 +90,7 @@ While the following lists show some of the most common workflow capabilities, Po
 
 - [Learn Power Automate](https://docs.microsoft.com/learn/browse/?products=power-automate&term=Power%20Automate&terms=Power%20Automate)
 
-- [Power Automate Documentation](https://docs.microsoft.com/power-automate/?utm_source=flow-sidebar&utm_medium=web)
+- [Power Automate Documentation](/power-automate/?utm_source=flow-sidebar&utm_medium=web)
 
 ### Workflow concepts
 

--- a/docs/business-apps/power-automate/guidance/migrate-from-classic-workflows-to-power-automate-flows.md
+++ b/docs/business-apps/power-automate/guidance/migrate-from-classic-workflows-to-power-automate-flows.md
@@ -29,7 +29,6 @@ Classic workflows in SharePoint constitutes two workflow systems namely
 While both workflow systems allow users to build and publish workflows in SharePoint, see the following key differences:
 
 - SharePoint 2010 workflows, released along with SharePoint Server 2010, are hosted, and executed in SharePoint workflow runtime.
-
 - SharePoint 2013 workflows, released along with SharePoint Server 2013, are hosted in SharePoint, and executed in Workflow Manager, that runs independently.
 
 Users primarily use SharePoint Designer to author and publish workflows in SharePoint, while professional developers, looking to extend and build workflows, use Visual Studio to build and publish workflows in SharePoint.
@@ -45,12 +44,12 @@ Since the release of classic workflows, SharePoint and Microsoft 365 apps have e
 Using Microsoft Power Automate, SharePoint users can use the SharePoint Connector to create automations for when data changes in a list or a library. Users can build simple to complex workflows such as, but not limited to:
 
 - Send an email when a new item is created in a list.
-
 - Start approval when a new file is added in a library.
 
 To create and author flows, users primarily use [Power Automate website](https://flow.microsoft.com) while users can also [create flows from within SharePoint](https://support.microsoft.com/office/create-a-flow-for-a-list-or-library-in-sharepoint-or-onedrive-a9c3e03b-0654-46af-a254-20252e580d01?ui=en-us&rs=en-us&ad=us) or using the [Power Automate mobile app](/power-automate/mobile-create-flow).
 
-To learn more about building workflows using Power Automate in SharePoint, start here: Business apps and Business process [automation in SharePoint](https://docs.microsoft.com/sharepoint/dev/business-apps/introduction-to-sharepoint-business-process-integration).
+To learn more about building workflows using Power Automate in SharePoint, start here: Business apps and Business process [automation in SharePoint](../../introduction-to-sharepoint-business-process-integration).
+
 
 ## Pain points in moving between classic workflows in SharePoint and Power Automate flows
 
@@ -69,12 +68,10 @@ While these pain points do exist, you can see there are workarounds for each of 
 Approvals are the most common workflow scenario when it comes to automating business processes in SharePoint. Transitioning to Power Automate flows, approvals can be streamlined for data in SharePoint, Dynamics 365, forms, SQL, and so on. You can create approvals in your workflow, and view sent and received requests in a unified Actions center. Power Automate approvals enable users to customize flows and create approvals for the following types:
 
 - [Single approvals](/power-automate/modern-approvals)
-
 - [Sequential approvals](/power-automate/sequential-modern-approvals)
-
 - [Parallel approvals](/power-automate/parallel-modern-approvals)
 
-SharePoint approvals such as [page approvals](https://docs.microsoft.com/sharepoint/dev/business-apps/power-automate/guidance/customize-page-approvals), [document approvals](https://docs.microsoft.com/sharepoint/dev/business-apps/power-automate/guidance/require-doc-approval), and [hub association approvals](https://support.microsoft.com/office/set-up-your-sharepoint-hub-site-e2daed64-658c-4462-aeaf-7d1a92eba098#bkmk_managesiteassociationapprovals) are all integrated and powered by Power Automate flows, providing users the flexibility to customize the business process for each of the approval scenarios.
+SharePoint approvals such as [page approvals](../../power-automate/guidance/customize-page-approvals), [document approvals](../../power-automate/guidance/require-doc-approval), and [hub association approvals](https://support.microsoft.com/office/set-up-your-sharepoint-hub-site-e2daed64-658c-4462-aeaf-7d1a92eba098#bkmk_managesiteassociationapprovals) are all integrated and powered by Power Automate flows, providing users the flexibility to customize the business process for each of the approval scenarios.
 
 ## Authoring classic workflows and flows
 
@@ -86,10 +83,8 @@ See the following tables that compare the workflow terminologies, triggers, and 
 
 While the following lists show some of the most common workflow capabilities, Power Automate offers many more features, and is actively updated with new features. We highly recommend visiting the following Power Automate websites for guided learning:
 
-- [SharePoint Power Automate Documentation](https://docs.microsoft.com/sharepoint/dev/business-apps/power-automate/sharepoint-connector-actions-triggers)
-
-- [Learn Power Automate](https://docs.microsoft.com/learn/browse/?products=power-automate&term=Power%20Automate&terms=Power%20Automate)
-
+- [SharePoint Power Automate Documentation](../../power-automate/sharepoint-connector-actions-triggers)
+- [Learn Power Automate](/learn/browse/?products=power-automate&term=Power%20Automate&terms=Power%20Automate)
 - [Power Automate Documentation](/power-automate/?utm_source=flow-sidebar&utm_medium=web)
 
 ### Workflow concepts


### PR DESCRIPTION
For the section "Workflow administration" item "Create a workflow with elevated permissions" it is possible to elevate a workflow in PowerAutomate by calling a child workflow, this allows the child workflow to run under the elevated permissions of the flow publisher instead of the user running the flow granting the elevated permissions of the publisher account.

It would be useful to have this mentioned for when people come across this section so they are aware there is a possible work around

## Category

- [X] Content fix

## What's in this Pull Request?

Change to the section "Workflow administration" item "Create a workflow with elevated permissions"
