### PR TITLE
Added a code sample for lookup columns

### DIFF
--- a/docs/declarative-customization/list-form-conditional-show-hide.md
+++ b/docs/declarative-customization/list-form-conditional-show-hide.md
@@ -1,7 +1,7 @@
 ---
 title: Show or hide columns in a list form
 description: Customize which columns to show or hide using a conditional formula in the list form by constructing a simple formula that are equations performing conditional checks on values in a SharePoint list or library.
-ms.date: 09/02/2020
+ms.date: 04/20/2021
 localization_priority: Priority
 ---
 

--- a/docs/declarative-customization/list-form-conditional-show-hide.md
+++ b/docs/declarative-customization/list-form-conditional-show-hide.md
@@ -132,3 +132,11 @@ The following formula checks if the Yes/No column [$Promoted] is equal to a Yes.
 =if([$Promoted]==true,'true','false')
 ```
 
+##### Lookup column
+
+The following formula checks if the lookup column [$City] is equal to _Toronto_. To do so, it checks for the value _1;#Toronto_ where 1 is an item ID in the lookup list of cities.
+
+```
+=if([$City]=='1;#Toronto', 'true', 'false')
+```
+


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- fixes #6917 

## What's in this Pull Request?

Before submitting this pull requests, I have researched the way lookup column validation works. Results are as follows:

### This won't work
```
=if([$LookupField.name]=='London', 'true', 'false')
```

and this won't work either:
```
=if([$LookupField.lookupValue]=='London', 'true', 'false')
```
and this:
```
=if([$LookupField]=='London', 'true', 'false')
```

### What works
This is how lookups look like in the JSON formula validation function:

![image](https://user-images.githubusercontent.com/2797648/114875463-4e268000-9dcb-11eb-82b1-5705c8f7ab9b.png)

As a result, the lookup values can be references this way in the JSON formula

```
=if([$LookupField]=='1;#London', 'true', 'false')
```

So, when referencing a lookup value, we need to use this format: `<Lookup ID>;#<Lookup Value>`
