### PR TITLE
Docs update for 1.12.1 & SPFx dev preview installs

### DIFF
--- a/docs/spfx/developer-preview-beta-features.md
+++ b/docs/spfx/developer-preview-beta-features.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint Framework developer preview releases
 description: Details on how to use developer preview pre-release packages with SharePoint Framework.
-ms.date: 04/13/2021
+ms.date: 04/17/2021
 ms.prod: sharepoint
 localization_priority: Priority
 ---
@@ -35,9 +35,9 @@ http://aka.ms/spfx
 keywords: yeoman-generator
 
 dist
-.tarball: https://registry.npmjs.org/@microsoft/generator-sharepoint/-/generator-sharepoint-1.11.0.tgz
-.shasum: 43323fa642165e4ce5b1b9d4624244b07d6332bb
-.integrity: sha512-ySYCMk5nMIk3mZhDoxS0Dgxs6dnM5JBAOrEpwWDb1jLQCoxnXFBsanfHzbBSS3UIokpaS3ZNrocr22d2RIdQww==
+.tarball: https://registry.npmjs.org/@microsoft/generator-sharepoint/-/generator-sharepoint-1.xx.xx.tgz
+.shasum: 43323fa642165e4ce5b1b...<omitted>
+.integrity: sha512-ySYCMk5nMIk...<omitted>
 .unpackedSize: 1.9 MB
 
 dependencies:
@@ -51,7 +51,7 @@ maintainers:
 - odspnpm <odspnpm@microsoft.com>
 
 dist-tags:
-latest: 1.11.0     next: 1.12.1-rc.0
+latest: 10.10.0     next: 10.11.12-rc.5
 
 published 9 months ago by odspnpm <odspnpm@microsoft.com>
 ```
@@ -62,14 +62,14 @@ In the sample output above, you can see the current released version is *1.11* w
 
 To install a specific version of an NPM package, add `@` followed by the version number at the end of the package name.
 
-For example, if the **info** command lists the **next** version is *10.11.12-rc.5*, you'd globally install the latest version of the generator with the following command:
+For example, if the **info** command lists the **next** version is *10.11.12-rc.5*, you'd globally install the next preview version of the generator with the following command:
 
 ```console
-npm install @microsoft/generator-sharepoint@10.11.12-rc.5 --global
+npm install @microsoft/generator-sharepoint@next --global
 ```
 
 > [!NOTE]
-> For more information on installing NPM packages, see the NPM documentation on [npm-install](https://docs.npmjs.com/cli/v7/commands/npm-install).
+> For more information on installing NPM packages, including how to install a specific versions, see the NPM documentation on [npm-install](https://docs.npmjs.com/cli/v7/commands/npm-install).
 
 ## Reporting issues
 

--- a/docs/spfx/release-1.12.1.md
+++ b/docs/spfx/release-1.12.1.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint Framework v1.12.1 release notes
 description: Release notes for the SharePoint Framework v1.12.1 release
-ms.date: 04/13/2021
+ms.date: 04/16/2021
 ms.prod: sharepoint
 localization_priority: Priority
 ---
@@ -41,7 +41,7 @@ This release introduces a new property & event in the Web Part API to detect the
 
 ## Changes in this release
 
-- Add support for **Node.js v12.x & v14.x**
+- Add support for **Node.js v12.13.x & v14.15.x**nvm 
   - *See [Set up your SharePoint Framework development environment](set-up-your-development-environment.md) for details.*
   - **Gulp v4** (installed globally) is required (*see [Regarding Gulp versions & Node.js v12+](#gulp-versions--nodejs-v12) for details*)
 - For all projects:
@@ -50,6 +50,7 @@ This release introduces a new property & event in the Web Part API to detect the
 - For projects that use React:
   - Update the React NPM packages (**react** & **react-dom**) to **v16.9.0**.
   - Update the Office UI Fabric React NPM package / Microsoft Fluent UI (**office-ui-fabric-react**) to **v7.156.0**.
+- The default location for resources used in deployments changed from `./temp/deploy` to `./releases/assets`. For projects created prior to SPFx v1.12.1, you should update the **./config/deploy-azure-storage.json** file property `workingDir` to the new location: `"workingDir": "./release/assets/"`. For more information, see [Deploy your SharePoint client-side web part to Azure CDN: Configure Azure Storage account details](web-parts/get-started/deploy-web-part-to-cdn.md#configure-azure-storage-account-details).
 
 ## Deprecations and removed items in this release
 

--- a/docs/spfx/web-parts/get-started/deploy-web-part-to-cdn.md
+++ b/docs/spfx/web-parts/get-started/deploy-web-part-to-cdn.md
@@ -265,7 +265,7 @@ Because you changed the web part bundle, you need to redeploy the package to the
 1. Go to any SharePoint site in your tenant and select **Add a page** from the *gears* menu.
 1. **Edit** the page and select **AzureCDN** web part from the web part picker to confirm that your deployment has been successful.
 
-    ![Screenshot of trust client-side solution package prompt](../../../images/cdn-azure-picker-selection-page.png)
+    ![Screenshot selecting the web part from the picker](../../../images/cdn-azure-picker-selection-page.png)
 
 1. Notice that you aren't running **gulp serve**, and therefore nothing is served from **localhost**. Content is served from the Azure CDN. You can also double-check this by selecting <kbd>F12</kbd> in your browser and confirming that you can see the Azure CDN as one of the sources for the page assets.
 

--- a/docs/spfx/web-parts/get-started/deploy-web-part-to-cdn.md
+++ b/docs/spfx/web-parts/get-started/deploy-web-part-to-cdn.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy your SharePoint client-side web part to Azure CDN
 description: Create a new sample web part and deploy its assets to an Azure CDN instead of using the default Office 365 CDN as the hosting solution.
-ms.date: 10/26/2020
+ms.date: 04/17/2021
 ms.prod: sharepoint
 ---
 # Deploy your SharePoint client-side web part to Azure CDN
@@ -146,12 +146,17 @@ Note, however, that you have not yet deployed the files.
     ```json
     {
       "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/deploy-azure-storage.schema.json",
-      "workingDir": "./temp/deploy/",
+      "workingDir": "./release/assets/",
       "account": "<!-- STORAGE ACCOUNT NAME -->",
       "container": "azurehosted-webpart",
       "accessKey": "<!-- ACCESS KEY -->"
     }
     ```
+
+    > [!IMPORTANT]
+    > The location of resources used in the Azure CDN deployments changed in SPFx v1.12.1. The snippet above reflects the correct location in the `workingDir` property.
+    >
+    > For projects created prior to SPFx v1.12.1, the `workingDir` property was set to `./temp/deploy/`. If you've upgraded the project to SPFx v1.12.1+, you should update this property to the above setting. For more information, see [SharePoint Framework v1.12.1 release notes](../../release-1.12.1.md).
 
 1. Replace the `account`, `container`, `accessKey` with your storage account name, BLOB container, and storage account access key respectively.
 
@@ -161,7 +166,8 @@ Note, however, that you have not yet deployed the files.
 
     ```json
     {
-      "workingDir": "./temp/deploy/",
+      "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/deploy-azure-storage.schema.json",
+      "workingDir": "./release/assets/",
       "account": "spfxsamples",
       "container": "azurehosted-webpart",
       "accessKey": "q1UsGWocj+CnlLuv9ZpriOCj46ikgBbDBCaQ0FfE8+qKVbDTVSbRGj41avlG73rynbvKizZpIKK9XpnpA=="


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- references #6847

## What's in this Pull Request?

- updated instructions for installing spfx dev preview:
  - replaced real version numbers & SHA's with fakes
  - changed install steps to use `@next` instead of a specific
    version to address devs who may copy-paste instructions
- update spfx v1.12.1 release docs & related topic docs for
  changes introduced to **./config/deploy-azure-storage.json**

