### PR TITLE
Removed "debugMode" attribute from sample JSON

### DIFF
--- a/docs/declarative-customization/list-form-configuration.md
+++ b/docs/declarative-customization/list-form-configuration.md
@@ -1,7 +1,7 @@
 ---
 title: Configure the list form
 description: Configure list form with a custom header, footer and body with one or more sections.
-ms.date: 01/28/2021
+ms.date: 04/23/2021
 localization_priority: Priority
 ---
 
@@ -50,7 +50,6 @@ To configure the form in a list or library:
 
     ```JSON
     {
-        "debugMode": true,
         "elmType": "div",
         "attributes": {
             "class": "ms-borderColor-neutralTertiary"
@@ -129,7 +128,6 @@ To configure the form in a list or library:
 
     ```JSON
     {
-        "debugMode": true,
         "elmType": "div",
         "style": {
             "width": "100%",


### PR DESCRIPTION
## Category

- [x] Content fix

## Related issues

- mentioned in https://github.com/SharePoint/sp-dev-docs/issues/6684

## What's in this Pull Request?

Removed "debugMode" attribute from sample JSON.

When using `"debugMode": true` while applying JSON to form header/footer from "New form", it shows error message which is confusing to users. 