### PR TITLE
update spfx compat doc

### DIFF
--- a/docs/spfx/compatibility.md
+++ b/docs/spfx/compatibility.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint Framework development tools and libraries compatibility
 description: Find which versions of the SharePoint Framework are compatible with each version of SharePoint, development tools and libraries.
-ms.date: 05/07/2021
+ms.date: 05/18/2021
 ms.prod: sharepoint
 localization_priority: Priority
 ---
@@ -15,11 +15,11 @@ Because SharePoint Online and the on-premises versions of SharePoint Server have
 
 SharePoint Online always uses the latest version of the SharePoint Framework, but SharePoint 2016 and SharePoint 2019 only support the versions that match the server-side dependencies of the deployed packages.
 
-|SharePoint version|Supported SPFx version|Supported features
-|---|---|---|
-|SharePoint Online|All versions|All features
-|SharePoint Server 2019|v1.4.1 or lower|SPFx client-side web parts in classic and modern pages, and extensions in modern pages.
-|SharePoint 2016 Feature Pack 2|v1.1|SPFx client-side web parts hosted in classic SharePoint pages.
+|       SharePoint version       | Supported SPFx version |                                   Supported features                                    |
+| ------------------------------ | ---------------------- | --------------------------------------------------------------------------------------- |
+| SharePoint Online              | All versions           | All features                                                                            |
+| SharePoint Server 2019         | v1.4.1 or lower        | SPFx client-side web parts in classic and modern pages, and extensions in modern pages. |
+| SharePoint 2016 Feature Pack 2 | v1.1                   | SPFx client-side web parts hosted in classic SharePoint pages.                          |
 
 For more information about SharePoint Framework development with SharePoint 2016 Feature Pack 2 and SharePoint 2019, see:
 
@@ -32,25 +32,26 @@ As each new version of the SharePoint Framework is released, support for newer v
 
 The following table lists SharePoint Framework and compatible versions of common tools and libraries:
 
-|SPFx|Node.js|NPM|TypeScript|React
-|---|---|---|---|---|
-|[1.12.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.12.0)|LTS v12.x, LTS v10.x|v5, v6|v3.7|v16.9.0|
-|[1.11.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.11.0)|LTS v10.x|v5, v6|v3.3|v16.8.5|
-|[1.10.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.10.0)|LTS v10.x, LTS 8.x|v5, v6|v3.3|v16.8.5|
-|[1.9.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.9.1)|LTS v10.x, LTS 8.x|v5, v6|v2.9|v16.8.5|
-|[1.8.2](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.8.2)| LTS 8.x, LTS 10.x | v5, v6 |v2.9|v16.7.0|
-|[1.8.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.8.1)| LTS 8.x | v5, v6|v2.7, v2.9, v3.x|v16.7.0|
-|[1.8.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.8.0)| LTS 8.x | v5, v6|v2.7, v2.9, v3.x|v16.7.0|
-|[1.7.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.7.1)| LTS 8.x | v5, v6 |v2.4|v16.3.2|
-|[1.7.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.7)| LTS 8.x | v5, v6 |v2.4|v16.3.2|
-|[1.6.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.6)|LTS 6.x,  LTS 8.x | v3 (w/ Node.js 6.x),<br/> v5 (w/ Node.js 8.x)|v2.4|v15.x|
-|[1.5.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.5.1)|LTS 6.x,  LTS 8.x | v3 (w/ Node.js 6.x),<br/> v5 (w/ Node.js 8.x)|v2.4|v15.x|
-|[1.5.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.5)|LTS 6.x,  LTS 8.x | v3 (w/ Node.js 6.x),<br/> v5 (w/ Node.js 8.x)|v2.4|v15.x|
-|[1.4.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.4.1)|LTS 6.x,  LTS 8.x | v3, v4 |v2.4|v15.x|
-|[1.4.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.4)|LTS 6.x| v3, v4 |v2.4|v15.x|
-|[1.3.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.3)|LTS 6.x| v3, v4 |v2.4|v15.x|
-|[1.1.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.1)|LTS 6.x| v3, v4 |v2.4|v15.x|
-|[1.0.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.0.0)|LTS 6.x| v3 |v2.4|v15.x|
+|                                    SPFx                                     |          Node.js          |                    NPM                    |   TypeScript   |    React    |
+| --------------------------------------------------------------------------- | ------------------------- | ----------------------------------------- | -------------- | ----------- |
+| [1.12.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.12.1)     | LTS v14, LTS v12, LTS v10 | v5, v6                                    | v3.7           | v16.9.0     |
+| ~~[1.12.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.12.0)~~ | ~~LTS v12, LTS v10~~      | ~~v5, v6~~                                | ~~v3.7~~       | ~~v16.9.0~~ |
+| [1.11.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.11.0)     | LTS v10                   | v5, v6                                    | v3.3           | v16.8.5     |
+| [1.10.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.10.0)     | LTS v10, LTS 8            | v5, v6                                    | v3.3           | v16.8.5     |
+| [1.9.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.9.1)       | LTS v10, LTS 8            | v5, v6                                    | v2.9           | v16.8.5     |
+| [1.8.2](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.8.2)       | LTS 8, LTS 10             | v5, v6                                    | v2.9           | v16.7.0     |
+| [1.8.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.8.1)       | LTS 8                     | v5, v6                                    | v2.7, v2.9, v3 | v16.7.0     |
+| [1.8.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.8.0)       | LTS 8                     | v5, v6                                    | v2.7, v2.9, v3 | v16.7.0     |
+| [1.7.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.7.1)       | LTS 8                     | v5, v6                                    | v2.4           | v16.3.2     |
+| [1.7.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.7)         | LTS 8                     | v5, v6                                    | v2.4           | v16.3.2     |
+| [1.6.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.6)         | LTS 6,  LTS 8             | v3 (w/ Node.js 6),<br/> v5 (w/ Node.js 8) | v2.4           | v15         |
+| [1.5.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.5.1)       | LTS 6,  LTS 8             | v3 (w/ Node.js 6),<br/> v5 (w/ Node.js 8) | v2.4           | v15         |
+| [1.5.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.5)         | LTS 6,  LTS 8             | v3 (w/ Node.js 6),<br/> v5 (w/ Node.js 8) | v2.4           | v15         |
+| [1.4.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.4.1)       | LTS 6,  LTS 8             | v3, v4                                    | v2.4           | v15         |
+| [1.4.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.4)         | LTS 6                     | v3, v4                                    | v2.4           | v15         |
+| [1.3.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.3)         | LTS 6                     | v3, v4                                    | v2.4           | v15         |
+| [1.1.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.1)         | LTS 6                     | v3, v4                                    | v2.4           | v15         |
+| [1.0.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.0.0)       | LTS 6                     | v3                                        | v2.4           | v15         |
 
 ## See also
 

--- a/docs/spfx/compatibility.md
+++ b/docs/spfx/compatibility.md
@@ -32,26 +32,26 @@ As each new version of the SharePoint Framework is released, support for newer v
 
 The following table lists SharePoint Framework and compatible versions of common tools and libraries:
 
-|                                    SPFx                                     |          Node.js          |                    NPM                    |   TypeScript   |    React    |
-| --------------------------------------------------------------------------- | ------------------------- | ----------------------------------------- | -------------- | ----------- |
-| [1.12.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.12.1)     | LTS v14, LTS v12, LTS v10 | v5, v6                                    | v3.7           | v16.9.0     |
-| ~~[1.12.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.12.0)~~ | ~~LTS v12, LTS v10~~      | ~~v5, v6~~                                | ~~v3.7~~       | ~~v16.9.0~~ |
-| [1.11.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.11.0)     | LTS v10                   | v5, v6                                    | v3.3           | v16.8.5     |
-| [1.10.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.10.0)     | LTS v10, LTS 8            | v5, v6                                    | v3.3           | v16.8.5     |
-| [1.9.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.9.1)       | LTS v10, LTS 8            | v5, v6                                    | v2.9           | v16.8.5     |
-| [1.8.2](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.8.2)       | LTS 8, LTS 10             | v5, v6                                    | v2.9           | v16.7.0     |
-| [1.8.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.8.1)       | LTS 8                     | v5, v6                                    | v2.7, v2.9, v3 | v16.7.0     |
-| [1.8.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.8.0)       | LTS 8                     | v5, v6                                    | v2.7, v2.9, v3 | v16.7.0     |
-| [1.7.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.7.1)       | LTS 8                     | v5, v6                                    | v2.4           | v16.3.2     |
-| [1.7.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.7)         | LTS 8                     | v5, v6                                    | v2.4           | v16.3.2     |
-| [1.6.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.6)         | LTS 6,  LTS 8             | v3 (w/ Node.js 6),<br/> v5 (w/ Node.js 8) | v2.4           | v15         |
-| [1.5.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.5.1)       | LTS 6,  LTS 8             | v3 (w/ Node.js 6),<br/> v5 (w/ Node.js 8) | v2.4           | v15         |
-| [1.5.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.5)         | LTS 6,  LTS 8             | v3 (w/ Node.js 6),<br/> v5 (w/ Node.js 8) | v2.4           | v15         |
-| [1.4.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.4.1)       | LTS 6,  LTS 8             | v3, v4                                    | v2.4           | v15         |
-| [1.4.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.4)         | LTS 6                     | v3, v4                                    | v2.4           | v15         |
-| [1.3.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.3)         | LTS 6                     | v3, v4                                    | v2.4           | v15         |
-| [1.1.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.1)         | LTS 6                     | v3, v4                                    | v2.4           | v15         |
-| [1.0.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.0.0)       | LTS 6                     | v3                                        | v2.4           | v15         |
+|               SPFx               |          Node.js          |                    NPM                    |   TypeScript   |    React    |
+| -------------------------------- | ------------------------- | ----------------------------------------- | -------------- | ----------- |
+| [1.12.1](/release-1.12.1.md)     | LTS v14, LTS v12, LTS v10 | v5, v6                                    | v3.7           | v16.9.0     |
+| ~~[1.12.0](/release-1.12.0.md)~~ | ~~LTS v12, LTS v10~~      | ~~v5, v6~~                                | ~~v3.7~~       | ~~v16.9.0~~ |
+| [1.11.0](/release-1.11.0.md)     | LTS v10                   | v5, v6                                    | v3.3           | v16.8.5     |
+| [1.10.0](/release-1.10.0.md)     | LTS v10, LTS 8            | v5, v6                                    | v3.3           | v16.8.5     |
+| [1.9.1](/release-1.9.1.md)       | LTS v10, LTS 8            | v5, v6                                    | v2.9           | v16.8.5     |
+| [1.8.2](/release-1.8.2.md)       | LTS 8, LTS 10             | v5, v6                                    | v2.9           | v16.7.0     |
+| [1.8.1](/release-1.8.1.md)       | LTS 8                     | v5, v6                                    | v2.7, v2.9, v3 | v16.7.0     |
+| [1.8.0](/release-1.8.0.md)       | LTS 8                     | v5, v6                                    | v2.7, v2.9, v3 | v16.7.0     |
+| [1.7.1](/release-1.7.1.md)       | LTS 8                     | v5, v6                                    | v2.4           | v16.3.2     |
+| [1.7.0](/release-1.7.md)         | LTS 8                     | v5, v6                                    | v2.4           | v16.3.2     |
+| [1.6.0](/release-1.6.md)         | LTS 6,  LTS 8             | v3 (w/ Node.js 6),<br/> v5 (w/ Node.js 8) | v2.4           | v15         |
+| [1.5.1](/release-1.5.1.md)       | LTS 6,  LTS 8             | v3 (w/ Node.js 6),<br/> v5 (w/ Node.js 8) | v2.4           | v15         |
+| [1.5.0](/release-1.5.md)         | LTS 6,  LTS 8             | v3 (w/ Node.js 6),<br/> v5 (w/ Node.js 8) | v2.4           | v15         |
+| [1.4.1](/release-1.4.1.md)       | LTS 6,  LTS 8             | v3, v4                                    | v2.4           | v15         |
+| [1.4.0](/release-1.4.md)         | LTS 6                     | v3, v4                                    | v2.4           | v15         |
+| [1.3.0](/release-1.3.md)         | LTS 6                     | v3, v4                                    | v2.4           | v15         |
+| [1.1.0](/release-1.1.md)         | LTS 6                     | v3, v4                                    | v2.4           | v15         |
+| [1.0.0](/release-1.0.0.md)       | LTS 6                     | v3                                        | v2.4           | v15         |
 
 ## See also
 


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- fixes #7009

## What's in this Pull Request?

- added entry for SPFx v1.12.1
- indicated v1.12.0 deprecated
- removed from version numbers because they imply some versions are supported when they arent... for instance, Node LTS v10.x isnt' accurate... LTS for v10 was v10.13.0+
