### PR TITLE
Updated pagination for large results set

### DIFF
--- a/docs/general-development/pagination-for-large-result-sets.md
+++ b/docs/general-development/pagination-for-large-result-sets.md
@@ -54,3 +54,18 @@ GET http://{site_url}/_api/search/query?querytext='sharepoint indexdocid>20'&amp
 ```
 
 And so on for the rest of the pages.
+
+To use the same approach in CSOM, see the following example:
+```C#
+...
+if (startRow == 0) // When issueing the query for first time, we don't have a DocId value yet
+    keywordQuery.QueryText = "sharepoint";
+else  // Putting the IndexDocId first and then the 'actual' query matters (in this case searching for the keyword 'sharepoint')
+    keywordQuery.QueryText = string.Format("IndexDocId > {0} AND (sharepoint)", startRow);
+keywordQuery.EnableSorting = true;
+keywordQuery.SortList.Add("[DocId]", Microsoft.SharePoint.Client.Search.Query.SortDirection.Ascending);
+...
+```
+
+> [!NOTE]
+> When using the SortList in search queries, the fieldname being used must be enclosed by brackets (e.g. `[DocId]`).


### PR DESCRIPTION
Added a CSOM example and made it important to include the brackets when using the sortlist. Otherwise, queries might fail in certain scenarios

## Category

- [x ] Content fix
- [ ] New article

## What's in this Pull Request?

Added a CSOM example on how to add sorting in the keyword query. 
Added a note that it is important the when using the sortlist property, the fieldname must be enclosed by brackets

