### PR TITLE
Update list permissions level for run-only flow users

### DIFF
--- a/docs/business-apps/power-automate/guidance/manage-list-flows.md
+++ b/docs/business-apps/power-automate/guidance/manage-list-flows.md
@@ -40,7 +40,7 @@ For triggers that support run-only users, below the **Owners** card, a **Manage 
 
 ![Manage run-only users card dropdown](../../../images/manage-run-only-users-card.png)
 
-Here, you can manage the run-only users or assign the users of the Microsoft list as run-only users. In order to run flows, users must have Edit Permissions on the list. Learn more about [list permissions and permission levels](../../../../../sharepoint/understanding-permission-levels#list-permissions-and-permission-levels).
+Here, you can manage the run-only users or assign the users of the Microsoft list as run-only users. In order to run flows, users must have Edit Permissions on the list. Learn more about [list permissions and permission levels](https://docs.microsoft.com/sharepoint/understanding-permission-levels#list-permissions-and-permission-levels).
 
 ![Manage run-only permissions](../../../images/manage-run-only-permissions.png)
 

--- a/docs/business-apps/power-automate/guidance/manage-list-flows.md
+++ b/docs/business-apps/power-automate/guidance/manage-list-flows.md
@@ -1,9 +1,10 @@
 ---
 title: Manage owners and users in your Microsoft list flows with Power Automate
-ms.date: 05/19/2020
+ms.date: 06/02/2021
 search.app: 
   - Flow
 search.appverid: met150
+description: Manage owners and users of your Power Automate flows for Microsoft lists. You can see all users of a flow, add new users or owners, and modify existing users or owners.
 ---
 
 # Manage owners and users in your Microsoft list flows with Power Automate
@@ -39,7 +40,7 @@ For triggers that support run-only users, below the **Owners** card, a **Manage 
 
 ![Manage run-only users card dropdown](../../../images/manage-run-only-users-card.png)
 
-Here, you can manage the run-only users or assign the users of the Microsoft list as run-only users. In order to run flows, users must have Edit Permissions on the list. Learn more about [list permissions and permission levels](https://docs.microsoft.com/sharepoint/understanding-permission-levels#list-permissions-and-permission-levels).
+Here, you can manage the run-only users or assign the users of the Microsoft list as run-only users. In order to run flows, users must have Edit Permissions on the list. Learn more about [list permissions and permission levels](../../../../sharepoint/understanding-permission-levels#list-permissions-and-permission-levels).
 
 ![Manage run-only permissions](../../../images/manage-run-only-permissions.png)
 

--- a/docs/business-apps/power-automate/guidance/manage-list-flows.md
+++ b/docs/business-apps/power-automate/guidance/manage-list-flows.md
@@ -39,7 +39,7 @@ For triggers that support run-only users, below the **Owners** card, a **Manage 
 
 ![Manage run-only users card dropdown](../../../images/manage-run-only-users-card.png)
 
-Here, you can manage the run-only users or assign the users of the Microsoft list as run-only users. In order to run flows, users must have the Edit Permissions on the list. Learn more about [list permissions and permission levels](https://docs.microsoft.com/sharepoint/understanding-permission-levels#list-permissions-and-permission-levels).
+Here, you can manage the run-only users or assign the users of the Microsoft list as run-only users. In order to run flows, users must have Edit Permissions on the list. Learn more about [list permissions and permission levels](https://docs.microsoft.com/sharepoint/understanding-permission-levels#list-permissions-and-permission-levels).
 
 ![Manage run-only permissions](../../../images/manage-run-only-permissions.png)
 

--- a/docs/business-apps/power-automate/guidance/manage-list-flows.md
+++ b/docs/business-apps/power-automate/guidance/manage-list-flows.md
@@ -40,7 +40,7 @@ For triggers that support run-only users, below the **Owners** card, a **Manage 
 
 ![Manage run-only users card dropdown](../../../images/manage-run-only-users-card.png)
 
-Here, you can manage the run-only users or assign the users of the Microsoft list as run-only users. In order to run flows, users must have Edit Permissions on the list. Learn more about [list permissions and permission levels](https://docs.microsoft.com/sharepoint/understanding-permission-levels#list-permissions-and-permission-levels).
+Here, you can manage the run-only users or assign the users of the Microsoft list as run-only users. In order to run flows, users must have Edit Permissions on the list. Learn more about [list permissions and permission levels](/sharepoint/understanding-permission-levels#list-permissions-and-permission-levels).
 
 ![Manage run-only permissions](../../../images/manage-run-only-permissions.png)
 

--- a/docs/business-apps/power-automate/guidance/manage-list-flows.md
+++ b/docs/business-apps/power-automate/guidance/manage-list-flows.md
@@ -1,12 +1,12 @@
 ---
-title: Manage owners and users in your SharePoint list flows with Power Automate
+title: Manage owners and users in your Microsoft list flows with Power Automate
 ms.date: 05/19/2020
 search.app: 
   - Flow
 search.appverid: met150
 ---
 
-# Manage owners and users in your SharePoint list flows with Power Automate
+# Manage owners and users in your Microsoft list flows with Power Automate
 
 Flows in Power Automate let you share your flows with others as owners or run-only users. Owners can modify flows, whereas run-only users can run or execute flows. Users' ability to run flows depends entirely on the trigger, specifically:
 
@@ -23,7 +23,7 @@ Now you can add people as owners to that flow. Select the **Users and groups** t
 
 ![Add owners to flow](../../../images/add-owners-flow.png)
 
-You can also add the SharePoint list as owners. This means that users who have edit permissions on that list automatically get owner access to the flow. This is a simple way to manage list flows as it helps you to easily share it with your team.
+You can also add the Microsoft list as owners. This means that users who have edit permissions on that list automatically get owner access to the flow. This is a simple way to manage list flows as it helps you to easily share it with your team.
 
 Select the **SharePoint** tab, select the **Site** from the dropdown, and then select the **list** from the dropdown. The site and list values depend on the trigger and actions you use in your flow. The appropriate sites and lists appear and are available for selection.
 
@@ -39,7 +39,7 @@ For triggers that support run-only users, below the **Owners** card, a **Manage 
 
 ![Manage run-only users card dropdown](../../../images/manage-run-only-users-card.png)
 
-Here, you can manage the run-only users or assign the users of the SharePoint list as run-only users. This means users who have read permissions to that list can run flows.
+Here, you can manage the run-only users or assign the users of the Microsoft list as run-only users. In order to run flows, users must have the Edit Permissions on the list. Learn more about [list permissions and permission levels](https://docs.microsoft.com/sharepoint/understanding-permission-levels#list-permissions-and-permission-levels).
 
 ![Manage run-only permissions](../../../images/manage-run-only-permissions.png)
 

--- a/docs/business-apps/power-automate/guidance/manage-list-flows.md
+++ b/docs/business-apps/power-automate/guidance/manage-list-flows.md
@@ -40,7 +40,7 @@ For triggers that support run-only users, below the **Owners** card, a **Manage 
 
 ![Manage run-only users card dropdown](../../../images/manage-run-only-users-card.png)
 
-Here, you can manage the run-only users or assign the users of the Microsoft list as run-only users. In order to run flows, users must have Edit Permissions on the list. Learn more about [list permissions and permission levels](../../../../sharepoint/understanding-permission-levels#list-permissions-and-permission-levels).
+Here, you can manage the run-only users or assign the users of the Microsoft list as run-only users. In order to run flows, users must have Edit Permissions on the list. Learn more about [list permissions and permission levels](../../../../../sharepoint/understanding-permission-levels#list-permissions-and-permission-levels).
 
 ![Manage run-only permissions](../../../images/manage-run-only-permissions.png)
 


### PR DESCRIPTION
Also updating SharePoint list to say Microsoft list

## Category

- [x] Content fix
- [ ] New article

## What's in this Pull Request?

Updating guidance on list permissions needed for run-only users to run flows on the list. Also updating "SharePoint list" to "Microsoft list" to reflect the new product branding.
