### PR TITLE
Typo: `termOfUseUrl` -> `termsOfUseUrl`

### DIFF
--- a/docs/spfx/toolchain/sharepoint-framework-toolchain.md
+++ b/docs/spfx/toolchain/sharepoint-framework-toolchain.md
@@ -145,7 +145,7 @@ Following properties are available as a part of the `developer` section:
 `websiteUrl`   | URL of a website with additional information about the application                                                          | Yes
 `mpnId`        | Microsoft Partner Network ID (more details on [MS Partner Network](/partner-center/mpn-overview)) | No (but highly recommended)
 `privacyUrl`   | Privacy statement URL                                                                                                       | Yes
-`termOfUseUrl` | Terms of use URL                                                                                                            | Yes
+`termsOfUseUrl` | Terms of use URL                                                                                                            | Yes
 
 ## Build tasks
 

--- a/docs/spfx/toolchain/sharepoint-framework-toolchain.md
+++ b/docs/spfx/toolchain/sharepoint-framework-toolchain.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint Framework toolchain
 description: The toolchain is the set of build tools, framework packages, and other items that manage building and deploying your SharePoint Framework client-side projects.
-ms.date: 11/10/2020
+ms.date: 08/05/2021
 ms.prod: sharepoint
 localization_priority: Priority
 ---


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article


## Related issues

None, noticed it when reading the docs

## What's in this Pull Request?

Simple typo for a property of the `developer` section on sharepoint `package-solution.json` file. Based on the schema found [here](https://developer.microsoft.com/json-schemas/spfx-build/package-solution.schema.json), it should be `termsOfUseUrl` but the document omits the `s` in `terms`