### PR TITLE
Fixed small typo in data types definition

### DIFF
--- a/docs/schema/field-element-list.md
+++ b/docs/schema/field-element-list.md
@@ -1,7 +1,7 @@
 ---
 title: Field element (List)
 manager: soliver
-ms.date: 01/18/2021
+ms.date: 08/05/2021
 ms.audience: Developer
 ms.topic: reference
 ms.prod: sharepoint

--- a/docs/schema/field-element-list.md
+++ b/docs/schema/field-element-list.md
@@ -64,7 +64,7 @@ Defines the internal data types used in the list infrastructure of a SharePoint 
   JoinRowOrdinal = "Integer"
   JoinType = "INNER" | "LEFT OUTER" | "RIGHT OUTER"
   LCID = "Integer"  LinkToItem = "TRUE" | "FALSE"  LinkToItemAllowed = "Text"
-  List = "Text"  ListItemMenu = "TRUE" | "FALSE"  ListItemMenuAllowed = "Text
+  List = "Text"  ListItemMenu = "TRUE" | "FALSE"  ListItemMenuAllowed = "Text"
   Max = "Number"
   MaxLength = "Integer"
   Min = "Number" 


### PR DESCRIPTION
## Category

- [x] Content fix

## Related issues

- fixes #7014

## What's in this Pull Request?

Very small typo was raised in #7014

I've added the missing quotation mark.
