### PR TITLE
Missing closing-tages

### DIFF
--- a/docs/solution-guidance/Introducing-the-PnP-Provisioning-Engine.md
+++ b/docs/solution-guidance/Introducing-the-PnP-Provisioning-Engine.md
@@ -78,11 +78,9 @@ The result of extracting and saving the template is, depending of the extension 
       <pnp:Navigation AddNewPagesToNavigation="true" CreateFriendlyUrlsForNewPages="true">
         <pnp:CurrentNavigation NavigationType="StructuralLocal">
           <pnp:StructuralNavigation RemoveExistingNodes="true">
-            <pnp:NavigationNode Title="Who we are" Url="http://linkless.header/" IsExternal="true">
-            </pnp:NavigationNode>
-            <pnp:NavigationNode Title="What's happening" Url="http://linkless.header/" IsExternal="true">
-            <pnp:NavigationNode Title="Find it" Url="http://linkless.header/" IsExternal="true">
-            </pnp:NavigationNode>
+            <pnp:NavigationNode Title="Who we are" Url="http://linkless.header/" IsExternal="true"/>
+            <pnp:NavigationNode Title="What's happening" Url="http://linkless.header/" IsExternal="true"/>
+            <pnp:NavigationNode Title="Find it" Url="http://linkless.header/" IsExternal="true"/>
           </pnp:StructuralNavigation>
         </pnp:CurrentNavigation>
       </pnp:Navigation>
@@ -131,6 +129,7 @@ The result of extracting and saving the template is, depending of the extension 
                 </pnp:CanvasControl>
                 <pnp:CanvasControl WebPartType="Button" JsonControlData="{&quot;id&quot;: &quot;0f087d7f-520e-42b7-89c0-496aaf979d58&quot;, &quot;instanceId&quot;: &quot;deb39e2b-11a0-4141-8ac1-1078fe7cc392&quot;, &quot;title&quot;: &quot;..." ControlId="0f087d7f-520e-42b7-89c0-496aaf979d58" Order="3" Column="1" />
                 <pnp:CanvasControl WebPartType="Image" JsonControlData="{&quot;id&quot;: &quot;d1d91016-032f-456d-98a4-721247c305e8&quot;, &quot;instanceId&quot;: &quot;e0b59b5b-8a5a-406e-9deb-6e6f9de4bd3b&quot;, &quot;title&quot;: &quot;Image&quot;, ..." ControlId="d1d91016-032f-456d-98a4-721247c305e8" Order="1" Column="2" />
+               </pnp:Controls>            
             </pnp:Section>
           </pnp:Sections>
         </pnp:ClientSidePage>


### PR DESCRIPTION
Add missing closing tags for NavigationNodes and Controls under section 3 / ThreeColumn

## Category

- [x] Content fix
- [ ] New article
- [ ] Example checked item (*delete this line*)

> **DELETE THIS LINE BEFORE SUBMITTING** | *For the above list, an empty checkbox is [ ] as in <kbd>[</kbd><kbd>SPACE</kbd><kbd>]</kbd>. A checked checkbox is [x] with no space between the brackets. Use the `PREVIEW` tab at the top right to preview the rendering before submitting your issue.*

## Related issues

- fixes #issuenumber
- partially #issuenumber
- mentioned in #issuenumber

> **DELETE THIS LINE BEFORE SUBMITTING** | *If this fixes (aka: closes) or references an issue, please reference it here. This helps maintaining the issue list as it will (1) link the PR to the issue & (2) automatically close the issue when this PR is merged in.*

## What's in this Pull Request?

> **DELETE THIS LINE BEFORE SUBMITTING** | *Please describe the changes in this PR. Sample description or details around bugs which are being fixed.*

## Submission guidelines

> - **!!IMPORTANT!!** - All submissions must complete the baseline sections included in this template. Ignoring or deleting this template may result in closing the issue with the label **type:incomplete-submission**.
> - Follow our guidance on [How To Create Good Pull Requests](https://github.com/SharePoint/sp-dev-docs/wiki/How-to-Create-Good-Pull-Requests).
> - Target the `master` branch of this repo. Released documents are in `live` branch.
>
> **DELETE THIS SECTION BEFORE SUBMITTING**
