### PR TITLE
Remove Line-breaks in code

### DIFF
--- a/docs/declarative-customization/view-formatting.md
+++ b/docs/declarative-customization/view-formatting.md
@@ -170,6 +170,9 @@ In the example below we have list with group headers formatted according to colu
 
 In this example below, the `headerFormatter` for `groupProps` is used to format the group header and the `@group` is used to access group info.
 
+> [!NOTE]
+> The JSON below contains line breaks. These have been added to improve the readability of the code. 
+
 ```JSON
 {
   "$schema": "https://developer.microsoft.com/json-schemas/sp/v2/row-formatting.schema.json",
@@ -188,13 +191,22 @@ In this example below, the `headerFormatter` for `groupProps` is used to format 
         "margin": "1px 4px 4px 1px"
       },
       "attributes": {
-        "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37', if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50', if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50', if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50', if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50', 'sp-field-borderAllRegular sp-field-borderAllSolid sp-css-borderColor-neutralSecondary')))))"
+        "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37', 
+                   if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50', 
+                   if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50', 
+                   if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50', 
+                   if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50', 
+                   'sp-field-borderAllRegular sp-field-borderAllSolid sp-css-borderColor-neutralSecondary')))))"
       },
       "children": [
         {
           "elmType": "img",
           "attributes": {
-            "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png', if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png', if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png', if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png', if(@group.fieldData == 'Washington DC', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Flag_of_the_District_of_Columbia.svg/2560px-Flag_of_the_District_of_Columbia.svg.png', '')))))"
+            "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png', 
+                     if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png', 
+                     if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png', 
+                     if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png', 
+                     if(@group.fieldData == 'Washington DC', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Flag_of_the_District_of_Columbia.svg/2560px-Flag_of_the_District_of_Columbia.svg.png', '')))))"
           },
           "style": {
             "max-width": "24px",
@@ -252,6 +264,9 @@ In the example below we have list with group headers formatted with group aggreg
 
 In this example the `hideFooter` for `groupProps` is set to `true` - to hide the group footer and the `@aggregates` array is used to display a summary in the group header.
 
+> [!NOTE]
+> The JSON below contains line breaks. These have been added to improve the readability of the code.  
+
 ```JSON
 {
   "$schema": "https://developer.microsoft.com/json-schemas/sp/v2/row-formatting.schema.json",
@@ -271,13 +286,22 @@ In this example the `hideFooter` for `groupProps` is set to `true` - to hide the
         "margin": "1px 4px 4px 1px"
       },
       "attributes": {
-        "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37', if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50', if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50', if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50', if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50', 'sp-field-borderAllRegular sp-field-borderAllSolid sp-css-borderColor-neutralSecondary')))))"
+        "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37', 
+                   if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50', 
+                   if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50', 
+                   if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50', 
+                   if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50', 
+                   'sp-field-borderAllRegular sp-field-borderAllSolid sp-css-borderColor-neutralSecondary')))))"
       },
       "children": [
         {
           "elmType": "img",
           "attributes": {
-            "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png', if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png', if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png', if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png', if(@group.fieldData == 'Washington DC', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Flag_of_the_District_of_Columbia.svg/2560px-Flag_of_the_District_of_Columbia.svg.png', '')))))"
+            "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png', 
+                     if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png', 
+                     if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png', 
+                     if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png', 
+                     if(@group.fieldData == 'Washington DC', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Flag_of_the_District_of_Columbia.svg/2560px-Flag_of_the_District_of_Columbia.svg.png', '')))))"
           },
           "style": {
             "max-width": "24px",
@@ -552,6 +576,7 @@ In the example below we have gallery view with formatted group headers as per co
 
 > [!NOTE]
 > Gallery card formatter is skipped in the below JSON for simplicity.
+> The example below also contains line breaks. These have been added to improve the readability of the code. 
 
 ```JSON
 {
@@ -577,13 +602,22 @@ In the example below we have gallery view with formatted group headers as per co
             "margin": "1px 4px 4px 1px"
           },
           "attributes": {
-            "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37', if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50', if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50', if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50', if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50', 'sp-field-borderAllRegular sp-field-borderAllSolid sp-css-borderColor-neutralSecondary'))))"
+            "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37', 
+                       if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50', 
+                       if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50', 
+                       if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50', 
+                       if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50', 
+                       'sp-field-borderAllRegular sp-field-borderAllSolid sp-css-borderColor-neutralSecondary'))))"
           },
           "children": [
             {
               "elmType": "img",
               "attributes": {
-                "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png', if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png', if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png', if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png', if(@group.fieldData == 'Washington DC', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Flag_of_the_District_of_Columbia.svg/2560px-Flag_of_the_District_of_Columbia.svg.png', '')))))"
+                "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png', 
+                         if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png', 
+                         if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png', 
+                         if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png', 
+                         if(@group.fieldData == 'Washington DC', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Flag_of_the_District_of_Columbia.svg/2560px-Flag_of_the_District_of_Columbia.svg.png', '')))))"
               },
               "style": {
                 "max-width": "24px",
@@ -651,6 +685,7 @@ In this example the `@aggregates` array is used to display a summary in the grou
 
 > [!NOTE]
 > Gallery card formatter is skipped in the below JSON for simplicity.
+> The example below also contains line breaks. These have been added to improve the readability of the code.
 
 ```JSON
 {
@@ -678,13 +713,21 @@ In this example the `@aggregates` array is used to display a summary in the grou
             "margin": "1px 4px 4px 1px"
           },
           "attributes": {
-            "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37', if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50', if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50', if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50', if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50', 'sp-field-borderAllRegular sp-field-borderAllSolid sp-css-borderColor-neutralSecondary')))))"
+            "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37', 
+                       if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50', 
+                       if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50', 
+                       if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50', 
+                       if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50', 'sp-field-borderAllRegular sp-field-borderAllSolid sp-css-borderColor-neutralSecondary')))))"
           },
           "children": [
             {
               "elmType": "img",
               "attributes": {
-                "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png', if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png', if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png', if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png', if(@group.fieldData == 'Washington DC', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Flag_of_the_District_of_Columbia.svg/2560px-Flag_of_the_District_of_Columbia.svg.png', '')))))"
+                "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png', 
+                         if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png', 
+                         if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png', 
+                         if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png', 
+                         if(@group.fieldData == 'Washington DC', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Flag_of_the_District_of_Columbia.svg/2560px-Flag_of_the_District_of_Columbia.svg.png', '')))))"
               },
               "style": {
                 "max-width": "24px",

--- a/docs/declarative-customization/view-formatting.md
+++ b/docs/declarative-customization/view-formatting.md
@@ -188,23 +188,13 @@ In this example below, the `headerFormatter` for `groupProps` is used to format 
         "margin": "1px 4px 4px 1px"
       },
       "attributes": {
-        "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37',
-                    if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50',
-                    if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50',
-                    if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50',
-                    if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50',
-                    'sp-field-borderAllRegular sp-field-borderAllSolid sp-css-borderColor-neutralSecondary'))))"
+        "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37', if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50', if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50', if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50', if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50', 'sp-field-borderAllRegular sp-field-borderAllSolid sp-css-borderColor-neutralSecondary')))))"
       },
       "children": [
         {
           "elmType": "img",
           "attributes": {
-            "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png',
-                    if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png',
-                    if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png',
-                    if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png',
-                    if(@group.fieldData == 'Washington DC', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Flag_of_the_District_of_Columbia.svg/2560px-Flag_of_the_District_of_Columbia.svg.png',
-                    ''))))"
+            "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png', if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png', if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png', if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png', if(@group.fieldData == 'Washington DC', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Flag_of_the_District_of_Columbia.svg/2560px-Flag_of_the_District_of_Columbia.svg.png', '')))))"
           },
           "style": {
             "max-width": "24px",
@@ -281,23 +271,13 @@ In this example the `hideFooter` for `groupProps` is set to `true` - to hide the
         "margin": "1px 4px 4px 1px"
       },
       "attributes": {
-        "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37',
-                    if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50',
-                    if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50',
-                    if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50',
-                    if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50',
-                    'sp-field-borderAllRegular sp-field-borderAllSolid sp-css-borderColor-neutralSecondary'))))"
+        "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37', if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50', if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50', if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50', if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50', 'sp-field-borderAllRegular sp-field-borderAllSolid sp-css-borderColor-neutralSecondary')))))"
       },
       "children": [
         {
           "elmType": "img",
           "attributes": {
-            "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png',
-                    if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png',
-                    if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png',
-                    if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png',
-                    if(@group.fieldData == 'Washington DC', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Flag_of_the_District_of_Columbia.svg/2560px-Flag_of_the_District_of_Columbia.svg.png',
-                    ''))))"
+            "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png', if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png', if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png', if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png', if(@group.fieldData == 'Washington DC', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Flag_of_the_District_of_Columbia.svg/2560px-Flag_of_the_District_of_Columbia.svg.png', '')))))"
           },
           "style": {
             "max-width": "24px",
@@ -597,23 +577,13 @@ In the example below we have gallery view with formatted group headers as per co
             "margin": "1px 4px 4px 1px"
           },
           "attributes": {
-            "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37',
-                        if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50',
-                        if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50',
-                        if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50',
-                        if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50',
-                        'sp-field-borderAllRegular sp-field-borderAllSolid sp-css-borderColor-neutralSecondary'))))"
+            "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37', if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50', if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50', if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50', if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50', 'sp-field-borderAllRegular sp-field-borderAllSolid sp-css-borderColor-neutralSecondary'))))"
           },
           "children": [
             {
               "elmType": "img",
               "attributes": {
-                "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png',
-                    if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png',
-                    if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png',
-                    if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png',
-                    if(@group.fieldData == 'Washington DC', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Flag_of_the_District_of_Columbia.svg/2560px-Flag_of_the_District_of_Columbia.svg.png',
-                    ''))))"
+                "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png', if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png', if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png', if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png', if(@group.fieldData == 'Washington DC', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Flag_of_the_District_of_Columbia.svg/2560px-Flag_of_the_District_of_Columbia.svg.png', '')))))"
               },
               "style": {
                 "max-width": "24px",
@@ -708,23 +678,13 @@ In this example the `@aggregates` array is used to display a summary in the grou
             "margin": "1px 4px 4px 1px"
           },
           "attributes": {
-            "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37',
-                      if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50',
-                      if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50',
-                      if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50',
-                      if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50',
-                      'sp-field-borderAllRegular sp-field-borderAllSolid sp-css-borderColor-neutralSecondary'))))"
+            "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37', if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50', if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50', if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50', if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50', 'sp-field-borderAllRegular sp-field-borderAllSolid sp-css-borderColor-neutralSecondary')))))"
           },
           "children": [
             {
               "elmType": "img",
               "attributes": {
-                "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png',
-                        if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png',
-                        if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png',
-                        if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png',
-                        if(@group.fieldData == 'Washington DC', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Flag_of_the_District_of_Columbia.svg/2560px-Flag_of_the_District_of_Columbia.svg.png',
-                        ''))))"
+                "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png', if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png', if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png', if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png', if(@group.fieldData == 'Washington DC', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Flag_of_the_District_of_Columbia.svg/2560px-Flag_of_the_District_of_Columbia.svg.png', '')))))"
               },
               "style": {
                 "max-width": "24px",

--- a/docs/declarative-customization/view-formatting.md
+++ b/docs/declarative-customization/view-formatting.md
@@ -36,7 +36,7 @@ The easiest way to use view formatting is to start from an example and edit it t
 
 You can use **`additionalRowClass`** to apply one or more classes to the entire list row depending on the value of one or more fields in the row. These examples leave the content and structure of list rows intact.
 
-For a list of recommended classes to use inside view formats, please see the [Style Guidelines section](https://docs.microsoft.com/sharepoint/dev/declarative-customization/column-formatting#style-guidelines) in the [Column Formatting reference document](https://docs.microsoft.com/sharepoint/dev/declarative-customization/column-formatting).
+For a list of recommended classes to use inside view formats, please see the [Style Guidelines section](/../../blob/master/docs/declarative-customization/column-formatting.md#style-guidelines) in the [Column Formatting reference document](/../../blob/master/docs/declarative-customization/column-formatting.md).
 
 > [!TIP]
 > Using the `additionalRowClass` property to apply classes to list rows will leave the formatting of individual columns in place. This allows you to combine view formats with column formatting for some powerful visualizations.
@@ -794,7 +794,7 @@ Creating custom view formatting JSON from scratch is simple if user understands 
 
 ### rowFormatter
 
-Optional element. Specifies a JSON object that describes a list row format. The schema of this JSON object is identical to the schema of a column format. For details on this schema and its capabilities, see the [Column Format detailed syntax reference](https://docs.microsoft.com/sharepoint/dev/declarative-customization/column-formatting#detailed-syntax-reference). Only valid for 'List' and 'Compact List' layouts.
+Optional element. Specifies a JSON object that describes a list row format. The schema of this JSON object is identical to the schema of a column format. For details on this schema and its capabilities, see the [Column Format detailed syntax reference](/../../blob/master/docs/declarative-customization/column-formatting.md#detailed-syntax-reference). Only valid for 'List' and 'Compact List' layouts.
 
 > [!NOTE]
 > Using the `rowFormatter` property will override anything specified in the `additionalRowClass` property. They are mutually exclusive.
@@ -831,7 +831,7 @@ Optional element. Defines the width of the card in pixels for 'Gallery' layout. 
 
 ### formatter
 
-JSON object that defines the layout of cards for 'Gallery' layout. The schema of this JSON object is identical to the schema of a column format (and that of rowFormatter). For details on this schema and its capabilities, see the [Column Format detailed syntax reference](https://docs.microsoft.com/sharepoint/dev/declarative-customization/column-formatting#detailed-syntax-reference). Only valid for 'Gallery' layout.
+JSON object that defines the layout of cards for 'Gallery' layout. The schema of this JSON object is identical to the schema of a column format (and that of rowFormatter). For details on this schema and its capabilities, see the [Column Format detailed syntax reference](/../../blob/master/docs/declarative-customization/column-formatting.md#detailed-syntax-reference). Only valid for 'Gallery' layout.
 
 ### groupProps
 
@@ -839,11 +839,11 @@ Groups the group related customization options. Valid in 'List', 'Compact List' 
 
 ### headerFormatter
 
-JSON object that defines the format for group header. The schema of this JSON object is identical to the schema of a column format. For details on this schema and its capabilities, see the [Column Format detailed syntax reference](https://docs.microsoft.com/sharepoint/dev/declarative-customization/column-formatting#detailed-syntax-reference). Valid in 'List', 'Compact List' and 'Gallery' layouts.
+JSON object that defines the format for group header. The schema of this JSON object is identical to the schema of a column format. For details on this schema and its capabilities, see the [Column Format detailed syntax reference](/../../blob/master/docs/declarative-customization/column-formatting.md#detailed-syntax-reference). Valid in 'List', 'Compact List' and 'Gallery' layouts.
 
 ### footerFormatter
 
-JSON object that defines the format for group and list footer. The schema of this JSON object is identical to the schema of a column format (and that of rowFormatter). For details on this schema and its capabilities, see the [Column Format detailed syntax reference](https://docs.microsoft.com/sharepoint/dev/declarative-customization/column-formatting#detailed-syntax-reference). Valid in 'List' and 'Compact List' layouts.
+JSON object that defines the format for group and list footer. The schema of this JSON object is identical to the schema of a column format (and that of rowFormatter). For details on this schema and its capabilities, see the [Column Format detailed syntax reference](/../../blob/master/docs/declarative-customization/column-formatting.md#detailed-syntax-reference). Valid in 'List' and 'Compact List' layouts.
 
 ### hideFooter
 
@@ -869,7 +869,7 @@ The `@group` object has the following properties (with example values):
 }
 ```
 
-You can also access sub properties for fields with rich data, e.g. People field, as mentioned under [Column Format special string values](https://docs.microsoft.com/sharepoint/dev/declarative-customization/column-formatting#special-string-values).
+You can also access sub properties for fields with rich data, e.g. People field, as mentioned under [Column Format special string values](/../../blob/master/docs/declarative-customization/column-formatting.md#special-string-values).
 
 ```JSON
 {
@@ -906,7 +906,7 @@ The `@columnAggregate` object has the following properties (with example values)
 
 Provides access to array of aggregated column's value, display name and aggregate type. Valid in 'List', 'Compact List' and 'Gallery' layouts. Available only inside `groupProps`.
 
-The `@aggregates` object has the following properties (with example value), and can be iterated on using [Column Format forEach](https://docs.microsoft.com/sharepoint/dev/declarative-customization/column-formatting#foreach) property.
+The `@aggregates` object has the following properties (with example value), and can be iterated on using [Column Format forEach](/../../blob/master/docs/declarative-customization/column-formatting.md#foreach) property.
 
 ```JSON
 [

--- a/docs/declarative-customization/view-formatting.md
+++ b/docs/declarative-customization/view-formatting.md
@@ -1,7 +1,7 @@
 ---
 title: Use view formatting to customize SharePoint
 description: Customize how views in SharePoint lists and libraries are displayed by constructing a JSON object that describes the elements that are displayed in a list view, and the styles to be applied to those elements.
-ms.date: 06/01/2021
+ms.date: 09/14/2021
 localization_priority: Priority
 ---
 
@@ -17,11 +17,15 @@ You can use view formatting to customize how items in SharePoint lists and libra
 
 ## Get started with view formatting
 
-To open the view formatting pane, open the view dropdown and choose **Format current view**. <img src="../images/view-dropdown-menu.png" alt="View dropdown menu" width="260" height="310"/>
+To open the view formatting pane, open the view dropdown and choose **Format current view**.
+
+![View dropdown menu](../images/view-dropdown-menu.png)
 
 The pane will look like the following depending on the current layout:
 
-<img src="../images/sp-viewformatting-panel-listlayout.png" alt="List layout formatting pane"/> <img src="../images/sp-viewformatting-panel-tileslayout.png" alt="Gallery layout formatting pane"/>
+![List layout formatting pane](../images/sp-viewformatting-panel-listlayout.png)
+
+![Gallery layout formatting pane](../images/sp-viewformatting-panel-tileslayout.png)
 
 > [!NOTE]
 > We have simplified the View formatting pane experience to separate out the List and Gallery layout formatting JSON. With this change, you do not need to add `tileProps` prop anymore.
@@ -36,7 +40,7 @@ The easiest way to use view formatting is to start from an example and edit it t
 
 You can use **`additionalRowClass`** to apply one or more classes to the entire list row depending on the value of one or more fields in the row. These examples leave the content and structure of list rows intact.
 
-For a list of recommended classes to use inside view formats, please see the [Style Guidelines section](/../../blob/master/docs/declarative-customization/column-formatting.md#style-guidelines) in the [Column Formatting reference document](/../../blob/master/docs/declarative-customization/column-formatting.md).
+For a list of recommended classes to use inside view formats, please see the [Style guidelines](column-formatting.md#style-guidelines) in the [Use column formatting to customize SharePoint](column-formatting.md).
 
 > [!TIP]
 > Using the `additionalRowClass` property to apply classes to list rows will leave the formatting of individual columns in place. This allows you to combine view formats with column formatting for some powerful visualizations.
@@ -171,7 +175,7 @@ In the example below we have list with group headers formatted according to colu
 In this example below, the `headerFormatter` for `groupProps` is used to format the group header and the `@group` is used to access group info.
 
 > [!NOTE]
-> The JSON below contains line breaks. These have been added to improve the readability of the code. 
+> The JSON below contains line breaks. These have been added to improve the readability of the code.
 
 ```JSON
 {
@@ -191,21 +195,21 @@ In this example below, the `headerFormatter` for `groupProps` is used to format 
         "margin": "1px 4px 4px 1px"
       },
       "attributes": {
-        "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37', 
-                   if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50', 
-                   if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50', 
-                   if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50', 
-                   if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50', 
+        "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37',
+                   if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50',
+                   if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50',
+                   if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50',
+                   if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50',
                    'sp-field-borderAllRegular sp-field-borderAllSolid sp-css-borderColor-neutralSecondary')))))"
       },
       "children": [
         {
           "elmType": "img",
           "attributes": {
-            "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png', 
-                     if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png', 
-                     if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png', 
-                     if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png', 
+            "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png',
+                     if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png',
+                     if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png',
+                     if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png',
                      if(@group.fieldData == 'Washington DC', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Flag_of_the_District_of_Columbia.svg/2560px-Flag_of_the_District_of_Columbia.svg.png', '')))))"
           },
           "style": {
@@ -265,7 +269,7 @@ In the example below we have list with group headers formatted with group aggreg
 In this example the `hideFooter` for `groupProps` is set to `true` - to hide the group footer and the `@aggregates` array is used to display a summary in the group header.
 
 > [!NOTE]
-> The JSON below contains line breaks. These have been added to improve the readability of the code.  
+> The JSON below contains line breaks. These have been added to improve the readability of the code.
 
 ```JSON
 {
@@ -286,21 +290,21 @@ In this example the `hideFooter` for `groupProps` is set to `true` - to hide the
         "margin": "1px 4px 4px 1px"
       },
       "attributes": {
-        "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37', 
-                   if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50', 
-                   if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50', 
-                   if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50', 
-                   if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50', 
+        "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37',
+                   if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50',
+                   if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50',
+                   if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50',
+                   if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50',
                    'sp-field-borderAllRegular sp-field-borderAllSolid sp-css-borderColor-neutralSecondary')))))"
       },
       "children": [
         {
           "elmType": "img",
           "attributes": {
-            "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png', 
-                     if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png', 
-                     if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png', 
-                     if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png', 
+            "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png',
+                     if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png',
+                     if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png',
+                     if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png',
                      if(@group.fieldData == 'Washington DC', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Flag_of_the_District_of_Columbia.svg/2560px-Flag_of_the_District_of_Columbia.svg.png', '')))))"
           },
           "style": {
@@ -576,7 +580,7 @@ In the example below we have gallery view with formatted group headers as per co
 
 > [!NOTE]
 > Gallery card formatter is skipped in the below JSON for simplicity.
-> The example below also contains line breaks. These have been added to improve the readability of the code. 
+> The example below also contains line breaks. These have been added to improve the readability of the code.
 
 ```JSON
 {
@@ -602,21 +606,21 @@ In the example below we have gallery view with formatted group headers as per co
             "margin": "1px 4px 4px 1px"
           },
           "attributes": {
-            "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37', 
-                       if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50', 
-                       if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50', 
-                       if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50', 
-                       if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50', 
+            "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37',
+                       if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50',
+                       if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50',
+                       if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50',
+                       if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50',
                        'sp-field-borderAllRegular sp-field-borderAllSolid sp-css-borderColor-neutralSecondary'))))"
           },
           "children": [
             {
               "elmType": "img",
               "attributes": {
-                "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png', 
-                         if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png', 
-                         if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png', 
-                         if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png', 
+                "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png',
+                         if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png',
+                         if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png',
+                         if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png',
                          if(@group.fieldData == 'Washington DC', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Flag_of_the_District_of_Columbia.svg/2560px-Flag_of_the_District_of_Columbia.svg.png', '')))))"
               },
               "style": {
@@ -713,20 +717,20 @@ In this example the `@aggregates` array is used to display a summary in the grou
             "margin": "1px 4px 4px 1px"
           },
           "attributes": {
-            "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37', 
-                       if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50', 
-                       if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50', 
-                       if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50', 
+            "class": "=if(@group.fieldData == 'California', 'sp-css-backgroundColor-blueBackground37',
+                       if(@group.fieldData == 'Chicago', 'sp-css-backgroundColor-successBackground50',
+                       if(@group.fieldData == 'New York', 'sp-css-backgroundColor-warningBackground50',
+                       if(@group.fieldData == 'Seattle', 'sp-css-backgroundColor-blockingBackground50',
                        if(@group.fieldData == 'Washington DC', 'sp-css-backgroundColor-errorBackground50', 'sp-field-borderAllRegular sp-field-borderAllSolid sp-css-borderColor-neutralSecondary')))))"
           },
           "children": [
             {
               "elmType": "img",
               "attributes": {
-                "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png', 
-                         if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png', 
-                         if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png', 
-                         if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png', 
+                "src": "=if(@group.fieldData == 'California', 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Flag_of_California.svg/1920px-Flag_of_California.svg.png',
+                         if(@group.fieldData == 'Chicago', 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Flag_of_Chicago%2C_Illinois.svg/1920px-Flag_of_Chicago%2C_Illinois.svg.png',
+                         if(@group.fieldData == 'New York', 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_New_York_City.svg/2560px-Flag_of_New_York_City.svg.png',
+                         if(@group.fieldData == 'Seattle', 'https://upload.wikimedia.org/wikipedia/en/thumb/6/6d/Flag_of_Seattle.svg/1920px-Flag_of_Seattle.svg.png',
                          if(@group.fieldData == 'Washington DC', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Flag_of_the_District_of_Columbia.svg/2560px-Flag_of_the_District_of_Columbia.svg.png', '')))))"
               },
               "style": {
@@ -794,7 +798,7 @@ Creating custom view formatting JSON from scratch is simple if user understands 
 
 ### rowFormatter
 
-Optional element. Specifies a JSON object that describes a list row format. The schema of this JSON object is identical to the schema of a column format. For details on this schema and its capabilities, see the [Column Format detailed syntax reference](/../../blob/master/docs/declarative-customization/column-formatting.md#detailed-syntax-reference). Only valid for 'List' and 'Compact List' layouts.
+Optional element. Specifies a JSON object that describes a list row format. The schema of this JSON object is identical to the schema of a column format. For details on this schema and its capabilities, see [Column Format Detailed syntax reference](column-formatting.md#detailed-syntax-reference). Only valid for 'List' and 'Compact List' layouts.
 
 > [!NOTE]
 > Using the `rowFormatter` property will override anything specified in the `additionalRowClass` property. They are mutually exclusive.
@@ -831,7 +835,7 @@ Optional element. Defines the width of the card in pixels for 'Gallery' layout. 
 
 ### formatter
 
-JSON object that defines the layout of cards for 'Gallery' layout. The schema of this JSON object is identical to the schema of a column format (and that of rowFormatter). For details on this schema and its capabilities, see the [Column Format detailed syntax reference](/../../blob/master/docs/declarative-customization/column-formatting.md#detailed-syntax-reference). Only valid for 'Gallery' layout.
+JSON object that defines the layout of cards for 'Gallery' layout. The schema of this JSON object is identical to the schema of a column format (and that of rowFormatter). For details on this schema and its capabilities, see the [Column Format Detailed syntax reference](column-formatting.md#detailed-syntax-reference). Only valid for 'Gallery' layout.
 
 ### groupProps
 
@@ -839,11 +843,11 @@ Groups the group related customization options. Valid in 'List', 'Compact List' 
 
 ### headerFormatter
 
-JSON object that defines the format for group header. The schema of this JSON object is identical to the schema of a column format. For details on this schema and its capabilities, see the [Column Format detailed syntax reference](/../../blob/master/docs/declarative-customization/column-formatting.md#detailed-syntax-reference). Valid in 'List', 'Compact List' and 'Gallery' layouts.
+JSON object that defines the format for group header. The schema of this JSON object is identical to the schema of a column format. For details on this schema and its capabilities, see the [Column Format Detailed syntax reference](column-formatting.md#detailed-syntax-reference). Valid in 'List', 'Compact List' and 'Gallery' layouts.
 
 ### footerFormatter
 
-JSON object that defines the format for group and list footer. The schema of this JSON object is identical to the schema of a column format (and that of rowFormatter). For details on this schema and its capabilities, see the [Column Format detailed syntax reference](/../../blob/master/docs/declarative-customization/column-formatting.md#detailed-syntax-reference). Valid in 'List' and 'Compact List' layouts.
+JSON object that defines the format for group and list footer. The schema of this JSON object is identical to the schema of a column format (and that of rowFormatter). For details on this schema and its capabilities, see the [Column Format Detailed syntax reference](column-formatting.md#detailed-syntax-reference). Valid in 'List' and 'Compact List' layouts.
 
 ### hideFooter
 
@@ -869,7 +873,7 @@ The `@group` object has the following properties (with example values):
 }
 ```
 
-You can also access sub properties for fields with rich data, e.g. People field, as mentioned under [Column Format special string values](/../../blob/master/docs/declarative-customization/column-formatting.md#special-string-values).
+You can also access sub properties for fields with rich data, e.g. People field, as mentioned under [Column Format Special string values](column-formatting.md#special-string-values).
 
 ```JSON
 {
@@ -906,7 +910,7 @@ The `@columnAggregate` object has the following properties (with example values)
 
 Provides access to array of aggregated column's value, display name and aggregate type. Valid in 'List', 'Compact List' and 'Gallery' layouts. Available only inside `groupProps`.
 
-The `@aggregates` object has the following properties (with example value), and can be iterated on using [Column Format forEach](/../../blob/master/docs/declarative-customization/column-formatting.md#foreach) property.
+The `@aggregates` object has the following properties (with example value), and can be iterated on using for [Column Format forEach](column-formatting.md#foreach) property.
 
 ```JSON
 [


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article


## Related issues

- fixes #7078 

## What's in this Pull Request?

JSON Doesn't allow line-breaks. 
Meaning when a user copies a code example and uses it within SPO they will get an error.
I removed the line-breaks and added an extra ')' to the strings because they were missing one closing char.

There is a side effect to this fix. It diminshes the readability of the example.

