### PR TITLE
Add steps to allow the DetailedQuickView to works

### DIFF
--- a/docs/spfx/viva/get-started/advanced-quick-view-functionality.md
+++ b/docs/spfx/viva/get-started/advanced-quick-view-functionality.md
@@ -1,7 +1,7 @@
 ---
 title: Advanced Quick View Functionality
 description: "This tutorial builds off the tutorial 'Advanced Card View Functionality'."
-ms.date: 10/25/2021
+ms.date: 11/11/2021
 ms.prod: sharepoint
 ms.localizationpriority: high
 ---
@@ -78,22 +78,26 @@ Start with the HelloWorld ACE from the previous tutorial, [Advanced Card View Fu
       ]
     }
     ```
-1. As you can see in the JSON template, we use the ${index} to pass the selected item index to the QuickView. To allow this to works, we must add and populate _index_ property of  the _IListItem_ object defined in the previous tutorial. Open and locate the file **./src/adaptiveCardExtensions/helloWorld/HelloWorldAdaptiveCardExtension.ts**, than add the property _index_ to the _IListItem_ definition:
-```typescript
-export interface IListItem {
-  title: string;
-  description: string;
-  index: number;
-}
-```
-1. Finally locate the _\_fetchData_ method in the same class and modify the map function inside it, to: 
-```typescript
-...
-.then((jsonResponse) => jsonResponse.value.map(
-    (item, index) => { return { title: item.Title, description: item.Description, index: index }; })
-)
-...
-```
+
+1. As you can see in the JSON template, we use the ${index} to pass the selected item index to the QuickView. To allow this to works, we must add and populate `index` property of  the `IListItem` object defined in the previous tutorial. Open and locate the file **./src/adaptiveCardExtensions/helloWorld/HelloWorldAdaptiveCardExtension.ts**, than add the property `index` to the `IListItem` definition:
+
+    ```typescript
+    export interface IListItem {
+      title: string;
+      description: string;
+      index: number;
+    }
+    ```
+
+1. Finally locate the `fetchData()` method in the same class and modify the map function inside it, to: 
+
+    ```typescript
+    ...
+    .then((jsonResponse) => jsonResponse.value.map(
+        (item, index) => { return { title: item.Title, description: item.Description, index: index }; })
+    )
+    ...
+    ```
 
 Build and launch the ACE in the hosted workbench:
 

--- a/docs/spfx/viva/get-started/advanced-quick-view-functionality.md
+++ b/docs/spfx/viva/get-started/advanced-quick-view-functionality.md
@@ -49,11 +49,11 @@ Start with the HelloWorld ACE from the previous tutorial, [Advanced Card View Fu
             "type": "Action.Submit",
             "data": {
               "id": "selectAction",
-              "newIndex": "${index}",
+              "newIndex": "${index}"
             }
           },
           "separator": true,
-          "items": [ // The template for an item in `items`
+          "items": [
             {
               "type": "TextBlock",
               "text": "${title}",

--- a/docs/spfx/viva/get-started/advanced-quick-view-functionality.md
+++ b/docs/spfx/viva/get-started/advanced-quick-view-functionality.md
@@ -78,6 +78,22 @@ Start with the HelloWorld ACE from the previous tutorial, [Advanced Card View Fu
       ]
     }
     ```
+1. As you can see in the JSON template, we use the ${index} to pass the selected item index to the QuickView. To allow this to works, we must add and populate _index_ property of  the _IListItem_ object defined in the previous tutorial. Open and locate the file **./src/adaptiveCardExtensions/helloWorld/HelloWorldAdaptiveCardExtension.ts**, than add the property _index_ to the _IListItem_ definition:
+```typescript
+export interface IListItem {
+  title: string;
+  description: string;
+  index: number;
+}
+```
+1. Finally locate the _\_fetchData_ method in the same class and modify the map function inside it, to: 
+```typescript
+...
+.then((jsonResponse) => jsonResponse.value.map(
+    (item, index) => { return { title: item.Title, description: item.Description, index: index }; })
+)
+...
+```
 
 Build and launch the ACE in the hosted workbench:
 


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- fixes #issuenumber
- partially #issuenumber
- mentioned in #issuenumber

## What's in this Pull Request?

The code reported in the documentation doesn't manage the index property of the IListItem object showed in the details view and so, when the user open the QuickView and click on one items, nothing happen beacause the ${index} in the DetailedQuickViewTemplate.json isn't mapped to any valid attribute and so, the action passed to the QuickView.onAction method, containes ${index} as newIndex.