### PR TITLE
Support approval status

### DIFF
--- a/docs/declarative-customization/column-formatting.md
+++ b/docs/declarative-customization/column-formatting.md
@@ -1,7 +1,7 @@
 ---
 title: Use column formatting to customize SharePoint
 description: Customize how fields in SharePoint lists and libraries are displayed by constructing a JSON object that describes the elements that are displayed when a field is included in a list view, and the styles to be applied to those elements.
-ms.date: 10/18/2021
+ms.date: 11/11/2021
 ms.localizationpriority: high
 ---
 

--- a/docs/declarative-customization/column-formatting.md
+++ b/docs/declarative-customization/column-formatting.md
@@ -705,6 +705,7 @@ The following column types support column formatting:
 * Managed Metadata
 * Average Rating
 * Likes
+* Approval Status
 
 The following are currently **not** supported:
 

--- a/docs/declarative-customization/formatting-syntax-reference.md
+++ b/docs/declarative-customization/formatting-syntax-reference.md
@@ -1,7 +1,7 @@
 ---
 title: Formatting syntax reference
 description: Formatting syntax reference
-ms.date: 10/18/2021
+ms.date: 11/11/2021
 ms.localizationpriority: high
 ---
 

--- a/docs/declarative-customization/formatting-syntax-reference.md
+++ b/docs/declarative-customization/formatting-syntax-reference.md
@@ -863,6 +863,35 @@ The following example shows how an image field can be used on a current field.
 }
 ```
 
+**Approval Status fields**
+
+The Approval Status field object has the following property (with example value):
+
+```JSON
+{
+   "displayValue": "Approved",
+}
+```
+`displayValue` is localized string of the approval status.
+
+`@currentField` or `[$__ModerationStatus]` will resolve to the internal code - 
+- 0 : Approved
+- 1 : Denied
+- 2 : Pending
+- 3 : Draft
+- 4 : Scheduled
+
+The following example shows how a approval status field might be used on a current field.
+
+```JSON
+{
+   "elmType": "div",
+   "txtContent": "@currentField.displayValue",
+   "style": {
+      "color": "=if(@currentField == 2, 'red', '')"
+   }
+}
+```
 
 ### "[$FieldName]"
 
@@ -1003,6 +1032,7 @@ The following column types can use displayValue property to get the default rend
 * Number
 * Yes/No
 * Currency
+* Approval Status
 
 ```JSON
  {


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues
- Documents #6731 

## What's in this Pull Request?
Support approval status column. 
The @currentField and [$_ModerationStatus] will resolve to internal code and @currentField.displayValue and [$_ModerationStatus.displayValue] will resolve to the localized string.
