### PR TITLE
Fixed issue with JSON sample

### DIFF
--- a/docs/declarative-customization/column-formatting.md
+++ b/docs/declarative-customization/column-formatting.md
@@ -1,7 +1,7 @@
 ---
 title: Use column formatting to customize SharePoint
 description: Customize how fields in SharePoint lists and libraries are displayed by constructing a JSON object that describes the elements that are displayed when a field is included in a list view, and the styles to be applied to those elements.
-ms.date: 11/11/2021
+ms.date: 02/10/2022
 ms.localizationpriority: high
 ---
 

--- a/docs/declarative-customization/column-formatting.md
+++ b/docs/declarative-customization/column-formatting.md
@@ -340,11 +340,11 @@ You can use column formatting to render quick action links next to fields. The f
         },
         {
             "elmType": "a",
+            "style": {
+                "text-decoration": "none"
+            },
             "attributes": {
                 "iconName": "Mail",
-                "style": {
-                    "text-decoration": "none"
-                },
                 "class": "sp-field-quickActions",
                 "href": {
                     "operator": "+",


### PR DESCRIPTION
## Category

- [x] Content fix

## What's in this Pull Request?

Fixed issue with JSON sample under "Add an action button to a field (advanced)" section. `style` property of the `a` element was misplaced in the JSON sample. Hence, styling was not getting applied as expected after using this JSON. 

So, corrected the JSON by removing `style` block under `attributes` and adding it at right place below `a` element.