### PR TITLE
Missing modern at the top of the text

### DIFF
--- a/docs/spfx/sharepoint-2019-support.md
+++ b/docs/spfx/sharepoint-2019-support.md
@@ -6,7 +6,7 @@ ms.localizationpriority: high
 ---
 # SharePoint Framework development with SharePoint Server 2019 & SharePoint Server SE
 
-SharePoint Server 2019 supports SharePoint Framework client-side web parts in classic and pages, and extensions in modern pages.
+SharePoint Server 2019 supports SharePoint Framework client-side web parts in classic and modern pages, and extensions in modern pages.
 
 > [!IMPORTANT]
 > SharePoint Server Subscription Edition (SE) has all the same dependencies and requirements for the SharePoint Framework as SharePoint Server 2019.


### PR DESCRIPTION
I think we are missing the "modern" description at the top of the text. Or maybe i did not get the whole context :)

## Category

- [x] Content fix

## Related issues

No related issues

## What's in this Pull Request?

Only a small change at the top of the content. i do really think we are missing the "modern" text at the very first line.
