### PR TITLE
Removing date and time functions

### DIFF
--- a/docs/business-apps/power-automate/guidance/working-with-get-items-and-get-files.md
+++ b/docs/business-apps/power-automate/guidance/working-with-get-items-and-get-files.md
@@ -1,6 +1,7 @@
 ---
 title: In-depth analysis into 'Get items' and 'Get files' SharePoint actions for flows in Power Automate
-ms.date: 03/11/2020
+description: In this article, learn more about the SharePoint actions get items & get files actions with Power Automate.
+ms.date: 03/24/2022
 search.app: 
   - Flow
 search.appverid: met150

--- a/docs/business-apps/power-automate/guidance/working-with-get-items-and-get-files.md
+++ b/docs/business-apps/power-automate/guidance/working-with-get-items-and-get-files.md
@@ -91,14 +91,6 @@ We support the following query methods and operators.
 * eq
 * ne
 
-### Date and time functions
-* day()
-* month()
-* year()
-* hour()
-* minute()
-* second()
-
 ## Order by query
 To order items based off of a column either in ascending or descending order, you can also specify an order by query. For example:
 


### PR DESCRIPTION
An investigation found that these functions aren't supported (by design)
-------
cc: @VesaJuvonen

## Category

- [x] Content fix
- [ ] New article

## What's in this Pull Request?

Removal of section regarding date and time functions as our API (and thus the connector) does not support filtering with these functions.
