### PR TITLE
Update Unable to Trust the self-signed development certificate

### DIFF
--- a/docs/spfx/set-up-your-development-environment.md
+++ b/docs/spfx/set-up-your-development-environment.md
@@ -172,7 +172,9 @@ npm list --global --depth=0️
 
 If you're having trouble trusting your self-signed certificate when you run **gulp trust-dev-cert** & you've verified that the correct versions of all dependencies are installed, one solution we usually see resolve the issue is to uninstall all globally installed packages, uninstall Node.js, reboot & start again.
 
-In some cases, executing the command **gulp trust-dev-cert**, doesn't have the wanted effect of trusting the self-signed development certificate on your machine. In rare cases such as these, you may need to delete a hidden folder that's generated in your profile folder. Locate & delete the folder **{{homedir}}/.gcb-serve-data** and then try to trust the self-signed development certificate again.
+In some cases, executing the command **gulp trust-dev-cert**, doesn't have the wanted effect of trusting the self-signed development certificate on your machine. In rare cases such as these, you may need to delete a hidden folder that's generated in your profile folder. 
+Locate & delete the folder **{{homedir}}/.gcb-serve-data** for SPFx version earlier than v1.12.1. For later versions delete folder **{{homedir}}/.rushstack** then try to trust the self-signed development certificate again. Otherwise running **gulp untrust-dev-cert** will have same effect to remove the certificate files from the profile folder. 
+In case the certificate is not added to the Trusted Root Certification Authority despite running **gulp trust-dev-cert** because of some policies blocking the action, the rushstack-serve.pem file from **{{homedir}}/.rushstack** folder can be imported manually into the Certificate Manager under Trusted Root Certification Authority with a local admin account.
 
 ### Unable to Install Packages with NPM - Corporate Proxies
 


### PR DESCRIPTION
Update Unable to Trust the self-signed development certificate for SPFx v1.12.1 and later in case the the certificate does not get added correctly into certificate manager.

## Category

- [ ] Content fix

## Related issues

## What's in this Pull Request?
Updated section Troubleshooting > **Unable to Trust the self-signed development certificate** for SPFx v.1.12.1 or later as the certificates are generated in profile folder .rushstack when gulp trust-dev-cert is run.


