### PR TITLE
[BrokenLinksH2] Fix path in link

### DIFF
--- a/docs/training/training.md
+++ b/docs/training/training.md
@@ -1,9 +1,8 @@
 ---
 title:  Tutorials and training for SharePoint Development
 description: Different tutorials and other resources around SharePoint development.
-ms.date: 02/27/2020
+ms.date: 04/06/2022
 ms.prod: sharepoint
-
 ms.localizationpriority: high
 ---
 

--- a/docs/training/training.md
+++ b/docs/training/training.md
@@ -23,7 +23,7 @@ Here are the different tutorials and training assets available for you to get st
 - [Building Microsoft Teams tab using SharePoint Framework](https://docs.microsoft.com/sharepoint/dev/spfx/web-parts/get-started/using-web-part-as-ms-teams-tab) | [video](https://www.youtube.com/watch?v=JoTAC2i-XeU&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq&index=8)
 - [Add jQueryUI Accordion to your SharePoint client-side web part](https://docs.microsoft.com/sharepoint/dev/spfx/web-parts/get-started/add-jqueryui-accordion-to-web-part) | [video](https://www.youtube.com/watch?v=N0C9azIyiTo&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq&index=10)
 - [Use Office UI Fabric React components in your SharePoint client-side web part](https://docs.microsoft.com/sharepoint/dev/spfx/web-parts/get-started/use-fabric-react-components) | [video](https://www.youtube.com/watch?v=kNrYd8nYaZY&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq&index=11)
-- [Tutorial for creating Outlook Web App extension using SharePoint Framework - Preview](https://docs.microsoft.com/sharepoint/dev/spfx/web-parts/get-started/office-addins-tutorial) | [video](https://www.youtube.com/watch?v=QtGjTAjbIKU&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq&index=9)
+
 
 ## Getting started tutorials for SharePoint Framework extensions
 

--- a/docs/training/training.md
+++ b/docs/training/training.md
@@ -13,37 +13,37 @@ Here are the different tutorials and training assets available for you to get st
 
 ## Setting up your development environment
 
-- [Set up your Office 365 tenant](https://docs.microsoft.com/sharepoint/dev/spfx/set-up-your-developer-tenant) | [video](https://www.youtube.com/watch?v=yc1IYgYp7qQ&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq) - Includes how to get a free tenant from Microsoft 365 developer program
-- [Set up development environment](https://docs.microsoft.com/sharepoint/dev/spfx/set-up-your-development-environment) | [video](https://www.youtube.com/watch?v=-2-jWsEa2Yw&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq&index=2) - Install needed tooling to get started
+- [Set up your Office 365 tenant](/sharepoint/dev/spfx/set-up-your-developer-tenant) | [video](https://www.youtube.com/watch?v=yc1IYgYp7qQ&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq) - Includes how to get a free tenant from Microsoft 365 developer program
+- [Set up development environment](/sharepoint/dev/spfx/set-up-your-development-environment) | [video](https://www.youtube.com/watch?v=-2-jWsEa2Yw&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq&index=2) - Install needed tooling to get started
 
 ## Getting started tutorials for SharePoint Framework
 
-- [Getting started with SharePoint Framework client-side web parts](https://docs.microsoft.com/sharepoint/dev/spfx/web-parts/get-started/build-a-hello-world-web-part) | [video](https://www.youtube.com/watch?v=_O2Re5uRLoo&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq&index=3) - Tutorial series with 4 parts
-- [Using Microsoft Graph APIs in your solution](https://docs.microsoft.com/sharepoint/dev/spfx/web-parts/get-started/using-microsoft-graph-apis) | [video](https://www.youtube.com/watch?v=tHzbh5JoC-A&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq&index=7)
-- [Building Microsoft Teams tab using SharePoint Framework](https://docs.microsoft.com/sharepoint/dev/spfx/web-parts/get-started/using-web-part-as-ms-teams-tab) | [video](https://www.youtube.com/watch?v=JoTAC2i-XeU&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq&index=8)
-- [Add jQueryUI Accordion to your SharePoint client-side web part](https://docs.microsoft.com/sharepoint/dev/spfx/web-parts/get-started/add-jqueryui-accordion-to-web-part) | [video](https://www.youtube.com/watch?v=N0C9azIyiTo&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq&index=10)
-- [Use Office UI Fabric React components in your SharePoint client-side web part](https://docs.microsoft.com/sharepoint/dev/spfx/web-parts/get-started/use-fabric-react-components) | [video](https://www.youtube.com/watch?v=kNrYd8nYaZY&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq&index=11)
+- [Getting started with SharePoint Framework client-side web parts](/sharepoint/dev/spfx/web-parts/get-started/build-a-hello-world-web-part) | [video](https://www.youtube.com/watch?v=_O2Re5uRLoo&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq&index=3) - Tutorial series with 4 parts
+- [Using Microsoft Graph APIs in your solution](/sharepoint/dev/spfx/web-parts/get-started/using-microsoft-graph-apis) | [video](https://www.youtube.com/watch?v=tHzbh5JoC-A&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq&index=7)
+- [Building Microsoft Teams tab using SharePoint Framework](/sharepoint/dev/spfx/web-parts/get-started/using-web-part-as-ms-teams-tab) | [video](https://www.youtube.com/watch?v=JoTAC2i-XeU&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq&index=8)
+- [Add jQueryUI Accordion to your SharePoint client-side web part](/sharepoint/dev/spfx/web-parts/get-started/add-jqueryui-accordion-to-web-part) | [video](https://www.youtube.com/watch?v=N0C9azIyiTo&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq&index=10)
+- [Use Office UI Fabric React components in your SharePoint client-side web part](/sharepoint/dev/spfx/web-parts/get-started/use-fabric-react-components) | [video](https://www.youtube.com/watch?v=kNrYd8nYaZY&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq&index=11)
 
 
 ## Getting started tutorials for SharePoint Framework extensions
 
-- [Getting started with SharePoint Framework Extensions](https://docs.microsoft.com/sharepoint/dev/spfx/extensions/get-started/build-a-hello-world-extension) | [video](https://www.youtube.com/watch?v=DnfRIl2YN8g&list=PLR9nK3mnD-OXtWO5AIIr7nCR3sWutACpV) - Tutorial series with 4 parts
-- [Build your first Field Customizer extension](https://docs.microsoft.com/sharepoint/dev/spfx/extensions/get-started/building-simple-field-customizer) | [video](https://www.youtube.com/watch?v=mBZ7Sq_KfDA&list=PLR9nK3mnD-OXtWO5AIIr7nCR3sWutACpV&index=5)
-- [Build your first ListView Command Set extension](https://docs.microsoft.com/sharepoint/dev/spfx/extensions/get-started/building-simple-cmdset-with-dialog-api) | [video](https://www.youtube.com/watch?v=uaUGtLrNbRA&list=PLR9nK3mnD-OXtWO5AIIr7nCR3sWutACpV&index=6)
+- [Getting started with SharePoint Framework Extensions](/sharepoint/dev/spfx/extensions/get-started/build-a-hello-world-extension) | [video](https://www.youtube.com/watch?v=DnfRIl2YN8g&list=PLR9nK3mnD-OXtWO5AIIr7nCR3sWutACpV) - Tutorial series with 4 parts
+- [Build your first Field Customizer extension](/sharepoint/dev/spfx/extensions/get-started/building-simple-field-customizer) | [video](https://www.youtube.com/watch?v=mBZ7Sq_KfDA&list=PLR9nK3mnD-OXtWO5AIIr7nCR3sWutACpV&index=5)
+- [Build your first ListView Command Set extension](/sharepoint/dev/spfx/extensions/get-started/building-simple-cmdset-with-dialog-api) | [video](https://www.youtube.com/watch?v=uaUGtLrNbRA&list=PLR9nK3mnD-OXtWO5AIIr7nCR3sWutACpV&index=6)
 
 ## Additional tutorials for SharePoint Framework
 
-- [Provision SharePoint assets from your SharePoint client-side web part](https://docs.microsoft.com/sharepoint/dev/spfx/web-parts/get-started/provision-sp-assets-from-package) | [video](https://www.youtube.com/watch?v=09uoG6Voeew&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq&index=12)
-- [Deploy your SharePoint client-side web part to Azure CDN](https://docs.microsoft.com/sharepoint/dev/spfx/web-parts/get-started/deploy-web-part-to-cdn)
-- [Consume the Microsoft Graph in the SharePoint Framework](https://docs.microsoft.com/sharepoint/dev/spfx/use-aad-tutorial)
-- [Consume enterprise APIs secured with Azure AD in SharePoint Framework](https://docs.microsoft.com/sharepoint/dev/spfx/use-aadhttpclient-enterpriseapi)
-- [Consume multi-tenant enterprise APIs secured with Azure AD in SharePoint Framework](https://docs.microsoft.com/sharepoint/dev/spfx/use-aadhttpclient-enterpriseapi-multitenant) |
+- [Provision SharePoint assets from your SharePoint client-side web part](/sharepoint/dev/spfx/web-parts/get-started/provision-sp-assets-from-package) | [video](https://www.youtube.com/watch?v=09uoG6Voeew&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq&index=12)
+- [Deploy your SharePoint client-side web part to Azure CDN](/sharepoint/dev/spfx/web-parts/get-started/deploy-web-part-to-cdn)
+- [Consume the Microsoft Graph in the SharePoint Framework](/sharepoint/dev/spfx/use-aad-tutorial)
+- [Consume enterprise APIs secured with Azure AD in SharePoint Framework](/sharepoint/dev/spfx/use-aadhttpclient-enterpriseapi)
+- [Consume multi-tenant enterprise APIs secured with Azure AD in SharePoint Framework](/sharepoint/dev/spfx/use-aadhttpclient-enterpriseapi-multitenant) |
 
 Migration tutorials from classic customizations to SharePoint Framework
 
-- [Migrating from Edit Control Block (ECB) menu item to SharePoint Framework Extensions](https://docs.microsoft.com/sharepoint/dev/spfx/extensions/guidance/migrate-from-ecb-to-spfx-extensions)
-- [Migrating from JSLink to SharePoint Framework Extensions](https://docs.microsoft.com/sharepoint/dev/spfx/extensions/guidance/migrate-from-jslink-to-spfx-extensions)
-- [Migrating from UserCustomAction to SharePoint Framework Extensions](https://docs.microsoft.com/sharepoint/dev/spfx/extensions/guidance/migrate-from-usercustomactions-to-spfx-extensions)
+- [Migrating from Edit Control Block (ECB) menu item to SharePoint Framework Extensions](/sharepoint/dev/spfx/extensions/guidance/migrate-from-ecb-to-spfx-extensions)
+- [Migrating from JSLink to SharePoint Framework Extensions](/sharepoint/dev/spfx/extensions/guidance/migrate-from-jslink-to-spfx-extensions)
+- [Migrating from UserCustomAction to SharePoint Framework Extensions](/sharepoint/dev/spfx/extensions/guidance/migrate-from-usercustomactions-to-spfx-extensions)
 
 ## Getting started training modules for SharePoint Framework
 


### PR DESCRIPTION
Removing line 26:

- [Tutorial for creating Outlook Web App extension using SharePoint Framework - Preview](https://docs.microsoft.com/sharepoint/dev/spfx/web-parts/get-started/office-addins-tutorial) | [video](https://www.youtube.com/watch?v=QtGjTAjbIKU&list=PLR9nK3mnD-OXvSWvS2zglCzz4iplhVrKq&index=9)

Note: The redirect isn't working, and the target content is hard to find. Asking the author for additional information.

