### PR TITLE
Updated export of ServicePrincipalCredentials

### DIFF
--- a/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
+++ b/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
@@ -48,13 +48,20 @@ Ensure the following before you begin:
 
     foreach ($appentry in $applist) {
         $principalId = $appentry.AppPrincipalId
-        $principalName = $appentry.DisplayName
 
-        Get-MsolServicePrincipalCredential -AppPrincipalId $principalId -ReturnKeyValues $false | ? { $_.Type -eq "Password" } | % { "$principalName;$principalId;" + $_.KeyId.ToString() +";" + $_.StartDate.ToString() + ";" + $_.EndDate.ToString() } | out-file -FilePath c:\temp\appsec.txt -append
+        Get-MsolServicePrincipalCredential -AppPrincipalId $principalId -ReturnKeyValues $false | Where-Object { $_.Type -eq "Password" } | ForEach-Object {
+            [PSCustomObject][Ordered]@{
+                PrincipalName = $appentry.DisplayName
+                PrincipalId = $principalId
+                KeyID = $_.KeyId
+                StartDate = $_.StartDate
+                EndDate = $_.EndDate
+            } | Export-Csv -Path C:\temp\appsec.csv -NoTypeInformation -Delimiter ';' -Append
+        }
     }
     ```
 
-1. Open the file C:\temp\appsec.txt to see the report. Leave the Windows PowerShell window open for the next procedure, if any of the secrets are near expiration.
+1. Open the file C:\temp\appsec.csv to see the report. Leave the Windows PowerShell window open for the next procedure, if any of the secrets are near expiration.
 
 ## Generate a new secret
 

--- a/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
+++ b/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
@@ -1,7 +1,7 @@
 ---
 title: Replace an expiring client secret in a SharePoint Add-in
 description: Add a new client secret for a SharePoint Add-in that is registered with AppRegNew.aspx.
-ms.date: 03/03/2022
+ms.date: 04/12/2022
 ms.prod: sharepoint
 ms.localizationpriority: high
 ---


### PR DESCRIPTION
Updated the PowerShell script for exporting ServicePrincipalCredentials more readable so it is clear to the reader what it is doing.
Also used an object and exported it to CSV instead of a text file

## Category

- [X] Content fix
- [ ] New article
- [x] Example checked item (*delete this line*)

