### PR TITLE
Update subscribe-to-list-notifications.md

### DIFF
--- a/docs/spfx/subscribe-to-list-notifications.md
+++ b/docs/spfx/subscribe-to-list-notifications.md
@@ -32,9 +32,9 @@ export default class LatestDocumentsWebPart extends BaseClientSideWebPart<ILates
   private _listSubscriptionFactory: ListSubscriptionFactory;
   private _listSubscription: IListSubscription;
 
-  private createListSubscription(): void {
+  private async createListSubscription(): Promise<void> {
     this._listSubscriptionFactory = new ListSubscriptionFactory(this);
-    this._listSubscription = this._listSubscriptionFactory.createSubscription({
+    this._listSubscription = await this._listSubscriptionFactory.createSubscription({
       listId: Guid.parse(this.properties.listId),
       callbacks: {
         notification: this._loadDocuments.bind(this)


### PR DESCRIPTION
Update `createListSubscription` to correctly initialize `this._listSubscription` from returned promise object.

## Category

- [x] Content fix
- [ ] New article

## Related issues

- fixes #issuenumber
- partially #issuenumber
- mentioned in #6477 

## What's in this Pull Request?

Updates `createListSubscription` code to correctly initialize `this._listSubscription` from the returned promise object.
