### PR TITLE
Update pnp-provisioning-tenant-templates.md

### DIFF
--- a/docs/solution-guidance/pnp-provisioning-tenant-templates.md
+++ b/docs/solution-guidance/pnp-provisioning-tenant-templates.md
@@ -1,7 +1,7 @@
 ---
 title: PnP Provisioning Tenant Templates
-description: 
-ms.date: 06/05/2020
+description: Think of Tenant Templates as an extension on top of PnP Provisioning or Site Templates. Instead of just provisioning artifacts to a site, you can now create sites, create teams, provision Azure AD entries, provision taxonomy etc.
+ms.date: 04/28/2022
 ms.localizationpriority: high
 ---
 

--- a/docs/solution-guidance/pnp-provisioning-tenant-templates.md
+++ b/docs/solution-guidance/pnp-provisioning-tenant-templates.md
@@ -99,6 +99,6 @@ If at a later state you want to remove this consent, login to your Azure Portal,
 
 ## See also
 
-- [SharePoint Patterns and Practices](https://github.com/SharePoint/PnP/)
+- [Microsoft 365 Patterns and Practices](https://pnp.github.io/)
 - [SharePoint Developer Group at Microsoft Tech Community](https://techcommunity.microsoft.com/t5/SharePoint-Developer/bd-p/SharePointDev) 
 - [PnP remote provisioning](pnp-remote-provisioning.md)


### PR DESCRIPTION
Changed the link for SharePoint PnP to M365 PnP page. The SharePoint PnP Github repo is archived.

## Category

- [X] Content fix
- [ ] New article


## Related issues

- fixes #7905



## What's in this Pull Request?

Changed the link at the bottom of the page. 
