### PR TITLE
SharePoint Framework development with SharePoint Server 2019 & SharePoint Server SE - Correct guidance on compatible Node.js versions

### DIFF
--- a/docs/spfx/sharepoint-2019-support.md
+++ b/docs/spfx/sharepoint-2019-support.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint Framework development with SharePoint Server 2019 & SharePoint Server SE
 description: SharePoint Server 2019 supports SharePoint Framework client-side web parts in classic and modern pages, and extensions in modern pages.
-ms.date: 06/07/2022
+ms.date: 06/10/2022
 ms.localizationpriority: high
 ---
 # SharePoint Framework development with SharePoint Server 2019 & SharePoint Server SE
@@ -27,11 +27,9 @@ If Internet access isn't available for the development machines, you can set up 
 
 The [Team-based development on the SharePoint Framework](team-based-development-on-sharepoint-framework.md) guidance document includes different options for development environment setup including when you might need to support multiple SharePoint Framework versions.
 
-### Node.js, Gulp, & Yeoman versions
+### Node.js, Gulp CLI, and Yeoman versions
 
-The dependencies for SPFx v1.4.1 frameworks, tools, and the associated versions don't match the same dependency matrix for the latest versions of SPFx. In these cases, you may need to install specific versions of the tools.
-
-For example, Gulp v3.* is only supported up to Node.js v10, while Gulp v4.* is supported from Node.js v12 and higher. Because SPFx v1.4.1 is only supported on Node.js v6 and Node.js v8, you need to ensure you have an older version of Node.js installed as well as an older version of Gulp & Yeoman.
+The dependencies for SPFx v1.4.1 frameworks, tools, and the associated versions don't match the same dependency matrix for the latest versions of SPFx. In these cases, you may need to install specific versions of the tools. Because SPFx v1.4.1 is only supported on Node.js v6 and Node.js v8, you need to ensure you have a supported version of Node.js installed as well as an older version of Gulp CLI and Yeoman.
 
 > [!NOTE]
 > The Gulp team introduced a separate package, [gulp-cli](https://www.npmjs.com/package/gulp-cli), that should be installed globally. It can be used by projects that use either Gulp v3 & Gulp v4.
@@ -41,9 +39,9 @@ For example, Gulp v3.* is only supported up to Node.js v10, while Gulp v4.* is s
 Microsoft recommends using the most recent version of the Yeoman generator for the SharePoint Framework ([@microsoft/generator-sharepoint](https://www.npmjs.com/package/@microsoft/generator-sharepoint)) that supports creating on-premises projects: SPFx v1.10.0.
 
 > [!IMPORTANT]
-> The Yeoman generator for the SharePoint Framework, starting with v1.13.0, only supports projects for SharePoint Online. Learn more about this change in the [SharePoint Framework v1.13 release notes](release-1.13.md). However, SPFx 1.4.1 only supports up to Node.js v10. Therefore, you need to get the latest version of the Yeoman generator for the SharePoint Framework (v1.10.0) that works on the same version of Node.js (v10) that SPFx v1.4.1 is supported on. Solution structure is created then with the v1.4.1 version packages as long as you select the environmen target properly in the Yeoman generator flow.
+> The Yeoman generator for the SharePoint Framework, starting with v1.13.0, only supports projects for SharePoint Online. Learn more about this change in the [SharePoint Framework v1.13 release notes](release-1.13.md). However, SPFx 1.4.1 is only supported on Node.js v6 and Node.js v8. Therefore, you need to get the latest version of the Yeoman generator for the SharePoint Framework (v1.10.0) that works on the same version of Node.js (v6 or v8) that SPFx v1.4.1 is supported on. Solution structure is created then with the v1.4.1 version packages as long as you select the environmen target properly in the Yeoman generator flow.
 
-1. Install [Node.js v10.24.1](https://nodejs.org/download/release/v10.24.1/)
+1. Install [Node.js v8.17.0](https://nodejs.org/download/release/v8.17.0/)
 1. Install global dependencies
 
     ```console


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## What's in this Pull Request?

SharePoint 2019 supports assets developed using SPFx v1.4.1. The existing document indicates that SPFx v1.4.1 is compatible with Node.js v1.10.x and instructs the reader to install this version on Node.js when setting up a SPFx development environment for SharePoint 2019. This is incorrect - SPFx v1.4.1 is not compatible with Node.js v1.10.x, it is only compatible with Node.js v6.x and v8.x. This updates made in this PR correct the information contained in the document in this regard.     