### PR TITLE
Update site-design-scoping.md to clarify admin rights

### DIFF
--- a/docs/declarative-customization/site-design-scoping.md
+++ b/docs/declarative-customization/site-design-scoping.md
@@ -1,7 +1,7 @@
 ---
 title: Select audiences for SharePoint site templates
 description: Determine which audiences can access certain site templates.
-ms.date: 08/23/2021
+ms.date: 06/13/2022
 ms.localizationpriority: high
 ---
 

--- a/docs/declarative-customization/site-design-scoping.md
+++ b/docs/declarative-customization/site-design-scoping.md
@@ -11,6 +11,9 @@ Site templates are available to everyone by default. You can also scope site tem
 
 This article explains how you can control which users and groups can see specific site templates.
 
+> [!NOTE]
+> Users with the SharePoint Admin role assigned will see all site templates, regardless of scoping.
+
 ## Grant rights to a site template
 
 When a site template is first created, it is available to everyone. You can grant **View** rights to the site template. After rights are granted, only the users or groups (principals) specified have access. You can continue granting rights to more principals with subsequent API calls.


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## What's in this Pull Request?

Note added about SharePoint Admin permissions. Testing indicates that SharePoint Admins will see all Site Templates defines, regardless of any scoping that is done.
