### PR TITLE
Update GeolocationTutorial.md

### DIFF
--- a/docs/spfx/viva/get-started/actions/geolocation/GeolocationTutorial.md
+++ b/docs/spfx/viva/get-started/actions/geolocation/GeolocationTutorial.md
@@ -251,16 +251,16 @@ longitude: "Longitude: " + this.state.longitude
 
 So far we have created defined our geolocation actions and wired in our states. Now we can finally implement the `onAction` function, which gives the ability to the Third Party Developer to decide what they wish to do with the location coordinates that the user has shared with them.
 
-For this, open the QuickView.ts file (**./src/adaptiveCardExtensions/geoLocation/quickView/QuickView.ts**) and import the `IActionArguments` interface, as follows:
+For this, open the QuickView.ts file (**./src/adaptiveCardExtensions/geoLocation/quickView/QuickView.ts**) and import the `IGetLocationActionArguments` interface, as follows:
 
 ```typescript
-import IActionArguments from @microsoft/sp-adaptive-card-extension-base
+import {IGetLocationActionArguments} from '@microsoft/sp-adaptive-card-extension-base';
 ```
 
 Finally, introduce the following `onAction` function in the QuickView class:
 
 ```typescript
-public onAction(action: IActionArguments): void {
+public onAction(action: IGetLocationActionArguments): void {
   if (action.type === 'VivaAction.GetLocation') {
     this.setState({
       latitude: action.location.latitude.toString(),


### PR DESCRIPTION
In @microsoft/generator-sharepoint@1.15.0-rc.0 - this interface has changed to IGetLocationActionArguments.

## Category

- [X] Content fix
- [ ] New article

In testing the new SPFx framework, I found this page needed updating when working with V1.15.0

