### PR TITLE
[BrokenLinksH2] Fix path in link

### DIFF
--- a/docs/solution-guidance/javascript-patterns-and-performance.md
+++ b/docs/solution-guidance/javascript-patterns-and-performance.md
@@ -437,7 +437,6 @@ For a more complex usage of asynchronous and Deferred, you can refer to the deve
 ## <a name="Resources"></a> Resources
 
 ### See Also
-- [JavaScript – Patterns and Usage](https://developer.microsoft.com/office/blogs//javascript-development-patterns-with-sharepoint)
 - [JavaScript – Performance Considerations](https://developer.microsoft.com/office/blogs//javascript-performance-considerations-with-sharepoint)
 - [Complete basic operations using JavaScript library code in SharePoint 2013](https://msdn.microsoft.com/library/office/jj163201.aspx)
 - [Client-side rendering (JS Link) code samples](https://code.msdn.microsoft.com/office/Client-side-rendering-JS-2ed3538a)

--- a/docs/solution-guidance/javascript-patterns-and-performance.md
+++ b/docs/solution-guidance/javascript-patterns-and-performance.md
@@ -1,7 +1,7 @@
 ---
 title: JavaScript Patterns and Performance
 description: Years ago, ASP.NET gave us server-side UI control rendering, and it was good. That server-side rendering, however, requires full trust code. Now that we have transitioned to SharePoint and Office 365, full trust code is no longer an option. That means server-side UI control rendering won't work for us any more.
-ms.date: 6/23/2022
+ms.date: 06/27/2022
 ms.localizationpriority: medium
 ---
 # JavaScript Patterns and Performance
@@ -437,7 +437,7 @@ For a more complex usage of asynchronous and Deferred, you can refer to the deve
 ## <a name="Resources"></a> Resources
 
 ### See Also
-- [JavaScript – Performance Considerations](https://developer.microsoft.com/office/blogs//javascript-performance-considerations-with-sharepoint)
+- [Performance considerations in the SharePoint Add-in model](https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/performance-considerations-sharepoint-add-in)
 - [Complete basic operations using JavaScript library code in SharePoint 2013](https://msdn.microsoft.com/library/office/jj163201.aspx)
 - [Client-side rendering (JS Link) code samples](https://code.msdn.microsoft.com/office/Client-side-rendering-JS-2ed3538a)
 - [JavaScript Embedding (Customize your SharePoint site UI by using JavaScript)](https://msdn.microsoft.com/library/dn913116.aspx)

--- a/docs/solution-guidance/javascript-patterns-and-performance.md
+++ b/docs/solution-guidance/javascript-patterns-and-performance.md
@@ -1,7 +1,7 @@
 ---
 title: JavaScript Patterns and Performance
 description: Years ago, ASP.NET gave us server-side UI control rendering, and it was good. That server-side rendering, however, requires full trust code. Now that we have transitioned to SharePoint and Office 365, full trust code is no longer an option. That means server-side UI control rendering won't work for us any more.
-ms.date: 11/03/2017
+ms.date: 6/23/2022
 ms.localizationpriority: medium
 ---
 # JavaScript Patterns and Performance


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## What's in this Pull Request?

The Content & Learning team is fixing broken links on docs.microsoft.com for the rest of H2. In this particular PR was applied removing broken link related to "JavaScript – Patterns and Usage", file not found.
