### PR TITLE
[BrokenLinksH2] Fix path in link

### DIFF
--- a/docs/general-development/excel-services-blogs-forums-and-resources.md
+++ b/docs/general-development/excel-services-blogs-forums-and-resources.md
@@ -1,7 +1,7 @@
 ---
 title: Excel Services Blogs, Forums, and Resources
 description: Provides links to Excel Services blogs, forums, and resources, as well as links to articles on Excel Services concepts.
-ms.date: 06/09/2022
+ms.date: 06/23/2022
 keywords: blogger
 f1_keywords:
 - blogger
@@ -36,7 +36,7 @@ The following are links to blogs, forums, and additional resources related to Ex
 
 |Additional Resources|Links|
 |:-----|:-----|
-|Excel Services Resource Center  <br/> | [Excel Services Resource Center on MSDN](https://msdn.microsoft.com/office/bb203828.aspx) <br/> |
+|Excel Services Resource Center  <br/> | Excel Services Resource Center on MSDN <br/> |
 |IT Pro \\ Administration Documentation  <br/> | [TechNet](https://technet.microsoft.com/library/ee424401%28office.14%29.aspx) <br/> |
 |Microsoft Excel Online, part of Office Online, also supports Excel workbooks in the browser.  <br/> |For more information about Excel Online, see the  [documentation](https://technet.microsoft.com/library/ee855124.aspx) on Technet. <br/> |
    

--- a/docs/general-development/excel-services-blogs-forums-and-resources.md
+++ b/docs/general-development/excel-services-blogs-forums-and-resources.md
@@ -1,7 +1,7 @@
 ---
 title: Excel Services Blogs, Forums, and Resources
 description: Provides links to Excel Services blogs, forums, and resources, as well as links to articles on Excel Services concepts.
-ms.date: 06/23/2022
+ms.date: 06/27/2022
 keywords: blogger
 f1_keywords:
 - blogger
@@ -9,76 +9,37 @@ ms.prod: sharepoint
 ms.assetid: c0b137cd-126d-4c74-a3f7-eb9debe3c35f
 ms.localizationpriority: medium
 ---
-
-
 # Excel Services Blogs, Forums, and Resources
 
 The following are links to blogs, forums, and additional resources related to Excel Services and SharePoint:
-  
-    
-    
 
+|                               Blog Name                                |                                                          Links                                                          |
+| :--------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------- |
+| Cum Grano Salis                                                        | [Home page](https://blogs.msdn.com/cumgranosalis/)  [Excel Services page](/archive/blogs/cumgranosalis/#excel-services) |
+| Microsoft Excel: The official blog of the Microsoft Excel product team | [Home page](https://www.microsoft.com/microsoft-365/blog/excel)                                                         |
 
+|              Forum Name              |                                                        Links                                                        |
+| :----------------------------------- | :------------------------------------------------------------------------------------------------------------------ |
+| SharePoint - Excel Services          | [Excel Services forum home page](/sharepoint/dev/general-development/excel-services-blogs-forums-and-resources)     |
+| SharePoint Products and Technologies | [List of SharePoint Products and Technologies forums](https://social.msdn.microsoft.com/forums/category/sharepoint) |
 
-|Blog Name|Links|
-|:-----|:-----|
-|Cum Grano Salis  <br/> | [Home page](https://blogs.msdn.com/cumgranosalis/) <br/>  [Excel Services page](/archive/blogs/cumgranosalis/#excel-services) <br/> |
-|Microsoft Excel: The official blog of the Microsoft Excel product team  <br/> | [Home page](https://www.microsoft.com/microsoft-365/blog/excel) <br/>  |
-   
-
-
-|Forum Name|Links|
-|:-----|:-----|
-|SharePoint - Excel Services  <br/> | [Excel Services forum home page](/sharepoint/dev/general-development/excel-services-blogs-forums-and-resources) <br/> |
-|SharePoint Products and Technologies  <br/> | [List of SharePoint Products and Technologies forums](https://social.msdn.microsoft.com/forums/category/sharepoint) <br/> |
-   
-
-
-|Additional Resources|Links|
-|:-----|:-----|
-|Excel Services Resource Center  <br/> | Excel Services Resource Center on MSDN <br/> |
-|IT Pro \\ Administration Documentation  <br/> | [TechNet](https://technet.microsoft.com/library/ee424401%28office.14%29.aspx) <br/> |
-|Microsoft Excel Online, part of Office Online, also supports Excel workbooks in the browser.  <br/> |For more information about Excel Online, see the  [documentation](https://technet.microsoft.com/library/ee855124.aspx) on Technet. <br/> |
-   
+|                                     Additional Resources                                     |                                                               Links                                                                |
+| :------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------- |
+| IT Pro \\ Administration Documentation                                                       | [TechNet](https://technet.microsoft.com/library/ee424401%28office.14%29.aspx)                                                      |
+| Microsoft Excel Online, part of Office Online, also supports Excel workbooks in the browser. | For more information about Excel Online, see the  [documentation](https://technet.microsoft.com/library/ee855124.aspx) on Technet. |
 
 ## See also
 
-
 #### Concepts
 
+- [Excel Services Overview](excel-services-overview.md)
+- [Excel Services Development Roadmap](excel-services-development-roadmap.md)
+- [Excel Services Architecture](excel-services-architecture.md)
+- [Excel Services Best Practices](excel-services-best-practices.md)
+- [Excel Services Alerts](excel-services-alerts.md)
+- [Excel Services Known Issues and Tips](excel-services-known-issues-and-tips.md)
 
-  
-    
-    
- [Excel Services Overview](excel-services-overview.md)
-  
-    
-    
- [Excel Services Development Roadmap](excel-services-development-roadmap.md)
-  
-    
-    
- [Excel Services Architecture](excel-services-architecture.md)
-  
-    
-    
- [Excel Services Best Practices](excel-services-best-practices.md)
-  
-    
-    
- [Excel Services Alerts](excel-services-alerts.md)
-  
-    
-    
- [Excel Services Known Issues and Tips](excel-services-known-issues-and-tips.md)
 #### Other resources
 
-
-  
-    
-    
- [Walkthrough: Developing a Custom Application Using Excel Web Services](walkthrough-developing-a-custom-application-using-excel-web-services.md)
-  
-    
-    
- [Unsupported Features in Excel Services](https://msdn.microsoft.com/library/5868e672-4786-4fed-9168-07ff538f6f5c%28Office.15%29.aspx)
+- [Walkthrough: Developing a Custom Application Using Excel Web Services](walkthrough-developing-a-custom-application-using-excel-web-services.md)
+- [Unsupported Features in Excel Services](https://msdn.microsoft.com/library/5868e672-4786-4fed-9168-07ff538f6f5c%28Office.15%29.aspx)


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

## What's in this Pull Request?

The Content & Learning team is fixing broken links on docs.microsoft.com for the rest of H2. In this particular PR was applied removing broken link related to [Excel Services Resource Center on MSDN](https://msdn.microsoft.com/office/bb203828.aspx),  file not found.


