### PR TITLE
Update security docs to use PnP Framework

### DIFF
--- a/docs/solution-guidance/security-apponly-azureacs.md
+++ b/docs/solution-guidance/security-apponly-azureacs.md
@@ -58,11 +58,11 @@ Connect-PnPOnline -Url https://contoso.sharepoint.com/sites/demo -ClientId [Your
 
 ## Using this principal in your application using the SharePoint PnP Sites Core library
 
-In a first step, you add the SharePoint PnP Sites Core library nuget package: https://www.nuget.org/packages/SharePointPnPCoreOnline. Once that’s done you can use below code construct:
+In a first step, you add the PnP Framework library nuget package: https://www.nuget.org/packages/PnP.Framework. Once that’s done you can use below code construct:
 
 ```csharp
 string siteUrl = "https://contoso.sharepoint.com/sites/demo";
-using (var cc = new AuthenticationManager().GetAppOnlyAuthenticatedContext(siteUrl, "[Your Client ID]", "[Your Client Secret]"))
+using (var cc = new AuthenticationManager().GetACSAppOnlyContext(siteUrl, "[Your Client ID]", "[Your Client Secret]"))
 {
     cc.Load(cc.Web, p => p.Title);
     cc.ExecuteQuery();

--- a/docs/solution-guidance/security-apponly-azureacs.md
+++ b/docs/solution-guidance/security-apponly-azureacs.md
@@ -1,7 +1,7 @@
 ---
 title: Granting access using SharePoint App-Only
 description: Granting access using SharePoint App-Only
-ms.date: 06/13/2022
+ms.date: 06/28/2022
 ms.prod: sharepoint
 author: vesajuvonen
 ms.author: vesaj

--- a/docs/solution-guidance/security-apponly-azuread.md
+++ b/docs/solution-guidance/security-apponly-azuread.md
@@ -1,7 +1,7 @@
 ---
 title: Granting access via Azure AD App-Only
 description: Granting access via Azure AD App-Only
-ms.date: 06/05/2020
+ms.date: 06/28/2022
 ms.prod: sharepoint
 author: vesajuvonen
 ms.author: vesaj

--- a/docs/solution-guidance/security-apponly-azuread.md
+++ b/docs/solution-guidance/security-apponly-azuread.md
@@ -233,12 +233,12 @@ You can now perform operations through PnP PowerShell against your SharePoint On
 
 ## Using this principal in your application using the SharePoint PnP Sites Core library
 
-In a first step, you add the SharePointPnPCoreOnline library NuGet package: https://www.nuget.org/packages/SharePointPnPCoreOnline.
+In a first step, you add the PnP Framework library NuGet package: https://www.nuget.org/packages/PnP.Framework.
 
 Once that’s done you can use below code construct:
 
 ```csharp
-using OfficeDevPnP.Core;
+using PnP.Framework;
 using System;
 
 namespace AzureADCertAuth
@@ -247,8 +247,8 @@ namespace AzureADCertAuth
     {
         static void Main(string[] args)
         {
-            string siteUrl = "https://contoso.sharepoint.com/sites/demo";
-            using (var cc = new AuthenticationManager().GetAzureADAppOnlyAuthenticatedContext(siteUrl, "<application id>", "contoso.onmicrosoft.com", @"C:\BertOnlineAzureADAppOnly.pfx", "<password>"))
+            var authManager = new AuthenticationManager("<application id>", "c:\\temp\\mycert.pfx", "<password>", "contoso.onmicrosoft.com");
+            using (var cc = authManager.GetAzureADAppOnlyAuthenticatedContext("https://contoso.sharepoint.com/sites/demo"))
             {
                 cc.Load(cc.Web, p => p.Title);
                 cc.ExecuteQuery();


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## What's in this Pull Request?

The security docs for App-Only connections refers to the `SharePointPnPCoreOnline` NuGet package which has been considered legacy for a while now.

The docs and code samples have been updated to use the new `PnP.Framework` library.

A migration guide from PnP Sites Core to PnP Framework can be found [here](https://github.com/pnp/pnpframework/blob/dev/docs/MigratingFromPnPSitesCore.md).