### PR TITLE
Update compatibility.md

### DIFF
--- a/docs/spfx/compatibility.md
+++ b/docs/spfx/compatibility.md
@@ -33,8 +33,8 @@ The following table lists SharePoint Framework and compatible versions of common
 
 |              SPFx               |   Node.js (LTS) |                    NPM                    |   TypeScript   |    React    |
 | ------------------------------- | --------------- | ----------------------------------------- | -------------- | ----------- |
-| [1.15.2](release-1.15.2.md)     | v12,  v14,  v16 | v5, v6, v7, v8                            | v4.5           | v16.13.1    |
-| [1.15.0](release-1.15.md)       | v12,  v14,  v16 | v5, v6, v7, v8                            | v4.5           | v16.13.1    |
+| [1.15.2](release-1.15.2.md)     | v14,  v16       | v5, v6, v7, v8                            | v4.5           | v16.13.1    |
+| [1.15.0](release-1.15.md)       | v14,  v16       | v5, v6, v7, v8                            | v4.5           | v16.13.1    |
 | [1.14.0](release-1.14.md)       | v12,  v14       | v5, v6                                    | v3.9           | v16.13.1    |
 | [1.13.1](release-1.13.1.md)     | v12,  v14       | v5, v6                                    | v3.9           | v16.13.1    |
 | [1.13.0](release-1.13.md)       | v12,  v14       | v5, v6                                    | v3.9           | v16.13.1    |

--- a/docs/spfx/compatibility.md
+++ b/docs/spfx/compatibility.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint Framework development tools and libraries compatibility
 description: Find which versions of the SharePoint Framework are compatible with each version of SharePoint, development tools and libraries.
-ms.date: 08/05/2022
+ms.date: 08/17/2022
 ms.localizationpriority: high
 ---
 # SharePoint Framework development tools and libraries compatibility


### PR DESCRIPTION
removed support for Node V12 for SPFx 1.15.0 releases and above

## Category

- [x] Content fix
- [ ] New article
- [ ] Example checked item (*delete this line*)

## What's in this Pull Request?

removed Node V12 support for SPFx versions 1.15.0 and above.