### PR TITLE
Fixes wrong parameter name in update webhook docs

### DIFF
--- a/docs/apis/webhooks/lists/update-subscription.md
+++ b/docs/apis/webhooks/lists/update-subscription.md
@@ -2,7 +2,6 @@
 title: Update a subscription
 description: Updates a webhook subscription on a SharePoint list.
 ms.date: 09/06/2022
-ms.prod: sharepoint
 ms.localizationpriority: medium
 ---
 

--- a/docs/apis/webhooks/lists/update-subscription.md
+++ b/docs/apis/webhooks/lists/update-subscription.md
@@ -57,7 +57,7 @@ Name | Type | Description
 -----|------|------------
 notificationUrl|string|The service URL to send notifications to.
 expirationDateTime|date|The date the notification will expire and be deleted.
-client-clientState|string|Optional. Opaque string passed back to the client on all notifications.<br/>You can use this for validating notifications or tagging different subscriptions.
+clientState|string|Optional. Opaque string passed back to the client on all notifications.<br/>You can use this for validating notifications or tagging different subscriptions.
 
 
 ## Response

--- a/docs/apis/webhooks/lists/update-subscription.md
+++ b/docs/apis/webhooks/lists/update-subscription.md
@@ -1,7 +1,7 @@
 ---
 title: Update a subscription
 description: Updates a webhook subscription on a SharePoint list.
-ms.date: 02/08/2018
+ms.date: 09/06/2022
 ms.prod: sharepoint
 ms.localizationpriority: medium
 ---


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- fixes #7670

## What's in this Pull Request?

Property is displayed as `client-clientState`, this should be `clientState` (validated it with API call).

