### PR TITLE
Update how-to-avoid-getting-throttled-or-blocked-in-sharepoint-online.md

### DIFF
--- a/docs/general-development/how-to-avoid-getting-throttled-or-blocked-in-sharepoint-online.md
+++ b/docs/general-development/how-to-avoid-getting-throttled-or-blocked-in-sharepoint-online.md
@@ -197,8 +197,7 @@ The most common causes of per-user throttling in SharePoint Online are client-si
 
 - **Creating multiple AppIDs for the same application**
 
-    Don't create separate AppIDs where the applications essentially perform the same operations, such as backup or data loss prevention. Applications running against the same tenant ultimately share the same resource of the tenant. Historically some applications have tried this approach to get around the application throttling but ended up exhausting the tenant’s resource and causing multiple applications to be throttled in the tenant.
-
+    Don't create separate AppIDs where the applications essentially perform the same operations, such as backup or data loss prevention. Applications running against the same tenant ultimately share the same resource of the tenant. Historically some applications have tried this approach to get around the application throttling but ended up exhausting the tenant’s resource and causing multiple applications to be throttled in the tenant. When this can not be avoided, each instance of custom code that interacts with SharePoint Online should be architected to account for throttling being present. 
 ## Scenario specific limits
 
 ### When using app-only authentication with Sites.Read.All permission


### PR DESCRIPTION
Add additional detail to better handle situations in which throttling is present in the SPO APIs.

## Category

- [x] Content fix
- [] New article

# Related issues

n/a

## What's in this Pull Request?

Add the follow sentence to the documentation to better handle situations where throttling can not be removed from an environment

```
When this can not be avoided, each instance of custom code that interacts with SharePoint Online should be architected to account for throttling being present. 
```
