### PR TITLE
🐞📚 fix errors with frontmatter for syntex docs

### DIFF
--- a/docs/apis/syntex/rest-applymodel-method.md
+++ b/docs/apis/syntex/rest-applymodel-method.md
@@ -1,18 +1,16 @@
 ---
 title: Batch apply model
+description: Use REST API to apply a document understanding model to one or more libraries.
+ms.date: 09/23/2022
 ms.author: chucked
 author: chuckedmonson
 manager: pamgreen
 ms.reviewer: ssquires
 audience: admin
 ms.topic: reference
-ms.prod: microsoft-365-enterprise
-search.appverid: 
 ms.collection: m365initiative-syntex
 ms.localizationpriority: high
-description: Use REST API to apply a document understanding model to one or more libraries.
 ---
-
 # Batch Apply model
 
 Applies (or syncs) a trained document understanding model to one or more libraries (see [example](rest-applymodel-method.md#examples)).
@@ -72,7 +70,7 @@ None
 |--------|-------|------------|
 |StatusCode|int|The HTTP status code.|
 |ErrorMessage|string|The error message which tells what's wrong when apply the model to the document library.|
-|Publication|MachineLearningPublicationEntityData|It specifies the model info and the target document library.| 
+|Publication|MachineLearningPublicationEntityData|It specifies the model info and the target document library.|
 
 ### MachineLearningPublicationEntityData
 

--- a/docs/apis/syntex/rest-batchdelete-method.md
+++ b/docs/apis/syntex/rest-batchdelete-method.md
@@ -1,16 +1,15 @@
 ---
 title: BatchDelete
+description: Use REST API to remove an applied document understanding model from one or more libraries.
+ms.date: 09/23/2022
 ms.author: chucked
 author: chuckedmonson
 manager: pamgreen
 ms.reviewer: ssquires
 audience: admin
 ms.topic: reference
-ms.prod: microsoft-365-enterprise
-search.appverid: 
 ms.collection: m365initiative-syntex
 ms.localizationpriority: high
-description: Use REST API to remove an applied document understanding model from one or more libraries.
 ---
 
 # BatchDelete
@@ -70,7 +69,7 @@ None
 |--------|-------|------------|
 |StatusCode|int|The HTTP status code.|
 |ErrorMessage|string|The error message which tells what's wrong when apply the model to the document library.|
-|Publication|MachineLearningPublicationEntityData|It specifies the model info and the target document library.| 
+|Publication|MachineLearningPublicationEntityData|It specifies the model info and the target document library.|
 
 ### MachineLearningPublicationEntityData
 
@@ -90,16 +89,16 @@ In this sample, the ID of the Contoso Contract document understanding model is `
 #### Sample request
 
 ```HTTP
-{ 
-    "publications": [ 
-        { 
-            "ModelUniqueId": "7645e69d-21fb-4a24-a17a-9bdfa7cb63dc", 
-            "TargetSiteUrl": "https://constco.sharepoint-df.com/sites/docsite", 
-            "TargetWebServerRelativeUrl": "/sites/docsite ", 
-            "TargetLibraryServerRelativeUrl": "/sites/dcocsite/joedcos" 
-        } 
-    ] 
-} 
+{
+    "publications": [
+        {
+            "ModelUniqueId": "7645e69d-21fb-4a24-a17a-9bdfa7cb63dc",
+            "TargetSiteUrl": "https://constco.sharepoint-df.com/sites/docsite",
+            "TargetWebServerRelativeUrl": "/sites/docsite ",
+            "TargetLibraryServerRelativeUrl": "/sites/dcocsite/joedcos"
+        }
+    ]
+}
 ```
 
 #### Sample response

--- a/docs/apis/syntex/rest-createclassificationrequest.md
+++ b/docs/apis/syntex/rest-createclassificationrequest.md
@@ -1,16 +1,15 @@
 ---
 title: Create file classification request
+description: Use REST API to create a request to classify one or more files using a trained document understanding model.
+ms.date: 09/23/2022
 ms.author: chucked
 author: chuckedmonson
 manager: pamgreen
 ms.reviewer: ssquires
 audience: admin
 ms.topic: reference
-ms.prod: microsoft-365-enterprise
-search.appverid: 
 ms.collection: m365initiative-syntex
 ms.localizationpriority: high
-description: Use REST API to create a request to classify one or more files using a trained document understanding model.
 ---
 
 # Create file classification request

--- a/docs/apis/syntex/rest-createfolderclassificationrequest.md
+++ b/docs/apis/syntex/rest-createfolderclassificationrequest.md
@@ -1,16 +1,15 @@
 ---
 title: Create folder classification request
+description: Use REST API to create a request to classify an entire folder using a trained document understanding model.
+ms.date: 09/23/2022
 ms.author: chucked
 author: chuckedmonson
 manager: pamgreen
 ms.reviewer: ssquires
 audience: admin
 ms.topic: reference
-ms.prod: microsoft-365-enterprise
-search.appverid: 
 ms.collection: m365initiative-syntex
 ms.localizationpriority: high
-description: Use REST API to create a request to classify an entire folder using a trained document understanding model.
 ---
 
 # Create folder classification request
@@ -78,7 +77,7 @@ None
     "TargetSiteId": "f686e63b-aba7-48e5-97c7-68c4c1df292f",
     "TargetWebId": "66d6b64d-6f88-4dd9-b3db-47e6f00c53e8",
     "TargetUniqueId": "e6cff8b7-c90c-4564-b5b8-033449090932",
-    "IsFolder": true 
+    "IsFolder": true
 }
 ```
 

--- a/docs/apis/syntex/rest-createmodel-method.md
+++ b/docs/apis/syntex/rest-createmodel-method.md
@@ -1,16 +1,15 @@
 ---
 title: Create model
+description: Use REST API to create a model and its associated content type.
+ms.date: 09/23/2022
 ms.author: chucked
 author: chuckedmonson
 manager: pamgreen
 ms.reviewer: ssquires
 audience: admin
 ms.topic: reference
-ms.prod: microsoft-365-enterprise
-search.appverid: 
 ms.collection: m365initiative-syntex
 ms.localizationpriority: high
-description: Use REST API to create a model and its associated content type.
 ---
 
 # Create model

--- a/docs/apis/syntex/rest-getbytitle-method.md
+++ b/docs/apis/syntex/rest-getbytitle-method.md
@@ -1,16 +1,15 @@
 ---
 title: GetByTitle
+description: Use REST API to get or update information about a SharePoint Syntex document understanding model using the model title.
+ms.date: 09/23/2022
 ms.author: chucked
 author: chuckedmonson
 manager: pamgreen
 ms.reviewer: ssquires
 audience: admin
 ms.topic: article
-ms.prod: microsoft-365-enterprise
-search.appverid: 
 ms.collection: m365initiative-syntex
 ms.localizationpriority: high
-description: Use REST API to get or update information about a SharePoint Syntex document understanding model using the model title.
 ---
 
 # GetByTitle

--- a/docs/apis/syntex/rest-getbyuniqueid-method.md
+++ b/docs/apis/syntex/rest-getbyuniqueid-method.md
@@ -1,16 +1,15 @@
 ---
 title: GetByUniqueId
+description: Use REST API to get or update information about a SharePoint Syntex document understanding model.
+ms.date: 09/23/2022
 ms.author: chucked
 author: chuckedmonson
 manager: pamgreen
 ms.reviewer: ssquires
 audience: admin
 ms.topic: reference
-ms.prod: microsoft-365-enterprise
-search.appverid: 
 ms.collection: m365initiative-syntex
 ms.localizationpriority: high
-description: Use REST API to get or update information about a SharePoint Syntex document understanding model.
 ---
 
 # GetByUniqueId
@@ -23,7 +22,7 @@ Gets or updates information about a SharePoint Syntex document understanding mod
 GET /_api/machinelearning/models/getbyuniqueid('{modelUniqueId}') HTTP/1.1
 ```
 
-This same method can be used for deleting a model, too. 
+This same method can be used for deleting a model, too.
 
 ```HTTP
 DELETE /_api/machinelearning/models/getbyuniqueid('{modelUniqueId}') HTTP/1.1

--- a/docs/apis/syntex/rest-getmodelandlibraryinfo.md
+++ b/docs/apis/syntex/rest-getmodelandlibraryinfo.md
@@ -1,16 +1,15 @@
 ---
 title: Get model and library info
+description: Use REST API to get information about a model and the library where it has been applied.
+ms.date: 09/23/2022
 ms.author: chucked
 author: chuckedmonson
 manager: pamgreen
 ms.reviewer: ssquires
 audience: admin
 ms.topic: reference
-ms.prod: microsoft-365-enterprise
-search.appverid: 
 ms.collection: m365initiative-syntex
 ms.localizationpriority: high
-description: Use REST API to get information about a model and the library where it has been applied.
 ---
 
 # Get model and library information

--- a/docs/apis/syntex/rest-updatemodelsettings-method.md
+++ b/docs/apis/syntex/rest-updatemodelsettings-method.md
@@ -1,16 +1,15 @@
 ---
 title: UpdateModelSettings
+description: Use REST API to update available models settings for a SharePoint Syntex document understanding model.
+ms.date: 09/23/2022
 ms.author: chucked
 author: chuckedmonson
 manager: pamgreen
 ms.reviewer: ssquires
 audience: admin
 ms.topic: reference
-ms.prod: microsoft-365-enterprise
-search.appverid: 
 ms.collection: m365initiative-syntex
 ms.localizationpriority: high
-description: Use REST API to update available models settings for a SharePoint Syntex document understanding model.
 ---
 
 # UpdateModelSettings

--- a/docs/apis/syntex/syntex-model-rest-api.md
+++ b/docs/apis/syntex/syntex-model-rest-api.md
@@ -1,24 +1,22 @@
 ---
 title: SharePoint Syntex document understanding model REST API
+description: Overview of the SharePoint Syntex document understanding model REST API.
+ms.date: 09/23/2022
 ms.author: chucked
 author: chuckedmonson
 manager: pamgreen
 ms.reviewer: ssquires
 audience: admin
 ms.topic: reference
-ms.prod: microsoft-365-enterprise
-ms.date: 04/06/2022
-search.appverid: 
 ms.collection: m365initiative-syntex
 ms.localizationpriority: high
-description: Overview of the SharePoint Syntex document understanding model REST API.
 ---
 
 # SharePoint Syntex document understanding model REST API
 
-You can use the SharePoint REST interface to create a document understanding model, apply or remove the model to one or more libraries, and obtain or update information about the model. 
+You can use the SharePoint REST interface to create a document understanding model, apply or remove the model to one or more libraries, and obtain or update information about the model.
 
-The SharePoint Online (and SharePoint 2016 and later on-premises) REST service supports combining multiple requests into a single call to the service by using the OData $batch query option. 
+The SharePoint Online (and SharePoint 2016 and later on-premises) REST service supports combining multiple requests into a single call to the service by using the OData $batch query option.
 
 For details and links to code samples, see [Make batch requests with the REST APIs](/sharepoint/dev/sp-add-ins/make-batch-requests-with-the-rest-apis).
 
@@ -26,7 +24,7 @@ For details and links to code samples, see [Make batch requests with the REST AP
 
 Before you get started, make sure that you're familiar with the following:
 
-- [Get to know the SharePoint REST service](/sharepoint/dev/sp-add-ins/get-to-know-the-sharepoint-rest-service) 
+- [Get to know the SharePoint REST service](/sharepoint/dev/sp-add-ins/get-to-know-the-sharepoint-rest-service)
 - [Complete basic operations using SharePoint REST endpoints](/sharepoint/dev/sp-add-ins/complete-basic-operations-using-sharepoint-rest-endpoints)
 
 ## REST commands
@@ -57,4 +55,3 @@ The remove model method just removes the model from one or more libraries where 
 ## See also
 
 [Document understanding overview](/microsoft-365/contentunderstanding/document-understanding-overview)
-

--- a/docs/apis/webhooks/get-started-webhooks.md
+++ b/docs/apis/webhooks/get-started-webhooks.md
@@ -1,17 +1,14 @@
 ---
 title: Get started with SharePoint webhooks
 description: Build an application that adds and handles SharePoint webhook requests.
-ms.date: 03/14/2018
-ms.prod: sharepoint
+ms.date: 09/23/2022
 ms.localizationpriority: high
 ---
-
-
 # Get started with SharePoint webhooks
 
 This article describes how to build an application that adds and handles SharePoint webhook requests. You will learn how to use [Postman client](https://www.getpostman.com/) to construct and execute SharePoint webhook requests quickly while interacting with a simple ASP.NET Web API as the webhook receiver.
 
-You will use plain HTTP requests, which is useful for helping you understand how webhooks work.  
+You will use plain HTTP requests, which is useful for helping you understand how webhooks work.
 
 To complete the step-by-step instructions in this article, download and install the following tools:
 
@@ -23,14 +20,14 @@ To complete the step-by-step instructions in this article, download and install 
 
 ## Step 1: Register an Azure AD application for Postman client
 
-In order for the Postman client to communicate with SharePoint, you need to register a Microsoft Azure Active Directory (Azure AD) app in your Azure AD tenant associated with your Office 365 tenant. 
+In order for the Postman client to communicate with SharePoint, you need to register a Microsoft Azure Active Directory (Azure AD) app in your Azure AD tenant associated with your Office 365 tenant.
 
 1. Ensure that you register the application as a **Web Application**.
 
 2. To access SharePoint Online, it's important to grant the Azure AD app permissions to the **Office 365 SharePoint Online** application and select the **read and write items and lists in all site collections** permission.
 
-	> [!NOTE] 
-	> For more information about adding an Azure AD application and granting permissions to applications, see [Adding an application](/azure/active-directory/develop/active-directory-integrating-applications#adding-an-application). 
+	> [!NOTE]
+	> For more information about adding an Azure AD application and granting permissions to applications, see [Adding an application](/azure/active-directory/develop/active-directory-integrating-applications#adding-an-application).
 
 3. Enter the following endpoint as the Reply (Redirect) URL for the app. This is the endpoint to which Azure AD will send the authentication response, including the access token, if authentication was successful.
 
@@ -43,7 +40,7 @@ In order for the Postman client to communicate with SharePoint, you need to regi
 5. The following properties are required in later steps, so copy them to a safe place:
 
 	* Client Id
-	* Client Secret 
+	* Client Secret
 
 ## Step 2: Build a webhook receiver
 
@@ -55,15 +52,15 @@ For this project, use the Visual Studio Web API project to build the webhook rec
 
 2. Select **File** > **New** > **Project**.
 
-3. In the **Templates** pane, select **Installed Templates**, and expand the **Visual C#** node. 
+3. In the **Templates** pane, select **Installed Templates**, and expand the **Visual C#** node.
 
-4. Under **Visual C#**, select **Web**. 
+4. Under **Visual C#**, select **Web**.
 
-5. In the list of project templates, select **ASP.NET Web Application**. 
+5. In the list of project templates, select **ASP.NET Web Application**.
 
 6. Name the project **SPWebhooksReceiver**, and select **OK**.
 
-7. In the **New ASP.NET Project** dialog, select the **Web API** template from the **ASP.NET 4.5.** group. 
+7. In the **New ASP.NET Project** dialog, select the **Web API** template from the **ASP.NET 4.5.** group.
 
 8. Change the authentication to **No Authentication** by selecting the **Change Authentication** button.
 
@@ -134,7 +131,7 @@ Because multiple notifications can be submitted to your webhook receiver in a si
 
 #### Add SharePoint webhook client state
 
-Webhooks provide the ability to use an optional string value that is passed back in the notification message for your subscription. This can be used to verify that the request is indeed coming from the source you trust, which in this case is SharePoint. 
+Webhooks provide the ability to use an optional string value that is passed back in the notification message for your subscription. This can be used to verify that the request is indeed coming from the source you trust, which in this case is SharePoint.
 
 Add a client state value with which the application can verify the incoming requests.
 
@@ -214,8 +211,8 @@ Now build the webhook receiver controller that handles the incoming requests fro
 
 	        if (!string.IsNullOrEmpty(clientStateHeaderValue) && clientStateHeaderValue.Equals(webhookClientState))
 	        {
-	            traceWriter.Trace(Request, "SPWebhooks", 
-	                TraceLevel.Info, 
+	            traceWriter.Trace(Request, "SPWebhooks",
+	                TraceLevel.Info,
 	                string.Format("Received client state: {0}", clientStateHeaderValue));
 
 	            var queryStringParams = HttpUtility.ParseQueryString(Request.RequestUri.Query);
@@ -226,9 +223,9 @@ Now build the webhook receiver controller that handles the incoming requests fro
 	                validationToken = queryStringParams.GetValues("validationtoken")[0].ToString();
 	                httpResponse.Content = new StringContent(validationToken);
 
-	                traceWriter.Trace(Request, "SPWebhooks", 
-	                    TraceLevel.Info, 
-	                    string.Format("Received validation token: {0}", validationToken));                        
+	                traceWriter.Trace(Request, "SPWebhooks",
+	                    TraceLevel.Info,
+	                    string.Format("Received validation token: {0}", validationToken));
 	                return httpResponse;
 	            }
 	            else
@@ -246,8 +243,8 @@ Now build the webhook receiver controller that handles the incoming requests fro
 	                    }
 	                    catch (JsonException ex)
 	                    {
-	                        traceWriter.Trace(Request, "SPWebhooks", 
-	                            TraceLevel.Error, 
+	                        traceWriter.Trace(Request, "SPWebhooks",
+	                            TraceLevel.Error,
 	                            string.Format("JSON deserialization error: {0}", ex.InnerException));
 	                        return httpResponse;
 	                    }
@@ -260,17 +257,17 @@ Now build the webhook receiver controller that handles the incoming requests fro
 	                             //you can send this to an Azure queue to be processed later
 	                            //for this sample, we just log to the trace
 
-	                            traceWriter.Trace(Request, "SPWebhook Notification", 
+	                            traceWriter.Trace(Request, "SPWebhook Notification",
 	                                TraceLevel.Info, string.Format("Resource: {0}", notification.Resource));
-	                            traceWriter.Trace(Request, "SPWebhook Notification", 
+	                            traceWriter.Trace(Request, "SPWebhook Notification",
 	                                TraceLevel.Info, string.Format("SubscriptionId: {0}", notification.SubscriptionId));
-	                            traceWriter.Trace(Request, "SPWebhook Notification", 
+	                            traceWriter.Trace(Request, "SPWebhook Notification",
 	                                TraceLevel.Info, string.Format("TenantId: {0}", notification.TenantId));
-	                            traceWriter.Trace(Request, "SPWebhook Notification", 
+	                            traceWriter.Trace(Request, "SPWebhook Notification",
 	                                TraceLevel.Info, string.Format("SiteUrl: {0}", notification.SiteUrl));
-	                            traceWriter.Trace(Request, "SPWebhook Notification", 
+	                            traceWriter.Trace(Request, "SPWebhook Notification",
 	                                TraceLevel.Info, string.Format("WebId: {0}", notification.WebId));
-	                            traceWriter.Trace(Request, "SPWebhook Notification", 
+	                            traceWriter.Trace(Request, "SPWebhook Notification",
 	                                TraceLevel.Info, string.Format("ExpirationDateTime: {0}", notification.ExpirationDateTime));
 
 	                        });
@@ -312,7 +309,7 @@ Now build the webhook receiver controller that handles the incoming requests fro
 
 	You should see ngrok running.
 
-4. Copy the **Forwarding** HTTPS address. You will use this address as the service proxy for SharePoint to send requests. 
+4. Copy the **Forwarding** HTTPS address. You will use this address as the service proxy for SharePoint to send requests.
 
 ## Step 5: Add webhook subscription using Postman
 
@@ -328,8 +325,8 @@ Postman makes it really simple to work with APIs. The first step is to configure
 
 4. Select the **Get New Access Token** button.
 
-5. In the dialog window, enter the following: 
-    * **Auth URL**: 
+5. In the dialog window, enter the following:
+    * **Auth URL**:
        * `https://login.microsoftonline.com/common/oauth2/authorize?resource=https%3A%2F%2F<_your-sharepoint-tenant-url-without-https_>`
        * Replace `your-sharepoint-tenant-url-without-https` with your tenant url without the **https** prefix.
     * **Access Token URL**: `https://login.microsoftonline.com/common/oauth2/token`
@@ -359,10 +356,10 @@ You need to manage webhooks for the default document library, which is provision
 	```
 
 2. Replace _site-collection_ with your site collection.
-	
+
 	Postman executes your request and if successful, you should see the result.
 
-3. Copy the **Id** from the results. Later you will use the **Id** to make webhook requests.   
+3. Copy the **Id** from the results. Later you will use the **Id** to make webhook requests.
 
 ### Add webhook subscription
 
@@ -403,7 +400,7 @@ Now that you have the required information, construct the query and the request 
 
 	![postman add webhook body](../../images/postman-add-webhook-body.png)
 
-9. Make sure the **expirationDateTime** is at most 6 months from today. 
+9. Make sure the **expirationDateTime** is at most 6 months from today.
 
 10. Make sure you are debugging the webhook receiver as in Step 4.
 
@@ -439,9 +436,9 @@ Now that you have the required information, construct the query and the request 
 		validationToken = queryStringParams.GetValues("validationtoken")[0].ToString();
 		httpResponse.Content = new StringContent(validationToken);
 
-		traceWriter.Trace(Request, "SPWebhooks", 
-			TraceLevel.Info, 
-			string.Format("Received validation token: {0}", validationToken));                        
+		traceWriter.Trace(Request, "SPWebhooks",
+			TraceLevel.Info,
+			string.Format("Received validation token: {0}", validationToken));
 		return httpResponse;
 	}
 	```
@@ -486,7 +483,7 @@ Now you'll run queries in Postman to get the subscription details.
 	https://site-collection/_api/web/lists('list-id')/subscriptions('subscription-id')
 	```
 
-7. Replace `subscription-id` with your subscription id. 
+7. Replace `subscription-id` with your subscription id.
 
 ## Step 7: Test webhook notification
 
@@ -521,7 +518,7 @@ Now add a file to the Documents library and test if you get a notification from 
 	iisexpress.exe Information: 0 : Message='ExpirationDateTime: 2016-10-27T16:17:57.0000000Z'
 	```
 
-This project only writes the information to the trace log. However, in your receiver, you send this information into a table or a queue that can process the received data to get information from SharePoint. 
+This project only writes the information to the trace log. However, in your receiver, you send this information into a table or a queue that can process the received data to get information from SharePoint.
 
 With this data, you can construct the URL and use the [GetChanges](https://msdn.microsoft.com/library/office/dn531433.aspx#bk_ListGetChanges) API to get the latest changes.
 

--- a/docs/apis/webhooks/lists/create-subscription.md
+++ b/docs/apis/webhooks/lists/create-subscription.md
@@ -1,15 +1,12 @@
 ---
 title: Create a new subscription
 description: Creates a new webhook subscription on a SharePoint list.
-ms.date: 02/08/2018
-ms.prod: sharepoint
+ms.date: 09/23/2022
 ms.localizationpriority: high
 ---
+# Create a new subscription
 
-
-# Create a new subscription 
-
-Creates a new webhook subscription on a SharePoint list. 
+Creates a new webhook subscription on a SharePoint list.
 
 ## Permissions
 
@@ -19,7 +16,7 @@ The application must have at least edit permissions to the SharePoint list where
 
 You must grant the Azure AD app the permissions specified in the following table:
 
-Application | Permission 
+Application | Permission
 ------------|------------
 Office 365 SharePoint Online|Read and write items and lists in all site collections.
 
@@ -27,7 +24,7 @@ Office 365 SharePoint Online|Read and write items and lists in all site collecti
 
 You must grant the SharePoint Add-in the following permission(s) or higher:
 
-Scope | Permission rights 
+Scope | Permission rights
 ------|------------
 List|Manage
 
@@ -41,7 +38,7 @@ POST /_api/web/lists('list-id')/subscriptions
 
 Include the following properties in the request body.
 
-Name | Type | Description 
+Name | Type | Description
 -----|------|------------
 resource|string|The URL of the list to receive notifications from.
 notificationUrl|string|The service URL to send notifications to.
@@ -75,7 +72,7 @@ Content-Type: application/json
 
 {
     "id": "a8e6d5e6-9f7f-497a-b97f-8ffe8f559dc7",
-    "expirationDateTime": "2016-04-27T16:17:57Z",    
+    "expirationDateTime": "2016-04-27T16:17:57Z",
     "notificationUrl": "https://91e383a5.ngrok.io/api/webhook/handlerequest",
     "resource": "5c77031a-9621-4dfc-bb5d-57803a94e91d"
 }

--- a/docs/apis/webhooks/lists/delete-subscription.md
+++ b/docs/apis/webhooks/lists/delete-subscription.md
@@ -1,12 +1,9 @@
 ---
 title: Delete a subscription
 description: Deletes a webhook subscription from a SharePoint list. After deleting the subscription, notifications are no longer delivered.
-ms.date: 02/08/2018
-ms.prod: sharepoint
+ms.date: 09/23/2022
 ms.localizationpriority: medium
 ---
-
-
 # Delete a subscription
 
 Deletes a webhook subscription from a SharePoint list. After deleting the subscription, notifications are no longer delivered.
@@ -19,7 +16,7 @@ The application must have at least edit permissions to the SharePoint list where
 
 You must grant the Azure AD app the permissions specified in the following table. A subscription can only be deleted by the Azure AD application that created it.
 
-Application | Permission 
+Application | Permission
 ------------|------------
 Office 365 SharePoint Online|Read and write items and lists in all site collections.
 
@@ -27,7 +24,7 @@ Office 365 SharePoint Online|Read and write items and lists in all site collecti
 
 You must grant the SharePoint Add-in the following permission(s) or higher. A subscription can only be deleted by the SharePoint Add-in that created it.
 
-Scope | Permission rights 
+Scope | Permission rights
 ------|------------
 List|Manage
 

--- a/docs/apis/webhooks/lists/get-subscription.md
+++ b/docs/apis/webhooks/lists/get-subscription.md
@@ -1,12 +1,9 @@
 ---
 title: Get subscriptions
 description: Gets one or more webhook subscriptions on a SharePoint list.
-ms.date: 02/08/2018
-ms.prod: sharepoint
+ms.date: 09/23/2022
 ms.localizationpriority: medium
 ---
-
-
 # Get subscriptions
 
 Gets one or more webhook subscriptions on a SharePoint list.
@@ -19,17 +16,17 @@ The application must have at least edit permissions to the SharePoint list where
 
 #### If your application is a Microsoft Azure Active Directory (Azure AD) application
 
-You must grant the Azure AD application the permissions specified in the following table. A subscription can only be retrieved by the Azure AD application that created it. 
+You must grant the Azure AD application the permissions specified in the following table. A subscription can only be retrieved by the Azure AD application that created it.
 
-Application | Permission 
+Application | Permission
 ------------|------------
 Office 365 SharePoint Online|Read and write items and lists in all site collections.
 
 #### If your application is a SharePoint Add-in
 
-You must grant the SharePoint Add-in the following permission(s) or higher. A subscription can only be retrieved by the SharePoint Add-in that created it. 
+You must grant the SharePoint Add-in the following permission(s) or higher. A subscription can only be retrieved by the SharePoint Add-in that created it.
 
-Scope | Permission rights 
+Scope | Permission rights
 ------|------------
 List|Manage
 
@@ -39,17 +36,17 @@ The application must have manage list permissions to the SharePoint list where t
 
 #### If your application is an Azure AD application
 
-You must grant the Azure AD app the permissions specified in the following table. 
+You must grant the Azure AD app the permissions specified in the following table.
 
-Application | Permission 
+Application | Permission
 ------------|------------
 Office 365 SharePoint Online|Have full control of all site collections.
 
 #### If your application is a SharePoint Add-in
 
-You must grant the SharePoint Add-in the following permission(s) or higher. 
+You must grant the SharePoint Add-in the following permission(s) or higher.
 
-Scope | Permission rights 
+Scope | Permission rights
 ------|------------
 List|Full control
 
@@ -111,7 +108,7 @@ Do not supply a request body for this method.
 
 #### Response
 
-This returns a collection of all subscriptions on a SharePoint resource. 
+This returns a collection of all subscriptions on a SharePoint resource.
 
 ```http
 HTTP/1.1 200 OK

--- a/docs/apis/webhooks/lists/overview-sharepoint-list-webhooks.md
+++ b/docs/apis/webhooks/lists/overview-sharepoint-list-webhooks.md
@@ -1,19 +1,16 @@
 ---
 title: SharePoint list webhooks
 description: List webhooks cover the events corresponding to list item changes for a given SharePoint list or a document library.
-ms.date: 02/08/2018
-ms.prod: sharepoint
+ms.date: 09/23/2022
 ms.localizationpriority: high
 ---
-
-
 # SharePoint list webhooks
 
 The SharePoint list webhooks cover the events corresponding to list item changes for a given SharePoint list or a document library. SharePoint webhooks provide a simple notification pipeline so your application can be aware of changes to a SharePoint list without polling the service.
 
 ## Tasks
 
-| Task                                                | HTTP method                                            |     
+| Task                                                | HTTP method                                            |
 |-----------------------------------------------------|--------------------------------------------------------|
 | [Create a new subscription](./create-subscription.md) | `POST    /_api/web/lists('list-guid')/subscriptions` |
 | [Get subscriptions](./get-subscription.md)          | `GET     /_api/web/lists('list-guid')/subscriptions`   |

--- a/docs/apis/webhooks/lists/update-subscription.md
+++ b/docs/apis/webhooks/lists/update-subscription.md
@@ -1,32 +1,30 @@
 ---
 title: Update a subscription
 description: Updates a webhook subscription on a SharePoint list.
-ms.date: 09/06/2022
+ms.date: 09/23/2022
 ms.localizationpriority: medium
 ---
-
-
 # Update a subscription
 
 Updates a webhook subscription on a SharePoint list.
 
 ## Permissions
 
-The application must have at least edit permissions to the SharePoint list where the subscription will be updated.  
+The application must have at least edit permissions to the SharePoint list where the subscription will be updated.
 
 ### If your application is a Microsoft Azure Active Directory (Azure AD) application
 
 You must grant the Azure AD application the permissions specified in the following table. A subscription can only be updated by the Azure AD application that created it.
 
-Application | Permission 
+Application | Permission
 ------------|------------
-Office 365 SharePoint Online|Read and write items and lists in all site collections. 
+Office 365 SharePoint Online|Read and write items and lists in all site collections.
 
 ### If your application is a SharePoint Add-in
 
 You must grant the SharePoint Add-in the following permission(s) or higher. A subscription can only be updated by the SharePoint Add-in that created it.
 
-Scope | Permission rights 
+Scope | Permission rights
 ------|------------
 List|Manage
 
@@ -52,7 +50,7 @@ Content-Type: application/json
 
 Include the following properties in the request body.
 
-Name | Type | Description 
+Name | Type | Description
 -----|------|------------
 notificationUrl|string|The service URL to send notifications to.
 expirationDateTime|date|The date the notification will expire and be deleted.

--- a/docs/apis/webhooks/overview-sharepoint-webhooks.md
+++ b/docs/apis/webhooks/overview-sharepoint-webhooks.md
@@ -1,27 +1,24 @@
 ---
 title: Overview of SharePoint webhooks
 description: Build applications that subscribe to receive notifications on specific events that occur in SharePoint.
-ms.date: 02/08/2018
-ms.prod: sharepoint
+ms.date: 09/23/2022
 ms.localizationpriority: high
 ---
-
-
 # Overview of SharePoint webhooks
 
 SharePoint webhooks enable developers to build applications that subscribe to receive notifications on specific events that occur in SharePoint. When an event is triggered, SharePoint sends an HTTP POST payload to the subscriber. Webhooks are easier to develop and consume than Windows Communication Foundation (WCF) services used by SharePoint Add-in remote event receivers because webhooks are regular HTTP services (web API).
 
-Currently webhooks are only enabled for SharePoint list items. SharePoint list item webhooks cover the events corresponding to list item changes for a given SharePoint list or a document library. SharePoint webhooks provide a simple notification pipeline so that your application can be aware of changes to a SharePoint list without polling the service. For more information, see [SharePoint list webhooks](./lists/overview-sharepoint-list-webhooks.md). 
+Currently webhooks are only enabled for SharePoint list items. SharePoint list item webhooks cover the events corresponding to list item changes for a given SharePoint list or a document library. SharePoint webhooks provide a simple notification pipeline so that your application can be aware of changes to a SharePoint list without polling the service. For more information, see [SharePoint list webhooks](./lists/overview-sharepoint-list-webhooks.md).
 
 ## Creating webhooks
 
-To create a new SharePoint webhook, you add a new subscription to the specific SharePoint resource, such as a SharePoint list. 
+To create a new SharePoint webhook, you add a new subscription to the specific SharePoint resource, such as a SharePoint list.
 
 The following information is required for creating a new subscription:
 
 - **Resource**. The resource endpoint URL you are creating the subscription for. For example, a SharePoint List API URL.
 - **Server notification URL**. Your service endpoint URL. SharePoint sends an HTTP POST to this endpoint when events occur in the specified resource.
-- **Expiration date**. The expiration date for your subscription. The expiration date should not be more than 180 days. By default, subscriptions are set to expire 180 days from when they are created. 
+- **Expiration date**. The expiration date for your subscription. The expiration date should not be more than 180 days. By default, subscriptions are set to expire 180 days from when they are created.
 
 You can also include the following information if needed:
 
@@ -145,9 +142,9 @@ If an error occurs while sending the notification to your application, SharePoin
 
 ## Expiration
 
-Webhook subscriptions are set to expire after 180 days by default if an **expirationDateTime** value is not specified. 
+Webhook subscriptions are set to expire after 180 days by default if an **expirationDateTime** value is not specified.
 
-You need to set an expiration date when creating the subscription. The expiration date should be less than 180 days. Your application is expected to handle the expiration date according to your application's needs by updating the subscription periodically. 
+You need to set an expiration date when creating the subscription. The expiration date should be less than 180 days. Your application is expected to handle the expiration date according to your application's needs by updating the subscription periodically.
 
 ## Retry mechanism
 

--- a/docs/apis/webhooks/sharepoint-webhooks-using-azure-functions.md
+++ b/docs/apis/webhooks/sharepoint-webhooks-using-azure-functions.md
@@ -1,12 +1,9 @@
 ---
 title: Using Azure Functions with SharePoint webhooks
 description: Set up and use Azure Functions for your webhooks to take care of the hosting and scaling of your function.
-ms.date: 05/09/2020
-ms.prod: sharepoint
+ms.date: 09/23/2022
 ms.localizationpriority: high
 ---
-
-
 # Using Azure Functions with SharePoint webhooks
 
 [Azure Functions](/azure/azure-functions/functions-overview) offers an easy way to host your SharePoint webhooks: you can add your webhook C# or JavaScript code via the browser, and Azure takes care of the hosting and scaling of your function. This guide shows how to set up and use Azure Functions for your webhooks.

--- a/docs/apis/webhooks/webhooks-reference-implementation.md
+++ b/docs/apis/webhooks/webhooks-reference-implementation.md
@@ -1,17 +1,14 @@
 ---
 title: SharePoint webhooks sample reference implementation
-description: This SharePoint Patterns and Practices (PnP) reference implementation shows how you can use SharePoint webhooks in your application. 
-ms.date: 02/08/2018
-ms.prod: sharepoint
+description: This SharePoint Patterns and Practices (PnP) reference implementation shows how you can use SharePoint webhooks in your application.
+ms.date: 09/23/2022
 ms.localizationpriority: high
 ---
-
-
 # SharePoint webhooks sample reference implementation
 
 The SharePoint Patterns and Practices (PnP) reference implementation shows how you can use SharePoint webhooks in your application. The webhooks are implemented in an enterprise ready manner using various Microsoft Azure components such as Azure Web Jobs, Azure SQL Server, and Azure Storage Queues for asynchronous web job notification handling.
 
-The reference implementation only works with [SharePoint list webhooks](./lists/overview-sharepoint-list-webhooks.md). 
+The reference implementation only works with [SharePoint list webhooks](./lists/overview-sharepoint-list-webhooks.md).
 
 You can also follow these steps by watching the video on the Microsoft 365 Platform Communtiy (PnP) YouTube Channel:
 
@@ -25,21 +22,21 @@ You can also follow these steps by watching the video on the Microsoft 365 Platf
 
 Microsoft Azure is used to host the various components needed to implement SharePoint webhooks.
 
-Source code and other materials for the reference implementation are available in two flavors: 
+Source code and other materials for the reference implementation are available in two flavors:
 - A SharePoint provider-hosted application version
-- An Office 365 Azure AD application, which can be found in the [SharePoint developer samples GitHub repository](https://aka.ms/sp-webhooks-sample-reference). 
+- An Office 365 Azure AD application, which can be found in the [SharePoint developer samples GitHub repository](https://aka.ms/sp-webhooks-sample-reference).
 
 ## Deploy the reference implementation
 
-The application shows you how to manage webhooks, specifically for a SharePoint list. It also contains a reference implementation of a webhook service endpoint that you can reuse in your webhook projects. 
+The application shows you how to manage webhooks, specifically for a SharePoint list. It also contains a reference implementation of a webhook service endpoint that you can reuse in your webhook projects.
 
 ![SharePoint webhook reference implementation application](../../images/webhook-sample-application.png)
 
 ### Deployment guides
 
-- The [SharePoint webhooks reference implementation deployment guide](https://github.com/SharePoint/sp-dev-samples/blob/master/Samples/WebHooks.List/Deployment%20guide.md) lists the deployment steps used to deploy the SharePoint provider-hosted reference implementation. 
+- The [SharePoint webhooks reference implementation deployment guide](https://github.com/SharePoint/sp-dev-samples/blob/master/Samples/WebHooks.List/Deployment%20guide.md) lists the deployment steps used to deploy the SharePoint provider-hosted reference implementation.
 
-- To deploy the Office 365 Azure AD application, use the steps described at [SharePoint webhooks Azure AD reference implementation deployment guide](https://github.com/SharePoint/sp-dev-samples/blob/master/Samples/WebHooks.List.AzureAD/Deployment%20guide.md), which shows you how to use a Web API function as webhook service. 
+- To deploy the Office 365 Azure AD application, use the steps described at [SharePoint webhooks Azure AD reference implementation deployment guide](https://github.com/SharePoint/sp-dev-samples/blob/master/Samples/WebHooks.List.AzureAD/Deployment%20guide.md), which shows you how to use a Web API function as webhook service.
 
 - If you're more interested in using Azure Functions, see the [Azure Functions guide](https://github.com/SharePoint/sp-dev-samples/blob/master/Samples/WebHooks.List.AzureAD/azure%20functions%20guide.md) for more details on how to use Azure Functions in this reference implementation.
 
@@ -53,7 +50,7 @@ The reference implementation works with a SharePoint list. To add a webhook to a
 
 * A payload that identifies the list that you're adding the webhook for.
 * The location of your webhook service URL to send the notifications.
-* The expiration date of the webhook. 
+* The expiration date of the webhook.
 
 After you've requested SharePoint to add your webhook, SharePoint validates that your webhook service endpoint exists. It sends a validation string to your service endpoint. SharePoint expects that your service endpoint returns the validation string within 5 seconds. If this process fails, the webhook creation is canceled. If you've deployed your service, this works and SharePoint returns an HTTP 201 message on the POST request that the application initially sent. The payload in the response contains the ID of the new webhook subscription.
 
@@ -119,7 +116,7 @@ In the previous step, your service endpoint was called, but SharePoint only prov
 
 ![Async GetChanges](../../images/webhook-sample-async-getchanges.png)
 
-You can learn more about the `GetChanges()` implementation in the **ProcessNotification** method in the [ChangeManager](https://github.com/SharePoint/sp-dev-samples/blob/master/Samples/WebHooks.List/SharePoint.WebHooks.Common/ChangeManager.cs) class of the **SharePoint.WebHooks.Common** project. 
+You can learn more about the `GetChanges()` implementation in the **ProcessNotification** method in the [ChangeManager](https://github.com/SharePoint/sp-dev-samples/blob/master/Samples/WebHooks.List/SharePoint.WebHooks.Common/ChangeManager.cs) class of the **SharePoint.WebHooks.Common** project.
 
 To avoid getting the same change repeatedly, it's important that you inform SharePoint from which point you want the changes. This is done by passing a **changeToken**, which also implies that your service endpoint needs to persist the last used **changeToken** so that it can be used the next time the service endpoint is called.
 
@@ -155,14 +152,14 @@ When your service receives a notification, it also gets information about the su
 
 ### Reliable but more complex model
 
-Create a web job that on a weekly basis reads all the subscription IDs from the persistent storage. One-by-one extend the found subscriptions each time. 
+Create a web job that on a weekly basis reads all the subscription IDs from the persistent storage. One-by-one extend the found subscriptions each time.
 
 > [!NOTE]
 > This web job is not part of this reference implementation.
 
-The actual renewal of a SharePoint list webhook can be done by using a [`PATCH /_api/web/lists('list-id')/subscriptions(‘subscriptionID’)`](./lists/update-subscription.md) REST call. 
+The actual renewal of a SharePoint list webhook can be done by using a [`PATCH /_api/web/lists('list-id')/subscriptions(‘subscriptionID’)`](./lists/update-subscription.md) REST call.
 
-In the reference implementation, updating of webhooks is implemented in the [WebHookManager](https://github.com/SharePoint/sp-dev-samples/blob/master/Samples/WebHooks.List/SharePoint.WebHooks.Common/WebHookManager.cs) class of the **SharePoint.WebHooks.Common** project. 
+In the reference implementation, updating of webhooks is implemented in the [WebHookManager](https://github.com/SharePoint/sp-dev-samples/blob/master/Samples/WebHooks.List/SharePoint.WebHooks.Common/WebHookManager.cs) class of the **SharePoint.WebHooks.Common** project.
 
 Updating a webhook is done by using the **UpdateListWebHookAsync** method:
 

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -52,7 +52,9 @@
         "spfx/**.md": "sharepoint"
       },
       "ms.service": {
-        "apis/**.md": "sharepoint-online",
+        "apis/*.md": "sharepoint-online",
+        "apis/webhooks/**.md": "sharepoint-online",
+        "apis/syntex/*.md": "microsoft-365-enterprise",
         "business-apps/power-apps/**.md": "powerapps",
         "business-apps/power-automate/guidance/**.md": "power-automate",
         "declarative-customization/**.md": "sharepoint-online",


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- n/a

## What's in this Pull Request?

- validation errors with `ms.prod` frontmatter prop:
  - invalid value set - value for `ms.service` used as `ms.prod` value
  - can't have both `ms.prod` & `ms.service`: mutually exclusive
  - removed value from docs & moved to docfx.json for mass set
- added missing `ms.date`
- fixes to other docs to account for above changes
