### PR TITLE
Update to sample Site Script code

### DIFF
--- a/docs/declarative-customization/get-started-create-site-design.md
+++ b/docs/declarative-customization/get-started-create-site-design.md
@@ -1,7 +1,7 @@
 ---
 title: Get started creating SharePoint site templates and site scripts
 description: Create site templates to provide reusable lists, themes, layouts, pages, or custom actions so that your users can quickly build new SharePoint sites with the features they need.
-ms.date: 06/28/2022
+ms.date: 09/30/2022
 ms.localizationpriority: high
 ---
 

--- a/docs/declarative-customization/get-started-create-site-design.md
+++ b/docs/declarative-customization/get-started-create-site-design.md
@@ -24,7 +24,7 @@ Each action is specified by the "verb" value in the JSON script. Also, actions c
    ```powershell
     $site_script = '
     {
-        "$schema": "schema.json",
+        "$schema": "https://developer.microsoft.com/json-schemas/sp/site-design-script-actions.schema.json",
             "actions": [
                 {
                     "verb": "createSPList",
@@ -64,9 +64,7 @@ Each action is specified by the "verb" value in the JSON script. Also, actions c
                         }
                     ]
                 }
-            ],
-                "bindata": { },
-        "version": 1
+            ]
     }
     '
    ```


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues
none known

## What's in this Pull Request?
Fix to sample code to match schema.
Including "binddata" and "version" in a Site Script caused it to fail.
Changing the schema reference at the top allowed VSCode to highlight the error, indicating that those aren't allowed.
Removing them resolved the issue.

Seems the schema is being 'more-enforced' than in the past.