### PR TITLE
updated correct SharePoint framework version - Line #45

### DIFF
--- a/docs/spfx/set-up-your-development-environment.md
+++ b/docs/spfx/set-up-your-development-environment.md
@@ -42,7 +42,7 @@ You can check if you already have Node.js already installed, including installed
 node --version
 ```
 
-The SharePoint Framework v1.18.0 is supported on the following Node.js versions:
+The SharePoint Framework v1.16.0 is supported on the following Node.js versions:
 
 - Node.js v16 LTS (v16.13.x - v16.18.x, *aka: Gallium*)
 


### PR DESCRIPTION
In line #45, SharePoint framework vesion number was mentioned as 1.18. instead of 1.18 it should be 1.16 so updated the same

## Category

- [x ] Content fix
- [ ] New article

## Related issues- N/A

## What's in this Pull Request?- Typo fix




