### PR TITLE
Fixed Advanced CardView tutorial references

### DIFF
--- a/docs/spfx/viva/get-started/advanced-quick-view-functionality.md
+++ b/docs/spfx/viva/get-started/advanced-quick-view-functionality.md
@@ -1,7 +1,7 @@
 ---
 title: Advanced Quick View Functionality
 description: "This tutorial builds off the tutorial 'Advanced Card View Functionality'."
-ms.date: 09/08/2022
+ms.date: 01/12/2023
 ms.localizationpriority: high
 ---
 # Advanced Quick View Functionality

--- a/docs/spfx/viva/get-started/advanced-quick-view-functionality.md
+++ b/docs/spfx/viva/get-started/advanced-quick-view-functionality.md
@@ -6,9 +6,9 @@ ms.localizationpriority: high
 ---
 # Advanced Quick View Functionality
 
-This tutorial builds off the following tutorial: [Advanced Card View Functionality](advanced-quick-view-functionality.md).
+This tutorial builds off the following tutorial: [Advanced Card View Functionality](advanced-card-view-functionality.md).
 
-Start with the HelloWorld ACE from the previous tutorial, [Advanced Card View Functionality](advanced-quick-view-functionality.md). The HelloWorld ACE displays either the count of total steps or one individual step at a time. Using the Quick View, the ACE can show a list of all the steps. Additionally, the ACE can show more details about a particular step if it's selected.
+Start with the HelloWorld ACE from the previous tutorial, [Advanced Card View Functionality](advanced-card-view-functionality.md). The HelloWorld ACE displays either the count of total steps or one individual step at a time. Using the Quick View, the ACE can show a list of all the steps. Additionally, the ACE can show more details about a particular step if it's selected.
 
 ## Show all items in Quick View
 


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

N/A

## What's in this Pull Request?

The references to _Advanced CardView Tutorial_ were linking to _Advanced QuickView Tutorial_ which was incorrect. This PR fixes this.
