### PR TITLE
Update release-1.17.md

### DIFF
--- a/docs/spfx/release-1.17.md
+++ b/docs/spfx/release-1.17.md
@@ -44,7 +44,7 @@ npm install @microsoft/generator-sharepoint@next --global
 
 Developers can specify `supportsSelfFramingInTeams` flag in a web part's manifest if the scenario requires the web part to render SharePoint page in the iframe.
 
-### Ability to specify claims parameter when requesting an AAD Oath2 token
+### Ability to specify claims parameter when requesting an AAD OAuth2 token
 
 `AADTokenProvider.getToken` definition was updated to allow specifying claims parameter:
 


### PR DESCRIPTION
Fixing typo in line 47: OAuth2 instead of Oath2

## Category

- [x] Content fix
- [ ] New article
- [] Example checked item (*delete this line*)


## Related issues

none

## What's in this Pull Request?

Fixing typo in OAuth2 name in line 47.

