### PR TITLE
🧼 cleanup markdown numbered list

### DIFF
--- a/docs/general-development/create-a-workflow-with-elevated-permissions-by-using-the-sharepoint-workflo.md
+++ b/docs/general-development/create-a-workflow-with-elevated-permissions-by-using-the-sharepoint-workflo.md
@@ -1,42 +1,36 @@
 ---
 title: Create a workflow with elevated permissions by using the SharePoint Workflow platform
 description: Create SharePoint workflows that access objects in SharePoint that require elevated permissions. These solutions grant permissions to the workflow app and wrap actions with the App Step.
-ms.date: 12/29/2017
+ms.date: 05/18/2023
 ms.assetid: 4656f6a0-36fd-4b7d-898e-8cd4bdbbda57
 ms.localizationpriority: high
 ---
 
-
 # Create a workflow with elevated permissions by using the SharePoint Workflow platform
-
-<a name="section1"> </a>
 
 This article describes how to create SharePoint workflows that access objects in SharePoint that require elevated permissions. These solutions use two features: granting permissions to the workflow app and wrapping actions with the App Step.
 
 > [!NOTE]
 > SharePoint 2010 workflows have been retired since August 1, 2020 for new tenants and removed from existing tenants on November 1, 2020. If you’re using SharePoint 2010 workflows, we recommend migrating to Power Automate or other supported solutions. For more info, see [SharePoint 2010 workflow retirement](https://support.microsoft.com/office/sharepoint-2010-workflow-retirement-1ca3fff8-9985-410a-85aa-8120f626965f).
 
-  
-> [!IMPORTANT] 
-> This article assumes that the SharePoint Workflow platform has been installed and configured and that SharePoint has been configured for add-ins. For more information about SharePoint Workflows and SharePoint Add-ins, including installation and configuration, see [Workflows in SharePoint](workflows-in-sharepoint.md) and [Install and manage SharePoint Add-ins](../sp-add-ins/sharepoint-add-ins.md). 
+> [!IMPORTANT]
+> This article assumes that the SharePoint Workflow platform has been installed and configured and that SharePoint has been configured for add-ins. For more information about SharePoint Workflows and SharePoint Add-ins, including installation and configuration, see [Workflows in SharePoint](workflows-in-sharepoint.md) and [Install and manage SharePoint Add-ins](../sp-add-ins/sharepoint-add-ins.md).
 
 Imagine that as a SharePoint administrator, you would like to define some processes for managing user requests for purchases of add-ins from the Office Store. In the simplest case, you want to send an acknowledgment email when a user requests an add-in. In addition, you might also want to add structure to the request approval process.
-  
-By default, workflow does not have permissions to access the app catalog. Catalog lists in SharePoint require owner (full control) permissions. Workflows generally run at a permission level equivalent to write. 
-  
+
+By default, workflow does not have permissions to access the app catalog. Catalog lists in SharePoint require owner (full control) permissions. Workflows generally run at a permission level equivalent to write.
+
 To solve this, you have to create a workflow with elevated permissions by doing the following in the Site Collection site:
 
 1. Allow the workflow to use add-in permissions.
-
-2. Grant full control permission to the workflow.
- 
-3. Develop the workflow to wrap actions inside an App Step.
+1. Grant full control permission to the workflow.
+1. Develop the workflow to wrap actions inside an App Step.
 
 ## Allow a workflow to use add-in permissions on a SharePoint site
 
 The first step is to allow the workflow to use add-in permissions. You configure a workflow to use add-in permissions on the **Site settings** page of the SharePoint site where the workflow runs. The following procedure configures the SharePoint site to allow the workflow to use add-in permissions.
-  
-> [!IMPORTANT] 
+
+> [!IMPORTANT]
 > The procedure must be completed by a user that has **Site Administrator** permissions.
 
 ### To allow workflow to use add-in permissions
@@ -45,79 +39,71 @@ The first step is to allow the workflow to use add-in permissions. You configure
 
   ![Settings menu](../images/SPD15-WFAppPermissions1.png)
 
-2. Go to **Site settings**.
- 
-3. In the **Site Actions** section, select **Manage site features**.
+1. Go to **Site settings**.
+1. In the **Site Actions** section, select **Manage site features**.
+1. Locate the feature called **Workflows can use app permissions**, as shown in the figure, and then select **Activate**.
 
-4. Locate the feature called **Workflows can use app permissions**, as shown in the figure, and then select **Activate**.
-    
-  > [!WARNING] 
-  > This feature will not activate unless you have properly configured the SharePoint Workflow platform and SharePoint Add-ins. 
+    > [!WARNING]
+    > This feature will not activate unless you have properly configured the SharePoint Workflow platform and SharePoint Add-ins.
 
-  ![Workflow can use app permissions feature](../images/SPD15-WFAppPermissions2.png)
-  
+    ![Workflow can use app permissions feature](../images/SPD15-WFAppPermissions2.png)
 
 ## Grant full control permission to a workflow
 
 For the workflow to function properly, it must be granted full control on the site. The following procedure grants full control permission to the workflow.
-  
-> [!IMPORTANT] 
+
+> [!IMPORTANT]
 > The procedure must be completed by a user that has **Site Owner** permissions. The workflow must already be published to the SharePoint site.
 
 ### To grant full control permission to a workflow
 
 1. Select the **Settings** icon.
- 
+
   ![Settings menu](../images/SPD15-WFAppPermissions1.png)
 
-2. Go to **Site settings**.    
-  
-3. In the **Users and Permissions** section, select **Site app permissions**.    
+1. Go to **Site settings**.
+1. In the **Users and Permissions** section, select **Site app permissions**.
 
-> [!IMPORTANT] 
-> In SharePoint Online, select **Site collection app permissions**. This option is only visible to **Site Collection Administrators**.
-  
-4. Copy the **client** section of the **App Identifier**. This is the identifier between the last "|" and the "@" sign, as shown in the figure.
-    
-  ![Selecting App Identifier](../images/SPD15-WFAppPermissions3.png)
+    > [!IMPORTANT]
+    > In SharePoint Online, select **Site collection app permissions**. This option is only visible to **Site Collection Administrators**.
 
-5. Go to the **Grant permission to an app** page. This must be done by browsing to the appinv.aspx page of the site.
-    
-  Example: `http://{hostname}/{the Site Collection}/_layouts/15/appinv.aspx`. 
-    
-  > [!NOTE]
-  > The 'app' in this step refers to the workflow add-in in general and not just a specific workflow. Individual workflows cannot be access controlled. When you enable add-in permissions, you are enabling for all workflows within the Site Collection. 
+1. Copy the **client** section of the **App Identifier**. This is the identifier between the last "|" and the "@" sign, as shown in the figure.
 
-  For more information about setting up a workflow, see the [Blog article from Sympraxis Consulting: Looping Through Content in a SharePoint Site Workflow](http://sympmarc.com/series/looping-through-content-in-a-sharepoint-2013-site-workflow/)
-    
-  The following figure shows an example.
- 
-  ![The appinv.aspx URL example and page.](../images/SPD15-WFAppPermissions4.png)
+    ![Selecting App Identifier](../images/SPD15-WFAppPermissions3.png)
 
-6. Paste the client ID in the **App Id** field, and then select **Lookup**, as shown in the previous figure.
+1. Go to the **Grant permission to an app** page. This must be done by browsing to the appinv.aspx page of the site.
 
-7. Paste the following code in the **Permission Request XML** field to grant full control permission *(note: this code block was updated on 12/29/17 to include the `AllowAppOnlyPolicy`)*.
-    
-  ```XML 
+    Example: `http://{hostname}/{the Site Collection}/_layouts/15/appinv.aspx`.
+
+    > [!NOTE]
+    > The 'app' in this step refers to the workflow add-in in general and not just a specific workflow. Individual workflows cannot be access controlled. When you enable add-in permissions, you are enabling for all workflows within the Site Collection.
+
+    For more information about setting up a workflow, see the [Blog article from Sympraxis Consulting: Looping Through Content in a SharePoint Site Workflow](http://sympmarc.com/series/looping-through-content-in-a-sharepoint-2013-site-workflow/)
+
+    The following figure shows an example.
+
+    ![The appinv.aspx URL example and page.](../images/SPD15-WFAppPermissions4.png)
+
+1. Paste the client ID in the **App Id** field, and then select **Lookup**, as shown in the previous figure.
+1. Paste the following code in the **Permission Request XML** field to grant full control permission *(note: this code block was updated on 12/29/17 to include the `AllowAppOnlyPolicy`)*.
+
+    ```XML
     <AppPermissionRequests AllowAppOnlyPolicy="true">
         <AppPermissionRequest Scope="http://sharepoint/content/sitecollection/web" Right="FullControl" />
     </AppPermissionRequests>
+    ```
 
-  ```
+    > [!WARNING]
+    > There are no placeholders in the **Scope** value. It is a literal value. Enter it exactly as it appears here.
 
-  > [!WARNING] 
-  > There are no placeholders in the **Scope** value. It is a literal value. Enter it exactly as it appears here.
+    The following figure shows an example of the completed page _(note that the code in the **Permission Request XML** area does not reflect the recent update to the code in Step 7)_.
 
-  The following figure shows an example of the completed page _(note that the code in the **Permission Request XML** area does not reflect the recent update to the code in Step 7)_. 
-  
-  ![Looking up an App Id.](../images/SPD15-WFAppPermissions5.png)
+    ![Looking up an App Id.](../images/SPD15-WFAppPermissions5.png)
 
-8. Select **Create**.
-    
-9. You are then asked to trust the workflow add-in, as shown in the following figure. Select **Trust It**.
-    
-  ![Trust the Workflow app.](../images/SPD15-WFAppPermissions6.png)
-  
+1. Select **Create**.
+1. You are then asked to trust the workflow add-in, as shown in the following figure. Select **Trust It**.
+
+    ![Trust the Workflow app.](../images/SPD15-WFAppPermissions6.png)
 
 ## Wrap actions inside an App Step
 
@@ -125,73 +111,60 @@ Finally, you need to wrap the workflow actions inside an App Step. The following
 
 ### To wrap actions inside an App Step
 
-1. Open the app catalog site in SharePoint Designer.    
-  
-2. Create a new Custom List on which to run the workflow. In this example, the list name is **App Demo**.    
-  
-3. Select **Workflows** in the navigation window.    
-  
-4. Create a new **List Workflow** for the **App Demo** list, as shown in the figure.
+1. Open the app catalog site in SharePoint Designer.
+1. Create a new Custom List on which to run the workflow. In this example, the list name is **App Demo**.
+1. Select **Workflows** in the navigation window.
+1. Create a new **List Workflow** for the **App Demo** list, as shown in the figure.
 
-  ![Create a new List Workflow.](../images/SPD15-WFAppPermissions7.png)
+    ![Create a new List Workflow.](../images/SPD15-WFAppPermissions7.png)
 
-5. Insert an **App Step**, as shown in the figure.
-    
-  ![Adding an App Step.](../images/SPD15-WFAppPermissions8.png)
+1. Insert an **App Step**, as shown in the figure.
 
-6. Insert a **Send an Email** action in the **App Step**.
- 
-7. Select the **Address book** button. In the **To** field, select **Workflow Lookup for a User**, and then select **Add** as shown in the figure.
+    ![Adding an App Step.](../images/SPD15-WFAppPermissions8.png)
 
-  ![Select Workflow lookup for a user.](../images/SPD15-WFAppPermissions9.png)
-  
-8. Enter the **Created By** field as the lookup value, as shown in the figure.
+1. Insert a **Send an Email** action in the **App Step**.
+1. Select the **Address book** button. In the **To** field, select **Workflow Lookup for a User**, and then select **Add** as shown in the figure.
 
-  ![Lookup for Person dialog.](../images/SPD15-WFAppPermissions10.png)
-  
-9. Enter **Email** from the **App Demo** list in the email message body.
-     
-10. Select **OK** to return to the workflow. The completed workflow is shown in the figure.
+    ![Select Workflow lookup for a user.](../images/SPD15-WFAppPermissions9.png)
 
-  ![Email action in App Step.](../images/SPD15-WFAppPermissions11.png)
-    
-11. Select the **Workflow Settings** icon in the ribbon, as shown in the figure.
-    
-  ![Workflow Settings icon in ribbon.](../images/SPD15-WFAppPermissions12.png)
+1. Enter the **Created By** field as the lookup value, as shown in the figure.
 
-12. Clear the check box next to **Automatically update the workflow status to the current stage name**, and then select **Publish**.
-    
-  ![Clear automatic updates check mark and publish.](../images/SPD15-WFAppPermissions13.png)
-  
+    ![Lookup for Person dialog.](../images/SPD15-WFAppPermissions10.png)
 
-<a name="section2"> </a>
+1. Enter **Email** from the **App Demo** list in the email message body.
+1. Select **OK** to return to the workflow. The completed workflow is shown in the figure.
+
+    ![Email action in App Step.](../images/SPD15-WFAppPermissions11.png)
+
+1. Select the **Workflow Settings** icon in the ribbon, as shown in the figure.
+
+    ![Workflow Settings icon in ribbon.](../images/SPD15-WFAppPermissions12.png)
+
+1. Clear the check box next to **Automatically update the workflow status to the current stage name**, and then select **Publish**.
+
+    ![Clear automatic updates check mark and publish.](../images/SPD15-WFAppPermissions13.png)
 
 ## Understand how it works
 
 To understand why elevating permissions for a workflow is required, consider that workflows are fundamentally add-ins for SharePoint, and they follow the same authorization rules of the add-in model. The default configuration for workflow is that the effective permissions of the workflow are an intersection of user permissions and the add-in permissions, as shown in the figure.
-    
+
 ![Permissions diagram.](../images/SPD15-WFAppPermissions14.png)
-  
+
 Two reasons why it is necessary to elevate permissions to create a workflow in the App Request list are:
 
 - By default, workflow only has write permission.
-
 - The user has no permissions.
-  
-The first step to solve this problem is to allow the application to authorize by using only its identity and ignoring that of the user. This is done by enabling the App Step feature. The second step grants full control permission to the workflow. 
-  
+
+The first step to solve this problem is to allow the application to authorize by using only its identity and ignoring that of the user. This is done by enabling the App Step feature. The second step grants full control permission to the workflow.
+
 The following diagram illustrates the change in permissions.
-  
+
 ![Permissions matrix.](../images/SPD15-WFAppPermissions15.png)
-  
-<a name="section3"> </a>
 
 ## See also
 
 - [Blog article from the SharePoint Designer team: Workflow package and deploy scenario](https://blogs.msdn.microsoft.com/sharepointdesigner/2012/08/29/packaging-sharepoint-2013-list-site-and-reusable-workflow-and-how-to-deploy-the-package/)
 - [What's new in workflow in SharePoint](what-s-new-in-workflows-for-sharepoint.md)
-- [Getting started with SharePoint workflow](get-started-with-workflows-in-sharepoint.md) 
+- [Getting started with SharePoint workflow](get-started-with-workflows-in-sharepoint.md)
 - [Workflow actions and activities reference for SharePoint](workflow-actions-and-activities-reference-for-sharepoint.md)
 - [Workflow development in SharePoint Designer and Visio](workflow-development-in-sharepoint-designer-and-visio.md)
-
-    

--- a/docs/general-development/create-hybrid-connectivity-apps-for-sharepoint.md
+++ b/docs/general-development/create-hybrid-connectivity-apps-for-sharepoint.md
@@ -1,231 +1,111 @@
 ---
 title: Create hybrid connectivity apps for SharePoint
 description: This is an article with links to learn about the process of developing and deploying apps for SharePoint hybrid connectivity solutions.
-ms.date: 06/07/2022
+ms.date: 05/18/2023
 ms.assetid: 311f036e-3442-4497-b35e-442b665462d3
 ms.localizationpriority: medium
 ---
 
-
 # Create hybrid connectivity apps for SharePoint
+
 Learn about the process of developing and deploying apps for SharePoint hybrid connectivity solutions.
+
 ## Hybrid connectivity in SharePoint and SharePoint Online
-<a name="bk_hybridconnectivity"> </a>
 
 As businesses move to using SharePoint Online, they need a way to expose large amounts of proprietary data safely and securely. To help solve this challenge, SharePoint introduced hybrid connectivity.
-  
-    
-    
-The Business Connectivity Services (BCS) hybrid connectivity capability lets SharePoint consume data housed on-premises, inside corporate firewalls, and secured by various forms of authentication. With hybrid connectivity functionality, SharePoint Online can access this data securely over the web as if it was on the same internal network. Once hybrid connectivity is configured, users can work with data that is secured within the business' infrastructure. They can access and manipulate the data according to the permissions that they have been granted in SharePoint.
-  
-    
-    
-For a complete description of how to configure a working hybrid solution, see  [Hybrid for SharePoint](https://technet.microsoft.com/library/jj838715.aspx). This series of articles walks you through all the requirements of configuring data sources, reverse proxies, search, security, networking, and everything else needed to set up the end-to-end scenario.
-  
-    
-    
 
-> **Caution:**
-> To configure a hybrid SharePoint environment, you need a combination of expert skills and significant hands-on experience with SharePoint, SharePoint Online, and related products and technologies. We recommend that you engage Microsoft Consulting Services to provide technical guidance and support during the design and deployment of your hybrid environment. > For more information, see  [Microsoft Services](https://www.microsoft.com/en-us/microsoft-365/products-apps-services). 
-  
-    
-    
+The Business Connectivity Services (BCS) hybrid connectivity capability lets SharePoint consume data housed on-premises, inside corporate firewalls, and secured by various forms of authentication. With hybrid connectivity functionality, SharePoint Online can access this data securely over the web as if it was on the same internal network. Once hybrid connectivity is configured, users can work with data that is secured within the business' infrastructure. They can access and manipulate the data according to the permissions that they have been granted in SharePoint.
+
+For a complete description of how to configure a working hybrid solution, see  [Hybrid for SharePoint](https://technet.microsoft.com/library/jj838715.aspx). This series of articles walks you through all the requirements of configuring data sources, reverse proxies, search, security, networking, and everything else needed to set up the end-to-end scenario.
+
+> [!CAUTION]
+> To configure a hybrid SharePoint environment, you need a combination of expert skills and significant hands-on experience with SharePoint, SharePoint Online, and related products and technologies. We recommend that you engage Microsoft Consulting Services to provide technical guidance and support during the design and deployment of your hybrid environment. > For more information, see  [Microsoft Services](https://www.microsoft.com/en-us/microsoft-365/products-apps-services).
 
 For you to be able to create an app that consumes data from an internal data source through BCS and the hybrid connection, this article assumes that you have already followed the procedures to configure your hybrid environment.
-  
-    
-    
 
 ## Create hybrid connectivity apps
-<a name="bkmk_CreatingHybridConnectivityApps"> </a>
 
 Creating a hybrid SharePoint Add-in is essentially the same as creating any SharePoint Add-in.
-  
-    
-    
-Follow these steps to create a hybrid app:
-  
-    
-    
 
--  [Prepare the data source](#bkmk_PrepareDataSource)
-    
-  
--  [Create an SharePoint Add-in](#bkmk_CreateAnApp)
-    
-  
--  [Create an external content type](#bkmk_CreateECT)
-    
-  
--  [Deploy the hybrid app](#bkmk_DeployHybridApp)
-    
-  
+Follow these steps to create a hybrid app
+
+- [Prepare the data source](#prepare-the-data-source)
+- [Create an SharePoint Add-in](#create-an-sharepoint-add-in)
+- [To add an external content ty](#to-add-an-external-content-type)
+- [Deploy the hybrid app](#deploy-the-hybrid-app)
 
 ### Prepare the data source
-<a name="bkmk_PrepareDataSource"> </a>
 
-Most of the time, the data source is already in place and is servicing any number of business applications. However, that data may only be available from inside the corporate security infrastructure. If your data does exist on a server located on the inside of a corporate firewall, or is secured by some other means, the next step is to expose that data to BCS, which is also housed inside the firewall. A network device is configured to translate calls from SharePoint Online to the internal SharePoint farm. This device is referred to as a "reverse proxy" and allows the SharePoint Add-in located in the cloud to call into BCS located inside the firewall. BCS handles all the data connectivity from there.
-  
-    
-    
-To make this data available to BCS, you should expose it as an OData source. You do this by creating an Internet Information Services (IIS) website that will host the service and allow BCS to talk to the data source through OData and Representational State Transfer (REST) endpoints.
-  
-    
-    
+Most of the time, the data source is already in place and is servicing any number of business applications. However, that data may only be available from inside the corporate security infrastructure. If your data does exist on a server located on the inside of a corporate firewall, or is secured by some other means, the next step is to expose that data to BCS, which is also housed inside the firewall. A network device is configured to translate calls from SharePoint Online to the internal ShePoint farm. This device is referred to as a "reverse proxy" and allows the SharePoint Add-in located in the cloud to call into BCS located inside the firewall. BCS handles all the data connectivity from there.
+
+To make this data available to BCS, you should expose it as an OData source. You do this by creating an Internet Information Services (IIS) website that will host the service and allow BCS to talk to the data source through OData and Representational State Transfer (REST) endpoints
+
 To create an OData endpoint, you will need to follow these steps for creating a Windows Communication Foundation (WCF) data service.
-  
-    
-    
-
-### To create a WCF data service
-
 
 1. Create an IIS website running at least Microsoft .NET Framework 4. Secure the site using basic authentication.
-    
+
     > [!NOTE]
-    > It's not necessary for SharePoint to be installed on this server. In fact, for the sake of simplicity and performance, it's better if SharePoint is not installed on the server that hosts the WCF data service. 
+    > It's not necessary for SharePoint to be installed on this server. In fact, for the sake of simplicity and performance, it's better if SharePoint is not installed on the server thathosts the WCF data service
 
-2. Create a new project in Visual Studio 2012 using the **ASP.NET Empty Web Application** template.
-    
-  
-3. In **Solution Explorer** add a new **ADO.NET Entity Data Model**.
-    
-  
-4. Choose the **Generate from database** option in the **Entity Data Model Wizard**.
-    
-  
-5. Select an existing connection, or create a new one.
-    
-  
-6. Provide the URL and connection security information.
-    
-  
-7. Select the items that you want to include in the model, and choose **Finish**.
-    
-  
-8. Again in **Solution Explorer**, add a new **WCF Data Service** using the Visual Studio template.
-    
-  
-9. Name the data service, and choose **Next**.
-    
+1. Create a new project in Visual Studio 2012 using the **ASP.NET Empty Web Application** template.
+1. In **Solution Explorer** add a new **ADO.NET Entity Data Model**.
+1. Choose the **Generate from database** option in the **Entity Data Model Wizard**.
+1. Select an existing connection, or create a new one.
+1. Provide the URL and connection security information.
+1. Select the items that you want to include in the model, and choose **Finish**.
+1. Again in **Solution Explorer**, add a new **WCF Data Service** using the Visual Studio template.
+1. Name the data service, and choose **Next**.
+
     At this point, the entity model will be created and the resulting classes will be included in your project.
-    
-  
-10. Set the security to the entities created by replacing the  `/* TODO: put your data source class name here */` with the class name of the entity model you just created and specifying which entities you want to grant permissions to.
-    
-  
-For a complete tutorial of how to set this up, see the following: 
-  
-    
-    
 
--  [Getting Started With OData Part 1: Building an OData Service](https://msdn.microsoft.com/data/gg601462)
-    
-  
--  [Quickstart (WCF Data Services)](https://msdn.microsoft.com/library/cc668796.aspx)
-    
-  
+1. Set the security to the entities created by replacing the  `/* TODO: put your data source class name here */` with the class name of the entity model you just created and specifying which entities you want to grant permissions to.
+
+For a complete tutorial of how to set this up, see the following:
+
+- [Getting Started With OData Part 1: Building an OData Service](https://msdn.microsoft.com/data/gg601462)
+- [Quickstart (WCF Data Services)](https://msdn.microsoft.com/library/cc668796.aspx)
 
 ### Create an SharePoint Add-in
-<a name="bkmk_CreateAnApp"> </a>
 
-One of the assumptions we are making here is that you are developing your app inside the corporate firewall. This represents a scenario where a developer working for a company would have a computer located behind the protection of the security infrastructure, developing and testing the app until it is ready to be deployed. This simplifies the process of connecting to the data source from Visual Studio, and uses Office Developer Tools for Visual Studio 2013 to automatically generate the external content type in the next step.
-  
-    
-    
+One of the assumptions we are making here is that you are developing your app inside the corporate firewall. This represents a scenario where a developer working for a company would have a computer located behind the protection of the security infrastructure, developing and testing the app until it is ready to be deployed. This simplifies the process of connecting to the data source from Visual Studio, and uses Office Developer Tools for Visual Studio 2013 to automatically generate the external content type in e next step.
 
 ### To create a new app
 
-
-1. Open Visual Studio 2012 on your development computer that has Office Developer Tools for Visual Studio 2013 and SharePoint installed.
-    
-  
-2. Create a new app for SharePoint.
-    
-  
-3. Specify the name of the app, the local SharePoint URL that will host your site for testing, and how you want the app to be hosted. Choose **Finish**.
-    
-  
-
-### Create an external content type
-<a name="bkmk_CreateECT"> </a>
+1. Open Visual Studio 2012 on your development computer that has Office Developer Tools for Visual Studio 2013 and SharePoint stalled.
+1. Create a new app for SharePoint.
+1. Specify the name of the app, the local SharePoint URL that will host your site for testing, and ### Create an external content type
 
 To add a BDC model or external content type to your project, do the following.
-  
-    
-    
 
 ### To add an external content type
 
-
 1. With your new project still open, open the shortcut menu for the solution, and choose **Add**, **Content types for an External Data source**.
-    
-  
-2. The first page of the wizard is used to specify the URL of the data service. On the **Specify OData Source** page, enter the URL of the OData service that you want to connect to. The URL should resemble the following: **http://services.odata.org/Northwind/Northwind.svc/**.
-    
-  
-3. Choose a name for your OData source, and then choose **Next**.
-    
-  
-4. A list of data entities that are being exposed by the OData service appears. Make sure that the **Create list instances for the selected data entities** check box is selected.
-    
-  
-5. Select one or more of the entities, and choose **Finish**.
-    
-  
-6. The last thing you have to do before deployment is modify the URL in your newly created external content type file.
-    
-    Open the .ect file in an XML editor.
-    
-  
-7. Modify the  `ODataServiceMetadataUrl` property to point to the URL that allows access through the reverse proxy.
-    
-  
-8. Modify the  `ODataServiceUrl` property with the URL that allows access through the reverse proxy.
-    
-  
+1. The first page of the wizard is used to specify the URL of the data service. On the **Specify OData Source** page, enter the URL of the OData service that you want to connect to. The URL should resemble the following: `http://services.odata.org/Northwind/Northwind.svc/`.
+1. Choose a name for your OData source, and then choose **Next**.
+1. A list of data entities that are being exposed by the OData service appears. Make sure that the
+1. The last thing you have to do before deployment is modify the URL in your newly created external content type file.
+
+    Open the **\*.ect** file in an XML editor.
+
+1. Modify the  `ODataServiceMetadataUrl` property to point to the URL that allows access through the reverse proxy.
+1. Modify the  `ODataServiceUrl` property with the URL that allows access through the reverse proxy.
+
 For information about how to add an OData-based external content type, see  [How to: Create an external content type from an OData source in SharePoint](how-to-create-an-external-content-type-from-an-odata-source-in-sharepoint.md).
-  
-    
-    
 
 ### Deploy the hybrid app
-<a name="bkmk_DeployHybridApp"> </a>
 
 When it is time to deploy your app, you have a couple of choices. You can deploy it directly to a tenancy using F5 deployment, or you can package it using the publishing features of Visual Studio to create an .app file. This file can then be given to the SharePoint Online tenant administrator and uploaded.
-  
-    
-    
-For information about deploying SharePoint Add-ins, see the following: 
-  
-    
-    
 
--  [Deploying and installing SharePoint Add-ins: methods and options](https://msdn.microsoft.com/library/d15a74a7-3c10-485a-9885-7ef11aaa0d90%28Office.15%29.aspx)
-    
-  
--  [Publish SharePoint Add-ins by using Visual Studio](https://msdn.microsoft.com/library/8137d0fa-52e2-4771-8639-60af80f693bb%28Office.15%29.aspx)
-    
-  
-You can also take the BDCM file created for the external content type and extract that to be used at any level above the app. This is demonstrated in  [How to: Convert an add-in-scoped external content type to tenant-scoped](how-to-convert-an-add-in-scoped-external-content-type-to-tenant-scoped.md).
-  
-    
-    
+For information about deploying SharePoint Add-ins, see the following:
+
+- [Deploying and installing SharePoint Add-ins: methods and options](https://msdn.microsoft.com/library/d15a74a7-3c10-485a-9885-7ef11aaa0d90%28Office.15%29.aspx
+
+- [Publish SharePoint Add-ins by using Visual Studio](https://msdn.microsoft.com/library/8137d0fa-52e2-4771-8639-60af80f693bb%28Office.15%29.aspx)
+
+You can also take the BDCM file created for the external content type and extract that to be used at any level above the app. This is demonstrated in [How to: Convert an add-in-scoped external
 
 ## See also
-<a name="bk_addresources"> </a>
 
-
--  [Hybrid for SharePoint](https://technet.microsoft.com/library/jj838715.aspx)
-    
-  
--  [Business Connectivity Services in SharePoint](business-connectivity-services-in-sharepoint.md)
-    
-  
--  [How to: Create an external content type from an OData source in SharePoint](how-to-create-an-external-content-type-from-an-odata-source-in-sharepoint.md)
-    
-  
--  [Publish SharePoint Add-ins by using Visual Studio](https://msdn.microsoft.com/library/8137d0fa-52e2-4771-8639-60af80f693bb%28Office.15%29.aspx)
-    
-  
-
+- [Hybrid for SharePoint](https://technet.microsoft.com/library/jj838715.aspx)
+- [Business Connectivity Services in SharePoint](business-connectivity-services-in-sharepoint.md)
+- [How to: Create an external content type from an OData source in SharePoint](how-to-create-an-external-content-type-from-an-odata-source-in-sharepoint.md)

--- a/docs/general-development/creating-a-workflow-by-using-sharepoint-designer-and-the-sharepoint-wo.md
+++ b/docs/general-development/creating-a-workflow-by-using-sharepoint-designer-and-the-sharepoint-wo.md
@@ -1,212 +1,86 @@
 ---
 title: Creating a workflow by using SharePoint Designer 2013 and the SharePoint Workflow platform
 description: This is an article with links to learn about creating a workflow by using SharePoint Designer 2013 and the SharePoint Workflow platform.
-ms.date: 06/07/2022
+ms.date: 05/09/2023
 ms.assetid: c05e0127-c6f5-48b8-b8f2-cbcc30149c8b
 ms.localizationpriority: high
 ---
-
-
 # Creating a workflow by using SharePoint Designer 2013 and the SharePoint Workflow platform
-Learn how to install, open, and create a workflow by using SharePoint Designer 2013 and the SharePoint Workflow platform. 
-   
-> [!NOTE]
-> SharePoint 2010 workflows have been retired since August 1, 2020 for new tenants and removed from existing tenants on November 1, 2020. If you’re using SharePoint 2010 workflows, we recommend migrating to Power Automate or other supported solutions. For more info, see [SharePoint 2010 workflow retirement](https://support.microsoft.com/office/sharepoint-2010-workflow-retirement-1ca3fff8-9985-410a-85aa-8120f626965f).
 
+Learn how to install, open, and create a workflow by using SharePoint Designer 2013 and the SharePoint Workflow platform.
+
+> [!CAUTION]
+> SharePoint 2010 workflows have been retired since August 1, 2020 for new tenants and removed from existing tenants on November 1, 2020. If you’re using SharePoint 2010 workflows, we recommend migrating to Power Automate or other supported solutions. For more information, see [SharePoint 2010 workflow retirement](https://support.microsoft.com/office/sharepoint-2010-workflow-retirement-1ca3fff8-9985-410a-85aa-8120f626965f).
+
+> [!CAUTION]
+> SharePoint 2013 workflows are scheduled for retirement in April 2024. For more information, see: [SharePoint 2013 workflow retirement](https://support.microsoft.com/office/sharepoint-2013-workflow-retirement-4613d9cf-69aa-40f7-b6bf-6e7831c9691e).
 
 ## Install SharePoint Designer 2013
-<a name="section1"> </a>
 
-SharePoint Designer 2013 is a free download. To download and install SharePoint Designer 2013 follow these steps: 
-  
-    
-    
+SharePoint Designer 2013 is a free download. To download and install SharePoint Designer 2013 follow these steps:
 
 ### To install SharePoint Designer 2013
 
-
-1. Open your web browser and navigate to the Microsoft Download Center:  [https://www.microsoft.com/download](https://www.microsoft.com/download). 
-    
-  
-2. Type SharePoint Designer 2013 in the search field.
-    
-  
-3. Click the link for "SharePoint Designer 2013". 
-    
-  
-4. Read the overview, system requirements, and installation instructions. Make sure your system is compatible. 
-    
-  
-5. Select your platform type: 64-bit ( **x64**) or 32-bit ( **x86**) as shown in the figure. 
-    
-  
-6. Follow the instructions to install SharePoint Designer 2013.
-    
-  
+1. Open your web browser and navigate to the Microsoft Download Center:  [https://www.microsoft.com/download](https://www.microsoft.com/download).
+1. Type SharePoint Designer 2013 in the search field.
+1. Click the link for "SharePoint Designer 2013".
+1. Read the overview, system requirements, and installation instructions. Make sure your system is compatible.
+1. Select your platform type: 64-bit ( **x64**) or 32-bit ( **x86**) as shown in the figure.
+1. Follow the instructions to install SharePoint Designer 2013.
 
 **Figure: SharePoint Designer 2013 download page**
 
-  
-    
-    
-
-  
-    
-    
 ![The SharePoint Designer 2013 Download page.](../images/SPD15-install-connect-1.png)
-  
-    
-    
-
-  
-    
-    
-
-  
-    
-    
 
 ## Open SharePoint Designer 2013 and connect to a SharePoint site
-<a name="section2"> </a>
 
-SharePoint Designer 2013 installs as an Office 2013 application. To open SharePoint Designer 2013 and connect to a SharePoint site follow these steps: 
-  
-    
-    
-2013
+SharePoint Designer 2013 installs as an Office 2013 application. To open SharePoint Designer 2013 and connect to a SharePoint site follow these steps:
+
 ### To open SharePoint Designer 2013 and connect to a SharePoint site
 
-
-1. Open SharePoint Designer 2013 by selecting it on the **Start** menu. Click **Start** icon, click **All Programs**, click **Microsoft Office 2013**, and then click **SharePoint Designer 2013**. 
-    
-  
-2. Click **Open Site** on the SharePoint Designer 2013 start page.
-    
-  
-3. Enter the SharePoint site that you want to connect to. For example, http://www.contoso.com/sites/a-sharepoint-site.
-    
-  
-4. Click **Open** to open the site.
-    
-  
-5. Enter your credentials, if prompted. (If security is not integrated with the computer you signed in on then you are prompted to enter your credentials.) Make sure to use credentials that have access to the SharePoint site.
-    
-  
+1. Open SharePoint Designer 2013 by selecting it on the **Start** menu. Click **Start** icon, click **All Programs**, click **Microsoft Office 2013**, and then click **SharePoint Designer 2013**.
+1. Click **Open Site** on the SharePoint Designer 2013 start page.
+1. Enter the SharePoint site that you want to connect to. For example, `https://www.contoso.com/sites/a-sharepoint-site`.
+1. Click **Open** to open the site.
+1. Enter your credentials, if prompted. (If security is not integrated with the computer you signed in on then you are prompted to enter your credentials.) Make sure to use credentials that have access to the SharePoint site.
 
 ## Create a List workflow based on the SharePoint Workflow platform
-<a name="section3"> </a>
 
 SharePoint Designer 2013 can be used for many important tasks. The navigational pane is used to switch between different aspects of SharePoint Designer 2013. To create a new List workflow based on the SharePoint Workflow platform, follow these steps:
-  
-    
-    
 
 ### To create a workflow based on the SharePoint Workflow platform
 
-
 1. Click the Workflows node in the Navigation pane.
-    
-  
-2. Click the **List Workflow** drop-down in the **New** section of the ribbon, as shown in the figure.
-    
-  
-3. Select the list that you want to associate with the new workflow.
-    
-  
-4. On the **Create List Workflow** dialog box, enter a name and description for the workflow and then make sure that the **Platform Type** is set to **SharePoint 2013 Workflow**, as shown in the figure.
-    
-    > [!NOTE]
-    > If you do not see SharePoint Workflow as an available platform type then Workflow Manager is not configured to work with the SharePoint farm. See [Configure Workflow Manager to work with the SharePoint Server 2013 Farm](https://technet.microsoft.com/library/jj658588.aspx#section5). 
+1. Click the **List Workflow** drop-down in the **New** section of the ribbon, as shown in the figure.
+1. Select the list that you want to associate with the new workflow.
+1. On the **Create List Workflow** dialog box, enter a name and description for the workflow and then make sure that the **Platform Type** is set to **SharePoint 2013 Workflow**, as shown in the figure.
 
-5. Click **OK** to create the workflow.
-    
-  
+    > [!NOTE]
+    > If you do not see SharePoint Workflow as an available platform type then Workflow Manager is not configured to work with the SharePoint farm. See [Configure Workflow Manager to work with the SharePoint Server 2013 Farm](https://technet.microsoft.com/library/jj658588.aspx#section5).
+
+1. Click **OK** to create the workflow.
 
 **Figure: The ribbon button for creating a new list workflow**
 
-  
-    
-    
-
-  
-    
-    
 ![SharePoint Designer 2013 - New List Workflow](../images/SPD15-install-connect-2.png)
-  
-    
-    
-
-  
-    
-    
-
-  
-    
-    
 
 **Figure: Create List Workflow dialog box**
 
-  
-    
-    
-
-  
-    
-    
 ![Workflow Creation Dialog](../images/SPD15-install-connect-3.png)
-  
-    
-    
 
-  
-    
-    
-
-  
-    
-    
-Now that the workflow is created, you can add Actions, Conditions, Stages, Steps, and Loops to build your workflow. These workflow components are available in the ribbon of SharePoint Designer 2013, as shown in the figure. 
-  
-    
-    
+Now that the workflow is created, you can add Actions, Conditions, Stages, Steps, and Loops to build your workflow. These workflow components are available in the ribbon of SharePoint Designer 2013, as shown in the figure.
 
 **Figure: Workflow items for the SharePoint Workflow platform**
 
-  
-    
-    
-
-  
-    
-    
 ![Workflow items in the ribbon.](../images/SPD15-install-connect-4.png)
-  
+
 > [!NOTE]
 > The previous procedure is used to create a List workflow. A Reusable workflow or Site workflow can be created using the same procedure with the following modification. Instead of selecting the List Workflow button in the ribbon select the **Reusable Workflow** or **Site Workflow** button when creating the workflow.
-  
-    
-    
 
 To learn more about the available components of workflow development, see  [Workflow actions quick reference (SharePoint Workflow platform)](workflow-actions-quick-reference-sharepoint-workflow-platform.md).
-  
-    
-    
 
 ## See also
-<a name="bk_addresources"> </a>
 
-
--  [What's new in workflow in SharePoint](https://msdn.microsoft.com/library/6ab8a28b-fa2f-4530-8b55-a7f663bf15ea.aspx)
-    
-  
--  [Getting started with SharePoint workflow](https://msdn.microsoft.com/library/cc73be76-a329-449f-90ab-86822b1c2ee8.aspx)
-    
-  
--  [Workflow development in SharePoint Designer and Visio](workflow-development-in-sharepoint-designer-and-visio.md)
-    
-  
-
-  
-    
-    
-
+- [What's new in workflow in SharePoint](https://msdn.microsoft.com/library/6ab8a28b-fa2f-4530-8b55-a7f663bf15ea.aspx)
+- [Getting started with SharePoint workflow](https://msdn.microsoft.com/library/cc73be76-a329-449f-90ab-86822b1c2ee8.aspx)
+- [Workflow development in SharePoint Designer and Visio](workflow-development-in-sharepoint-designer-and-visio.md)

--- a/docs/general-development/custom-content-processing-with-the-content-enrichment-web-service-callout.md
+++ b/docs/general-development/custom-content-processing-with-the-content-enrichment-web-service-callout.md
@@ -1,177 +1,96 @@
 ---
 title: Custom content processing with the Content Enrichment web service callout
 description: This is an article to learn about custom content processing with the Content Enrichment web service callout.
-ms.date: 06/07/2022
+ms.date: 05/18/2023
 ms.assetid: bdda92c8-9c8d-416e-9a6b-4a9373686fa0
 ms.localizationpriority: medium
 ---
-
-
 # Custom content processing with the Content Enrichment web service callout
-Learn about the content enrichment web service callout in SharePoint that enables developers to create an external web service to modify managed properties for crawled items during content processing.
-Search in SharePoint enables users to modify the managed properties of crawled items before they are indexed by calling out to an external content enrichment web service. The ability to modify managed properties for items during content processing is helpful when performing tasks such as data cleansing, entity extraction, classification, and tagging.
-  
-    
-    
 
+Learn about the content enrichment web service callout in SharePoint that enables developers to create an external web service to modify managed properties for crawled items during content processing.
+
+Search in SharePoint enables users to modify the managed properties of crawled items before they are indexed by calling out to an external content enrichment web service. The ability to modify managed properties for items during content processing is helpful when performing tasks such as data cleansing, entity extraction, classification, and tagging.
+
+![Content enrichment within content processing](../images/SP15_Content_Enrichment.gif)
 
 **Figure 1. Content enrichment within content processing**
 
-  
-    
-    
+Figure 1 shows a part of the process that takes place in the content processing component. The content enrichment web service is a SOAP-based service that you can create to receive a callout from the web service client inside the content processing component. Based on Figure 1, the web service client refers to the Content Enrichment operator inside the content processing component; the web service refers to the SOAP web service that you implement.The web service receives a configurable payload from the content processing component. Then, the resulting response from the web service is merged into the crawled item before it is added to the search index. The web service client works with managed properties that you can configure as input properties or as output properties. Input properties are sent to the web service; output properties are returned by the web service. Certain managed properties are hidden or are read-only and can't be sent to the web service or received from the web service. See [How to list all read-only managed properties for the Content Enrichment web service](#how-to-list-all-read-only-managed-properties-for-the-content-enrichment-web-service) for information about how to verify which managed properties are read-only.
 
-  
-    
-    
-![Content enrichment within content processing](../images/SP15_Content_Enrichment.gif)
-  
-    
-    
-Figure 1 shows a part of the process that takes place in the content processing component. The content enrichment web service is a SOAP-based service that you can create to receive a callout from the web service client inside the content processing component. Based on Figure 1, the web service client refers to the Content Enrichment operator inside the content processing component; theweb service refers to the SOAP web service that you implement.The web service receives a configurable payload from the content processing component. Then, the resulting response from the web service is merged into the crawled item before it is added to the search index. The web service client works with managed properties that you can configure as input properties or as output properties. Input properties are sent to the web service; output properties are returned by the web service. Certain managed properties are hidden or are read-only and can't be sent to the web service or received from the web service. See  [How to list all read-only managed properties for the Content Enrichment web service](#SP15contentprocess_read-only_managed_properties) for information about how to verify which managed properties are read-only.
-    
-> **Important:**
-> The content enrichment callout step can only be configured with a single web service endpoint. Any kind of fault tolerance, or routing capabilities to support multiple implementations must be handled by the developer implementing the web service. In addition, the developer may have various web service implementations hosted at different endpoints; however, at any given time, only one of these endpoints can be used in the configuration. 
-  
-    
-    
-
+> [!IMPORTANT]
+> The content enrichment callout step can only be configured with a single web service endpoint. Any kind of fault tolerance, or routing capabilities to support multiple implementations must be handled by the developer implementing the web service. In addition, the developer may have various web service implementations hosted at different endpoints; however, at any given time, only one of these endpoints can be used in the configuration.
 
 ## Content enrichment web service contract
-<a name="SP15webservcallout_enrich"> </a>
 
 The web service client is a SOAP (version 1.1) RPC client with a predefined behavior. The web service contract has the following characteristics:
-  
-    
-    
 
 - The content processing component sends a SOAP RPC call to a configurable endpoint over HTTP.
-    
-  
 - The payload contains an array of property objects.
-    
-  
 - The web service performs some custom logic on the array of property objects, and returns an array of modified or new property objects.
-    
-  
 - The web service must send a response to the web service client within a given timeout.
-    
-  
 - No specific authentication or encryption mechanisms are supported as part of the contract. You can, however, apply your own security on the transport mechanism.
-    
-  
 
 ## Configuring the Content Enrichment web service client
-<a name="content_enrichment_configuration"> </a>
 
 To configure the web service client, you use the following Windows PowerShell cmdlets:
-  
-    
-    
 
--  [Get-SPEnterpriseSearchContentEnrichmentConfiguration](https://technet.microsoft.com/library/jj219783%28office.15%29.aspx)
-    
-  
--  [Set-SPEnterpriseSearchContentEnrichmentConfiguration](https://technet.microsoft.com/library/jj219659%28office.15%29.aspx)
-    
-  
--  [Remove-SPEnterpriseSearchContentEnrichmentConfiguration](https://technet.microsoft.com/library/jj219742%28office.15%29.aspx)
-    
-  
--  [New-SPEnterpriseSearchContentEnrichmentConfiguration](https://technet.microsoft.com/library/jj219502%28office.15%29.aspx)
-    
-  
+- [Get-SPEnterpriseSearchContentEnrichmentConfiguration](https://technet.microsoft.com/library/jj219783%28office.15%29.aspx)
+- [Set-SPEnterpriseSearchContentEnrichmentConfiguration](https://technet.microsoft.com/library/jj219659%28office.15%29.aspx)
+- [Remove-SPEnterpriseSearchContentEnrichmentConfiguration](https://technet.microsoft.com/library/jj219742%28office.15%29.aspx)
+- [New-SPEnterpriseSearchContentEnrichmentConfiguration](https://technet.microsoft.com/library/jj219502%28office.15%29.aspx)
+
 Table 1 lists the properties you can configure through the Windows PowerShell cmdlets mentioned previously.
-  
-    
-    
 
 **Table 1. Properties that are configurable for the client by using Windows PowerShell cmdlets**
 
-
-|**Configuration property**|**Description**|**Default value**|
-|:-----|:-----|:-----|
-|**Endpoint** <br/> |Specifies the URL of the external web service.  <br/> |Empty.  <br/> |
-|**InputProperties** <br/> |The managed properties that the external web service receives.  <br/> |Empty.  <br/> |
-|**OutputProperties** <br/> |The managed properties that the external web service returns.  <br/> |Empty.  <br/> |
-|**Timeout** <br/> |The amount of time until the web service times out in milliseconds.  <br/> Depending on **FailureMode**, the item fails to be processed or a warning is written to the ULS log. <br/> |5000 milliseconds; Valid range [100, 30000].  <br/> |
-|**SendRawData** <br/> |Enables or disables sending raw data to the web service.  <br/> |False.  <br/> |
-|**MaxRawDataSize** <br/> |The maximum size of raw data sent to the web service in kilobytes (KB). If the binary data of an item exceeds this limit, the item is not sent. This does not prevent the **InputProperties** from being sent, and the **OutputProperties** from being received. <br/> |5120 kilobytes.  <br/> |
-|**FailureMode** <br/> |Controls the behavior of the web service client when errors occur. When **FailureMode** is set to **ERROR**, any problems that occur during content enrichment processing send a failed callback for that particular item.  <br/> When **FailureMode** is set to **WARNING**, the item is indexed, without any modifications by the web service and a warning is written to the ULS log.  <br/> |Error.  <br/> |
-|**DebugMode** <br/> |A mode that when set to **true** enables the content enrichment client to send all managed properties to the client without expecting any properties in return. Any configured **Trigger** property, **InputProperties** property, and **OutputProperties** property are ignored. <br/> |False.  <br/> |
-|**Trigger** <br/> |A **Boolean** predicate that is executed on every crawled item. If the predicate evaluates to **true**, the record is sent to the web service. Otherwise, the item is passed through to the search index. <br/> |Empty.  <br/> |
-   
+| **Configuration property** |                                                                                                                                                                                  **Description**                                                                                                                                                                                   |              **Default value**               |
+| :------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------- |
+| **Endpoint**               | Specifies the URL of the external web service.                                                                                                                                                                                                                                                                                                                                     | Empty.                                       |
+| **InputProperties**        | The managed properties that the external web service receives.                                                                                                                                                                                                                                                                                                                     | Empty.                                       |
+| **OutputProperties**       | The managed properties that the external web service returns.                                                                                                                                                                                                                                                                                                                      | Empty.                                       |
+| **Timeout**                | The amount of time until the web service times out in milliseconds.  Depending on **FailureMode**, the item fails to be processed or a warning is written to the ULS log.                                                                                                                                                                                                          | 5000 milliseconds; Valid range [100, 30000]. |
+| **SendRawData**            | Enables or disables sending raw data to the web service.                                                                                                                                                                                                                                                                                                                           | False.                                       |
+| **MaxRawDataSize**         | The maximum size of raw data sent to the web service in kilobytes (KB). If the binary data of an item exceeds this limit, the item is not sent. This does not prevent the **InputProperties** from being sent, and the **OutputProperties** from being received.                                                                                                                   | 5120 kilobytes.                              |
+| **FailureMode**            | Controls the behavior of the web service client when errors occur. When **FailureMode** is set to **ERROR**, any problems that occur during content enrichment processing send a failed callback for that particular item.  When **FailureMode** is set to **WARNING**, the item is indexed, without any modifications by the web service and a warning is written to the ULS log. | Error.                                       |
+| **DebugMode**              | A mode that when set to **true** enables the content enrichment client to send all managed properties to the client without expecting any properties in return. Any configured **Trigger** property, **InputProperties** property, and **OutputProperties** property are ignored.                                                                                                  | False.                                       |
+| **Trigger**                | A **Boolean** predicate that is executed on every crawled item. If the predicate evaluates to **true**, the record is sent to the web service. Otherwise, the item is passed through to the search index.                                                                                                                                                                          | Empty.                                       |
 
 ### How to list all read-only managed properties for the Content Enrichment web service
-<a name="SP15contentprocess_read-only_managed_properties"> </a>
 
 Certain managed properties are read-only and cannot be output from the web service. These properties can be listed by using the  [Get-SPEnterpriseSearchServiceApplication](https://technet.microsoft.com/library/ff608050%28office.15%29.aspx) and [Get-SPEnterpriseSearchMetadataManagedProperty](https://technet.microsoft.com/library/ff607560%28office.15%29.aspx)Windows PowerShell cmdlets, shown in the following example:
-  
-    
-    
 
-```
-
+```powershell
 $ssa = Get-SPEnterpriseSearchServiceApplication
 Get-SPEnterpriseSearchMetadataManagedProperty -SearchApplication $ssa  | ?{$_.IsReadOnly -or $_.MappingDisallowed -or $_.DeleteDisallowed}
-
 ```
 
-
 ## About trigger conditions for configuring the web service callout
-<a name="SP15contentprocess_trigger"> </a>
 
 A trigger condition is an expression that is used to configure the web service callout. If a trigger condition evaluates to **true**, the web service client performs a callout for that record. If a trigger condition evaluates to **false**, the web service client does not perform a callout and passes the crawled item to the search index. Alternatively, if no trigger condition is configured; all items are sent to the web service.
-  
-    
-    
-Trigger conditions use an expression language to refer to the values of managed properties. You can use the operators and functions in the expression language to build simple or complex trigger conditions so you can determine when to perform a web service callout. 
-  
-    
-    
+
+Trigger conditions use an expression language to refer to the values of managed properties. You can use the operators and functions in the expression language to build simple or complex trigger conditions so you can determine when to perform a web service callout.
+
 Table 2 lists examples of trigger conditions.
-  
-    
-    
 
 **Table 2. Trigger condition examples for configuring the Content Enrichment web service callout**
 
+|             **Expression**              |                                                         **Description**                                                         |                        **Requirements**                        |
+| :-------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------- |
+| MP1 > 2                                 | Returns **true** if the value of the managed property named MP1 is greater than 2.                                              | MP1 must have a numeric type.                                  |
+| IsNull(MP2)                             | Returns **true** if the managed property named MP2 is not present for the crawled item or is empty/null.                        | MP2 can be of any type.                                        |
+| StartsWith(MP1, "sample") AND MP2 != 18 | Returns **true** if the value in the managed property MP1 starts with "sample" and the value of managed property MP2 is not 18. | MP1 must be of type **string** and MP2 must be a numeric type. |
+| IsDay(MP1, 2009, 12, 24)                | Checks whether the managed property MP1 contains a **DateTime** that falls on December 24, 2009.                                | MP1 must be of type **DateTime**.                              |
 
-|**Expression**|**Description**|**Requirements**|
-|:-----|:-----|:-----|
-|MP1 > 2  <br/> |Returns **true** if the value of the managed property named MP1 is greater than 2. <br/> |MP1 must have a numeric type.  <br/> |
-|IsNull(MP2)  <br/> |Returns **true** if the managed property named MP2 is not present for the crawled item or is empty/null. <br/> |MP2 can be of any type.  <br/> |
-|StartsWith(MP1, "sample") AND MP2 != 18  <br/> |Returns **true** if the value in the managed property MP1 starts with "sample" and the value of managed property MP2 is not 18. <br/> |MP1 must be of type **string** and MP2 must be a numeric type. <br/> |
-|IsDay(MP1, 2009, 12, 24)  <br/> |Checks whether the managed property MP1 contains a **DateTime** that falls on December 24, 2009. <br/> |MP1 must be of type **DateTime**.  <br/> |
-   
-See  [Trigger expressions syntax in SharePoint](trigger-expressions-syntax-in-sharepoint.md) for the elements that can be used in a trigger expression and a list of supported functions.
-  
-    
-    
+See [Trigger expressions syntax in SharePoint](trigger-expressions-syntax-in-sharepoint.md) for the elements that can be used in a trigger expression and a list of supported functions.
 
 ## Implementing the Content Enrichment external web service
-<a name="SP15contentprocess_implement"> </a>
 
-For a basic implementation, do the following: 
-  
-    
-    
+For a basic implementation, do the following:
 
 1. Include the **Microsoft.Office.Server.Search.ContentProcessingEnrichment.dll** located in `C:\\Program Files\\Microsoft Office Servers\\15.0\\Search\\Applications\\External` in your project as a reference.
-    
-  
-2. Implement **IContentProcessingEnrichmentService** as a web service.
-    
-  
+1. Implement **IContentProcessingEnrichmentService** as a web service.
 
 ## See also
-<a name="bk_addresources"> </a>
 
-
--  [Configure search in SharePoint](configure-search-in-sharepoint.md)
-    
-  
--  [Custom content processing with the Content Enrichment web service callout](custom-content-processing-with-the-content-enrichment-web-service-callout.md)
-    
-  
-
+- [Configure search in SharePoint](configure-search-in-sharepoint.md)
+- [Custom content processing with the Content Enrichment web service callout](custom-content-processing-with-the-content-enrichment-web-service-callout.md)

--- a/docs/general-development/custom-word-breakers-in-sharepoint-server.md
+++ b/docs/general-development/custom-word-breakers-in-sharepoint-server.md
@@ -1,293 +1,99 @@
 ---
 title: Custom word breakers in SharePoint
 description: Describes word breaking in SharePoint and provides steps on how to switch to a custom word breaker in SharePoint.
-ms.date: 06/09/2022
+ms.date: 05/09/2023
 ms.assetid: d18b48d4-987c-4228-9932-30d5b30f86a2
 ms.localizationpriority: medium
 ---
 
-
 # Custom word breakers in SharePoint
-Learn about word breaking in SharePoint. 
-Word breaking is one of the key Natural Language Processing (NLP) features that enable search and improve search results (or recall). Word breakers split a stream of text into individual words or tokens on which you can base additional language processing. Word breakers are language-specific. In addition to built-in word breakers, Search in SharePoint enables the use of custom word breakers so that users can tune word breaking behavior according to their needs. See  [Supported languages for word breaker customizations in SharePoint](#SP15_SupportedLanguages) for a list languages supported for word breaker customization.
-  
-    
-    
 
-For information on how to write a word breaker refer to the following articles 
--  [Implementing a Word Breaker](https://msdn.microsoft.com/library/ms693186%28v=vs.85%29.aspx)
-    
-  
--  [IWordBreaker interface](https://msdn.microsoft.com/library/ms691079%28v=vs.85%29.aspx)
-    
-  
+Word breaking is one of the key Natural Language Processing (NLP) features that enable search and improve search results (or recall). Word breakers split a stream of text into individual words or tokens on which you can base additional language processing. Word breakers are language-specific. In addition to built-in word breakers, Search in SharePoint enables the use of custom word breakers so that users can tune word breaking behavior according to their needs. See  [Supported languages for word breaker customizations in SharePoint](#supported-languages-for-word-breaker-customizations-in-sharepoint) for a list languages supported for word breaker customization.
+
+For information on how to write a word breaker refer to the following articles
+
+- [Implementing a Word Breaker](https://msdn.microsoft.com/library/ms693186%28v=vs.85%29.aspx)
+- [IWordBreaker interface](https://msdn.microsoft.com/library/ms691079%28v=vs.85%29.aspx)
 
 ## How to switch to a custom word breaker in SharePoint
-<a name="SP15wordbreaker_howto"> </a>
 
-
-> **Caution:**
-> When you replace existing word breakers, you modify the registry at your own risk. Serious problems might occur if you modify the registry incorrectly by using Registry Editor or by using another method. These problems might require that you reinstall the operating system. Microsoft cannot ensure that these problems can be solved. Switching to a different word breaker might also cause serious problems during indexing and querying. Before you modify the registry, back up the registry and ensure that you know how to restore the registry if a problem occurs. 
-  
-    
-    
+> [!CAUTION]
+> When you replace existing word breakers, you modify the registry at your own risk. Serious problems might occur if you modify the registry incorrectly by using Registry Editor or by using another method. These problems might require that you reinstall the operating system. Microsoft cannot ensure that these problems can be solved. Switching to a different word breaker might also cause serious problems during indexing and querying. Before you modify the registry, back up the registry and ensure that you know how to restore the registry if a problem occurs.
 
 Take the following steps to replace the existing word breaker with a custom word breaker or replace the existing word breaker with a word breaker in another language.
-  
-    
-    
 
 1. Open the Registry Editor, as follows:
-    
 1. Choose **Start**, and then choose **Run**.
-    
-  
-2. In the **Open** dialog box, type **Regedit**, and then choose **OK**.
-    
-  
-2. In Registry Editor, select the following registry subkey:
-    
+1. In the **Open** dialog box, type **Regedit**, and then choose **OK**.
+1. In Registry Editor, select the following registry subkey:
+
     **HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Office Server\\15.0\\Search\\Setup\\ContentIndexCommon\\LanguageResources\\Default\\** _language from the list below_
-    
-  
-3. In the right pane, open the shortcut menu for the **WBDLLPathOverride** registry value, and then choose **Modify**.
-    
-  
-4. In the **Edit String** dialog box, in the **Value data** box, type the path to your custom word breaker DLL, and then choose **OK**. The new DLL should be located in the same path as the existing DLL that is being replaced.
-    
-  
-5. In the right pane, open the shortcut menu for the **WBreakerClass** registry value, and then choose **Modify**.
-    
-  
-6. In the **Edit String** dialog box, in the **Value data** box, type the class ID of your custom word breaker, and then choose **OK**.
-    
-  
-7. Restart the SharePoint Search Host Controller and SharePoint.
-    
-  
-8. Do a full re-crawl.
-    
-  
+
+1. In the right pane, open the shortcut menu for the **WBDLLPathOverride** registry value, and then choose **Modify**.
+1. In the **Edit String** dialog box, in the **Value data** box, type the path to your custom word breaker DLL, and then choose **OK**. The new DLL should be located in the same path as the existing DLL that is being replaced.
+1. In the right pane, open the shortcut menu for the **WBreakerClass** registry value, and then choose **Modify**.
+1. In the **Edit String** dialog box, in the **Value data** box, type the class ID of your custom word breaker, and then choose **OK**
+
+    Restart the SharePoint Search Host Controller and SharePoint.
+
+1. Do a full re-crawl.
 
 ## Supported languages for word breaker customizations in SharePoint
-<a name="SP15_SupportedLanguages"> </a>
 
 The following languages are supported for word breaker customization:
-  
-    
-    
-Arabic
-  
-    
-    
-Bengali
-  
-    
-    
-Bulgarian
-  
-    
-    
-Catalan
-  
-    
-    
-Chinese (People's Republic of China)
-  
-    
-    
-Chinese (Taiwan)
-  
-    
-    
-Croatian
-  
-    
-    
-Czech
-  
-    
-    
-Danish
-  
-    
-    
-Dutch (Dutch)
-  
-    
-    
-English (United States)
-  
-    
-    
-Estonian
-  
-    
-    
-Finnish
-  
-    
-    
-French (Standard)
-  
-    
-    
-German (Standard)
-  
-    
-    
-Greek
-  
-    
-    
-Gujarati
-  
-    
-    
-Hebrew
-  
-    
-    
-Hindi
-  
-    
-    
-Hungarian
-  
-    
-    
-Icelandic
-  
-    
-    
-Indonesian
-  
-    
-    
-Italian (Default)
-  
-    
-    
-Japanese
-  
-    
-    
-Kannada
-  
-    
-    
-Kazakh
-  
-    
-    
-Korean
-  
-    
-    
-Latvian
-  
-    
-    
-Lithuanian
-  
-    
-    
-Malay
-  
-    
-    
-Malayalam
-  
-    
-    
-Marathi
-  
-    
-    
-Norwegian
-  
-    
-    
-Polish
-  
-    
-    
-Portuguese (Portuguese)
-  
-    
-    
-Punjabi
-  
-    
-    
-Romanian
-  
-    
-    
-Russian
-  
-    
-    
-Serbian (Cyrillic)
-  
-    
-    
-Slovak
-  
-    
-    
-Slovenian
-  
-    
-    
-Spanish (Modern Sort)
-  
-    
-    
-Swedish
-  
-    
-    
-Tamil
-  
-    
-    
-Telugu
-  
-    
-    
-Thai
-  
-    
-    
-Turkish
-  
-    
-    
-Ukrainian
-  
-    
-    
-Urdu
-  
-    
-    
-Vietnamese
-  
-    
-    
+
+- Arabic
+- Bengali
+- Bulgarian
+- Catalan
+- Chinese (People's Republic of China)
+- Chinese (Taiwan)
+- Croatian
+- Czech
+- Danish
+- Dutch (Dutch)
+- English (United States)
+- Estonian
+- Finnish
+- French (Standard)
+- German (Standard)
+- Greek
+- Gujarati
+- Hebrew
+- Hindi
+- Hungarian
+- Icelandic
+- Indonesian
+- Italian (Default)
+- Japanese
+- Kannada
+- Kazakh
+- Korean
+- Latvian
+- Lithuanian
+- Malay
+- Malayalam
+- Marathi
+- Norwegian
+- Polish
+- Portuguese (Portuguese)
+- Punjabi
+- Romanian
+- Russian
+- Serbian (Cyrillic)
+- Slovak
+- Slovenian
+- Spanish (Modern Sort)
+- Swedish
+- Tamil
+- Telugu
+- Thai
+- Ukrainian
+- Urdu
+- Vietnamese
 
 ## See also
-<a name="SP15wordbreakers_addresources"> </a>
 
-
--  [Configure search in SharePoint](configure-search-in-sharepoint.md)
-    
-  
--  [Implementing a Word Breaker](https://msdn.microsoft.com/library/ms693186%28v=vs.85%29.aspx)
-    
-  
--  [IWordBreaker interface](https://msdn.microsoft.com/library/ms691079%28v=vs.85%29.aspx)
-    
-  
-
+- [Configure search in SharePoint](configure-search-in-sharepoint.md)
+- [Implementing a Word Breaker](https://msdn.microsoft.com/library/ms693186%28v=vs.85%29.aspx)
+- [IWordBreaker interface](https://msdn.microsoft.com/library/ms691079%28v=vs.85%29.aspx)

--- a/docs/general-development/developing-with-duet-enterprise-2-0.md
+++ b/docs/general-development/developing-with-duet-enterprise-2-0.md
@@ -1,172 +1,89 @@
 ---
 title: Developing with Duet Enterprise 2.0
 description: Describes Duet Enterprise 2.0's features and details how to set up the developer environment, how to add an external content type, and more.
-ms.date: 06/09/2022
+ms.date: 05/09/2023
 ms.assetid: c3ef38aa-559e-4832-95c7-75e222c77624
 ms.localizationpriority: medium
 ---
 
-
 # Developing with Duet Enterprise 2.0
 
 ## Overview
-<a name="Overview"> </a>
 
 Duet Enterprise 2.0 is the latest version of a collaborative effort between Microsoft and SAP to give SharePoint users the ability to work with data from SAP systems.It combines components from SAP as well as SharePoint and SharePoint Online. It gives a developer the ability to create components that will allow users to bring data from SAP systems into the familiar SharePoint environment.
-  
-    
-    
 
 ## Features of Duet Enterprise 2.0
-<a name="Overview"> </a>
 
 When properly installed and configured, Duet Enterprise 2.0 will provide the following features:
-  
-    
-    
 
 - You can work with data in SAP systems within SharePoint using Business Data Web parts, External lists and custom components.
-    
-  
 - Use SAP data in SharePoint without code by using built-in components.
-    
-  
 - Use SAP reporting systems inside of an app.
-    
-  
 - Use special web parts installed with Duet Enterprise 2.0 to add SAP information to SharePoint pages
-    
-  
 - Use SAP workflow in an app.
-    
-  
 - Developers can use client-side JavaScript to interact with SAP external data.
-    
-  
 - Secure data using OAuth for authentication.
-    
-  
 
 ## Setting up the development environment
-<a name="SettingUp"> </a>
 
 Developing SharePoint Add-ins using Duet Enterprise 2.0, for the most part, is exactly the same as creating standard SharePoint Add-ins. You can use Visual Studio to extend your apps and work within the robust framework of the Visual Studio integrated development environment.
-  
-    
-    
 
 ## Adding external content types
-<a name="AddingECT"> </a>
 
 In order to access the external data housed on the SAP system, you will have to add an external content type. Since SAP data is exposed through OData endpoints, the auto-generation tools installed in Visual Studio can be used to  [How to: Create an external content type from an OData source in SharePoint](how-to-create-an-external-content-type-from-an-odata-source-in-sharepoint.md) that is scoped at the app level.
-  
-    
-    
+
 Follow these steps to create an external content type:
-  
-    
-    
 
 ### Creating an external content type from an SAP OData endpoint
 
 
 1. In **Solution Explorer**, open the shortcut menu for the project, and choose **Add**, **Content types for External Data source**.
-    
-  
-2. On the **Specify OData Source** page, enter the URL of the Duet Enterprise Workflow Service.
-    
-  
-3. Choose a name for your OData source.
-    
-  
-4. Select the entities that are needed.
-    
-  
-5. Choose **Finish**.
-    
-  
+1. On the **Specify OData Source** page, enter the URL of the Duet Enterprise Workflow Service.
+1. Choose a name for your OData source.
+1. Select the entities that are needed.
+1. Choose **Finish**.
+
 Visual Studio will create a new folder named External Content Types where you will find the newly created BDC model.
-  
-    
-    
 
 ## Configuring the BDC model
-<a name="ConfiguringProject"> </a>
 
 The most important thing to make the project work, is to add the **ODataExtensionProvider** property to the BDC model. This property defines the extension provider that provides BCS with the SAP extensions needed for creating app code.
-  
-    
-    
+
 This sample shows the properties added to the BDC model:
-  
-    
-    
 
-
-
-```XML
-
+```xml
 <LobSystem Type="OData" Name="LOB_SYSTEM_NAME">
-                     <Properties>
-                          <Property Name="ODataServiceMetadataUrl" Type="System.String">
-                               https://<DUET_METADATA_URL>:443/sap/opu/odata/sap/ 
-                               ZANDY_PO_HEADER_SRV/$metadata</Property>
-                          <Property Name="ODataServicesVersion" Type="System.String">2.0</Property>
-                          <Property Name="ODataExtensionProvider" Type="System.String"> 
-                               OBA.Server.Canary.ObaOdataServerExtensionProvider, 
-                               OBA.Server.SSOProvider, 
-                               Version=15.0.0.0, 
-                               Culture=neutral, 
-                               PublicKeyToken=71e9bce111e9429c</Property>
-                          <Property Name="TraceHeader" Type="System.String">SAP-PASSPORT</Property>
-                     </Properties>
-
+<Properties>
+    <Property Name="ODataServiceMetadataUrl" Type="System.String">
+          https://<DUET_METADATA_URL>:443/sap/opu/odata/sap/
+          ZANDY_PO_HEADER_SRV/$metadata</Property>
+    <Property Name="ODataServicesVersion" Type="System.String">2.0</Property>
+    <Property Name="ODataExtensionProvider" Type="System.String">
+          OBA.Server.Canary.ObaOdataServerExtensionProvider,
+          OBA.Server.SSOProvider,
+          Version=15.0.0.0,
+          Culture=neutral,
+          PublicKeyToken=71e9bce111e9429c</Property>
+    <Property Name="TraceHeader" Type="System.String">SAP-PASSPORT</Property>
+</Properties>
 ```
 
-
 ## Using Duet starter services to develop custom apps
-<a name="UsingDuetStarterServices"> </a>
 
-Duet Enterprise 2.0 installs several starter services to the file system on the SharePoint server. In a default installation, the files are found at C:\\Program Files\\Duet Enterprise\\2.0\\Solutions\\Starter Services. Among these are: 
-  
-    
-    
+Duet Enterprise 2.0 installs several starter services to the file system on the SharePoint server. In a default installation, the files are found at **C:\\Program Files\\Duet Enterprise\\2.0\\Solutions\\Starter Services**. Among these are:
 
 - OBACustomerWorkspace
-    
-  
 - OBAOrderToCash
-    
-  
 - OBAPortal
-    
-  
 - OBAProductCenter
-    
-  
+
 Each of these solutions contains WSP files, solution and other supporting files needed to implement them.
-  
-    
-    
+
 These solutions can be used to see what can be done with Duet Enterprise 2.0 and what the development patterns are, but they are not supported for use in SharePoint Add-ins.
-  
-    
-    
 
 ## See also
-<a name="ConNavExample_resources"> </a>
 
-
--  [Duet Enterprise for Microsoft SharePoint and SAP Server 2.0](https://technet.microsoft.com/library/ff972436.aspx)
-    
-  
--  [How to: Create an external content type from an OData source in SharePoint](how-to-create-an-external-content-type-from-an-odata-source-in-sharepoint.md)
-    
-  
--  [Visual Studio Developer Center](https://msdn.microsoft.com/vstudio/default)
-    
-  
--  [Office Development with Visual Studio](https://msdn.microsoft.com/office/hh133430)
-    
-  
-
+- [Duet Enterprise for Microsoft SharePoint and SAP Server 2.0](https://technet.microsoft.com/library/ff972436.aspx)
+- [How to: Create an external content type from an OData source in SharePoint](how-to-create-an-external-content-type-from-an-odata-source-in-sharepoint.md)
+- [Visual Studio Developer Center](https://msdn.microsoft.com/vstudio/default)
+- [Office Development with Visual Studio](https://msdn.microsoft.com/office/hh133430)

--- a/docs/general-development/discovery-in-excel-services-rest-api.md
+++ b/docs/general-development/discovery-in-excel-services-rest-api.md
@@ -1,153 +1,86 @@
 ---
 title: Discovery in Excel Services REST API
 description: Describes the discovery mechanisms built into the Excel Services REST API and provides code examples.
-ms.date: 06/09/2022
+ms.date: 05/09/2023
 ms.assetid: e3a8e057-f803-446d-81c9-4eb8ef3691e1
 ms.localizationpriority: medium
 ---
 
-
 # Discovery in Excel Services REST API
 
 This topic discusses the discovery mechanisms built into the Excel Services REST API.
-  
-> [!NOTE]
-> The Excel Services REST API applies to SharePoint and SharePoint 2016 on-premises. For Office 365 Education, Business, and Enterprise accounts, use the Excel REST APIs that are part of the  [Microsoft Graph](http://graph.microsoft.io/docs/api-reference/v1.0/resources/excel
-) endpoint.
-  
-    
-    
 
+> [!NOTE]
+> The Excel Services REST API applies to SharePoint and SharePoint 2016 on-premises. For Office 365 Education, Business, and Enterprise accounts, use the Excel REST APIs that are part of the [Microsoft Graph](/graph/api/overview) endpoint.
 
 ## Discovery Base URL and Discovery Example
 
-Discovery enables developers and users to discover information about and the content of a workbook manually or programmatically. The discovery mechanism supplies the  [Atom](http://tools.ietf.org/html/rfc4287) feed that contains information about the resources in a workbook. By using discovery, you can explore and view the resources in the workbook. Resources that you can explore and access are ranges, charts, tables, and PivotTables.
-  
-    
-    
+Discovery enables developers and users to discover information about and the content of a workbook manually or programmatically. The discovery mechanism supplies the [Atom](http://tools.ietf.org/html/rfc4287) feed that contains information about the resources in a workbook. By using discovery, you can explore and view the resources in the workbook. Resources that you can explore and access are ranges, charts, tables, and PivotTables.
+
 Following is the construct of the REST URL to a specific element in a workbook:
-  
-    
-    
 
-
-
-```
-
+```http
 http://<ServerName>/_vti_bin/ExcelRest.aspx/<DocumentLibrary>/<FileName>/<ResourceLocation>
 ```
 
-As described in the  [Basic URI Structure and Path](basic-uri-structure-and-path.md) topic, following is the REST URL to access a workbook named **sampleWorkbook.xlsx** and further view the chart called **SampleChart**: 
-  
-    
-    
+As described in the [Basic URI Structure and Path](basic-uri-structure-and-path.md) topic, following is the REST URL to access a workbook named **sampleWorkbook.xlsx** and further view the chart called **SampleChart**:
 
-
-
-```
+```http
 http://<ServerName>/_vti_bin/ExcelRest.aspx/Docs/Documents/sampleWorkbook.xlsx/model/Charts('SampleChart')
 ```
 
 To start and explore the resources in the workbook and view the resources by using discovery, go to the model page by using a URI that follows this example:
-  
-    
-    
 
-
-
-```
+```http
 http://<ServerName>/_vti_bin/ExcelRest.aspx/<DocumentLibrary>/<FileName>/model
 ```
 
-Using the "sampleWorkbook.xlsx" example, following is the URI:
-  
-    
-    
+Using the **sampleWorkbook.xlsx** example, following is the URI:
 
-
-
-```
+```http
 http://<ServerName>/_vti_bin/ExcelRest.aspx/Docs/Documents/sampleWorkbook.xlsx/model
 ```
 
 Following is a screen shot of the model page.
-  
-    
-    
 
 **Excel Services REST model URL**
 
-  
-    
-    
-
-  
-    
-    
 ![Excel Services REST model URL](../images/SharePointServer14Con_XLSvcs_RESTModel.gif)
-  
-    
-    
-The URL to the model page is where you start the discovery. The model page displays four resource collections that the Excel Services REST API currently supports. The resource collections are ranges, charts, tables, or PivotTables. You can explore those resources in a particular workbook by clicking **Ranges**, **Charts**, **Tables**, or **PivotTables** on the model page.
-  
-    
-    
-For example, to access the chart in the workbook by using discovery, do the following: 
-  
-    
-    
 
-  
-    
-    
+The URL to the model page is where you start the discovery. The model page displays four resource collections that the Excel Services REST API currently supports. The resource collections are ranges, charts, tables, or PivotTables. You can explore those resources in a particular workbook by clicking **Ranges**, **Charts**, **Tables**, or **PivotTables** on the model page.
+
+For example, to access the chart in the workbook by using discovery, do the following:
 
 1. On the model page, click **Charts**. Clicking the **Charts** link brings another Atom feed—this resulting feed lists all the charts that are available in the sampleWorkbook.xlsx workbook. The sampleWorkbook.xlsx workbook contains three charts named **Chart 1**, **Chart 3**, and **SampleChart**. Therefore, three chart names are listed, as seen in the following screen shot.
-    
-   **Excel Services REST discovery chart list**
 
-  
+    **Excel Services REST discovery chart list**
 
-  ![Excel Services REST discovery chart list](../images/19126dce-b896-4623-8686-92f2fa807283.gif)
-  
+    ![Excel Services REST discovery chart list](../images/19126dce-b896-4623-8686-92f2fa807283.gif)
 
-  
+1. On the model page, click **SampleChart**. This displays the chart named **SampleChart** that resides in **sampleWorkbook.xlsx**, as shown in the following screen shot.
 
-  
-2. On the model page, click **SampleChart**. This displays the chart named **SampleChart** that resides in **sampleWorkbook.xlsx**, as shown in the following screen shot. 
-    
-   **Viewing chart using REST**
+    **Viewing chart using REST**
 
-  
+    ![Viewing chart using REST](../images/11734dcf-1b57-40cc-b1e8-8b10b7e5d5cb.gif)
 
-  ![Viewing chart using REST](../images/11734dcf-1b57-40cc-b1e8-8b10b7e5d5cb.gif)
-  
+1. Similarly, clicking **Chart 1** or **Chart 3** displays the chart with the corresponding name. Clicking **SampleChart** navigates to the actual chart URL. Following is the URL to the **SampleChart** image (as can be seen in the screen shot):
 
-  
-
-  
-3. Similarly, clicking **Chart 1** or **Chart 3** displays the chart with the corresponding name. Clicking **SampleChart** navigates to the actual chart URL. Following is the URL to the **SampleChart** image (as can be seen in the screen shot):
-    
-```
-  http://<ServerName>/_vti_bin/ExcelRest.aspx/Docs/Documents/sampleWorkbook.xlsx/model/Charts('SampleChart%20')?$format=image
-```
-
+    ```http
+    http://<ServerName>/_vti_bin/ExcelRest.aspx/Docs/Documents/sampleWorkbook.xlsx/model/Charts('SampleChart%20')?$format=image
+    ```
 
 ## Atom Feed
 
-Using the  [Atom](http://tools.ietf.org/html/rfc4287) feed provided by the REST API gives you an easier way of getting to the data that you are interested in. If you view the source of the webpage, you get the XML. An example from the charts in **sampleWorkbook.xlsx** is shown below.
-  
-    
-    
+Using the [Atom](http://tools.ietf.org/html/rfc4287) feed provided by the REST API gives you an easier way of getting to the data that you are interested in. If you view the source of the webpage, you get the XML. An example from the charts in **sampleWorkbook.xlsx** is shown below.
+
 As can be seen in the XML, the feed contains traversable elements that enable code to discover what elements exist in the workbook. Each Atom entry corresponds to a chart that can be accessed. This same mechanism applies to discovering ranges, tables, and PivotTables.
-  
-    
-    
 
-
-
-```XML
+```xml
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<feed xmlns="http://www.w3.org/2005/Atom" xmlns:x="http://schemas.microsoft.com/office/2008/07/excelservices/rest" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservice" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:x="http://schemas.microsoft.com/office/2008/07/excelservices/rest"
+      xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservice"
+      xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
   <title type="text">Charts</title>
   <id>http://ServerName/_vti_bin/ExcelRest.aspx/Docs/Documents/sampleWorkbook.xlsx/model/Charts</id>
   <updated>2010-01-19T19:32:53Z</updated>
@@ -191,14 +124,8 @@ As can be seen in the XML, the feed contains traversable elements that enable co
 </feed>
 ```
 
-
 ## See also
-
 
 #### Concepts
 
-
-  
-    
-    
- [Resources URI for Excel Services REST API](resources-uri-for-excel-services-rest-api.md)
+- [Resources URI for Excel Services REST API](resources-uri-for-excel-services-rest-api.md)

--- a/docs/general-development/excel-services-best-practices.md
+++ b/docs/general-development/excel-services-best-practices.md
@@ -1,7 +1,7 @@
 ---
 title: Excel Services Best Practices
 description: Describes the best practices for working with Excel Services and provides general advice and details on mitigating threats.
-ms.date: 06/09/2022
+ms.date: 05/09/2023
 keywords: guidelines
 f1_keywords:
 - guidelines
@@ -9,229 +9,116 @@ ms.assetid: 56fa3913-c156-49da-bed0-a6a106fc129f
 ms.localizationpriority: medium
 ---
 
-
 # Excel Services Best Practices
 
 This topic contains a list of best-practice recommendations for working with Excel Services.
-  
-    
-    
-
 
 ## Mitigating Threats
-
 
 ### Anonymous Access and Information Disclosure
 
 The following settings combination gives anonymous users access to any files in the share to which the process account has access. Therefore, the following combination of settings is not recommended, because of the possibility of information disclosure:
-  
-    
-    
 
 - Anonymous access to Microsoft SharePoint Foundation is turned on.
-    
-  
 - You have a UNC trusted location and the **Process account** is turned on.
-    
+
 > [!NOTE]
 > The **Process account** is a global Excel Services setting that affects all trusted locations.
-  
-    
-    
-
 
 ### To view the Process account option
 
-
 1. On the **Start** menu, click **All Programs**.
-    
-  
-2. Point to **Microsoft SharePoint 2010 Products**, and then click **SharePoint Central Administration**.
-    
-  
-3. Under **Application Management**, click **Manage service applications**.
-    
-  
-4. On the Manage Service Applications page, click **Excel Services Application**.
-    
-  
-5. On the **Excel Services Application** page, click **Global Settings**.
-    
-  
-6. In the **Security** section, look under **File Access Method** for the **Process account** option.
-    
-  
+1. Point to **Microsoft SharePoint 2010 Products**, and then click **SharePoint Central Administration**.
+1. Under **Application Management**, click **Manage service applications**.
+1. On the Manage Service Applications page, click **Excel Services Application**.
+1. On the **Excel Services Application** page, click **Global Settings**.
+1. In the **Security** section, look under **File Access Method** for the **Process account** option.
 
 ### Denial of Service Attack
 
 In a denial of service attack against a Web service, an attacker generates very large, individual requests against the Web service. The purpose is to attempt to exploit the limits of one or more Web service input values.
-  
-    
-    
+
 We recommend that you use the Microsoft Internet Information Services (IIS) setting to set the maximum request size for the Web service.
-  
-    
-    
+
 Use the **maxRequestLength** attribute in the **httpRuntime** element in the **system.web** element to prevent denial of service attacks that are caused by users posting large files to the server. The default size is 4096 KB (4 MB).
-  
-    
-    
+
 For more information, see  [\<httpRuntime\> Element](https://msdn.microsoft.com/library/e9b81350-8aaf-47cc-9843-5f7d0c59f369.aspx) and [\<maxRequestLength\> Element](https://msdn.microsoft.com/library/fd52b2c5-5014-4e6f-b869-4ea666dc83d6.aspx).
-  
-    
-    
 
 ### Sniffing Between the Calling Application and the Web Service Computer
 
 If the calling application and Excel Web Services are deployed to different computers, an attacker can listen to the network traffic for data transfer between the calling application and the Web service. This threat is also called "sniffing" or "eavesdropping."
-  
-    
-    
+
 To help mitigate this threat, we recommend that you:
-  
-    
-    
 
 - Use Secure Sockets Layer (SSL) to set up a secure channel to protect data transfer between the client and the server. The SSL protocol helps to protect data against packet sniffing by anyone with physical access to the network.
-    
-  
 - Physically protect the relevant network if a custom application using Excel Web Services is running in a confined network—for example, if Excel Web Services is deployed on a Web front-end computer within the enterprise.
-    
-  
-For more information, see  [Securing Your Network](https://msdn.microsoft.com/library/af62ece0-0dd7-4b8e-ad12-4d13f2d60816.aspx) and [SOAP Security](https://msdn.microsoft.com/library/aa912494.aspx).
-  
-    
-    
+
+For more information, see [Securing Your Network](https://msdn.microsoft.com/library/af62ece0-0dd7-4b8e-ad12-4d13f2d60816.aspx) and [SOAP Security](https://msdn.microsoft.com/library/aa912494.aspx).
+
 For information about Excel Services topology, scalability, performance, and security, see the Microsoft SharePoint Server 2010 TechCenter.
-  
-    
-    
 
 ### Spoofing
 
 We recommend that you use SSL to help mitigate the threats of hijacked Web service Internet Protocol (IP) addresses and ports, and to help prevent attackers from receiving requests and replying on behalf of the Web service.
-  
-    
-    
+
 The SSL certificate is matched against a few properties, one of which is the IP address from which the message is coming. The attacker cannot spoof the IP address if it does not have the Web service SSL certificate.
-  
-    
-    
+
 For more information, see  [Securing Your Network](https://msdn.microsoft.com/library/af62ece0-0dd7-4b8e-ad12-4d13f2d60816.aspx).
-  
-    
-    
 
 ## Excel Services User-Defined Functions (UDFs)
-
 
 ### Strong Name Dependencies
 
 In some cases, a user-defined function (UDF) assembly depends on other assemblies that are deployed with it. These dependent DLLs load successfully if they are in the global assembly cache, or if they are located in the same folder as the UDF assembly.
-  
-    
-    
-In the latter case, however, it is possible for the load to fail if Excel Calculation Services has already loaded another assembly with the same name. (It fails either because the assembly is not strongly named, or because another version with the same name has been deployed and loaded.)
-  
-    
-    
-Consider the following scenario, with the following directory structure:
-  
-    
-    
 
-1. C:\\Udfs\\Udf01
-    
+In the latter case, however, it is possible for the load to fail if Excel Calculation Services has already loaded another assembly with the same name. (It fails either because the assembly is not strongly named, or because another version with the same name has been deployed and loaded.)
+
+Consider the following scenario, with the following directory structure:
+
+1. ***C:\\Udfs\\Udf01***
+
     The Udf01 folder contains:
-    
-  - Udf01.dll 
-    
-  
-  - dependent.dll (not strongly named)
-    
-  
+
+    - Udf01.dll
+    - dependent.dll (not strongly named)
 
     The Udf01.dll file has a dependency on the dependent.dll file.
-    
-  
-2. C:\\Udfs\\Udf02
-    
+
+1. **C:\\Udfs\\Udf02**
+
     The Udf02 folder contains:
-    
-  - Udf02.dll (which depends on Interop.dll)
-    
-  
-  - dependent.dll (which is not strongly named)
-    
-  
+
+    - Udf02.dll (which depends on Interop.dll)
+    - dependent.dll (which is not strongly named)
 
     The Udf02.dll file has a dependency on the dependent.dll file. Udf01.dll's dependency and Udf02.dll's dependency share the same name. But Udf02.dll's dependent.dll file is not the same as Udf01.dll's dependent.dll file.
-    
-  
-Assume the following flow:
-  
-    
-    
 
-1. Udf01.dll is the first DLL to be loaded. Excel Calculation Services looks for dependent.dll and loads Udf01.dll's dependency, which in this case is dependent.dll. 
-    
-  
-2. Udf02.dll is loaded after Udf01.dll. Excel Calculation Services sees that Udf02.dll depends on dependent.dll. However, a DLL with the name "dependent.dll" is already loaded. Therefore, Udf02.dll's dependent.dll file is not loaded, and the currently loaded dependent.dll file is used as the dependency.
-    
-  
+Assume the following flow:
+
+1. Udf01.dll is the first DLL to be loaded. Excel Calculation Services looks for dependent.dll and loads Udf01.dll's dependency, which in this case is dependent.dll.
+1. Udf02.dll is loaded after Udf01.dll. Excel Calculation Services sees that Udf02.dll depends on dependent.dll. However, a DLL with the name "dependent.dll" is already loaded. Therefore, Udf02.dll's dependent.dll file is not loaded, and the currently loaded dependent.dll file is used as the dependency.
+
 As a result, the object—in this case, the dependent.dll file that Udf02.dll needs—is not loaded into memory.
-  
-    
-    
+
 To avoid name collision, we recommend that you strongly name your dependencies, and name them uniquely.
-  
-    
-    
 
 ## General
-
 
 ### Naming Managed-Code DLLs
 
 To ensure that your assembly names are unique, use the fully qualified class name, following the  [Namespace Naming Guidelines](https://msdn.microsoft.com/library/c08bc0d8-9b3a-4564-9af6-71699f62e00d.aspx).
-  
-    
-    
-For example, use CompanyName.Hierarchichal.Namespace.ClassName instead ofNamespace.ClassName. 
-  
-    
-    
+
+For example, use `CompanyName.Hierarchichal.Namespace.ClassName` instead of `Namespace.ClassName`.
 
 ## See also
 
-
 #### Tasks
 
-
-  
-    
-    
- [How to: Trust a Location](how-to-trust-a-location.md)
+- [How to: Trust a Location](how-to-trust-a-location.md)
 #### Concepts
 
-
-  
-    
-    
- [Excel Services Architecture](excel-services-architecture.md)
-  
-    
-    
- [Accessing the SOAP API](accessing-the-soap-api.md)
-  
-    
-    
- [Excel Services Alerts](excel-services-alerts.md)
-  
-    
-    
- [Excel Services Known Issues and Tips](excel-services-known-issues-and-tips.md)
-  
-    
-    
- [Excel Services Blogs, Forums, and Resources](excel-services-blogs-forums-and-resources.md)
+- [Excel Services Architecture](excel-services-architecture.md)
+- [Accessing the SOAP API](accessing-the-soap-api.md)
+- [Excel Services Alerts](excel-services-alerts.md)
+- [Excel Services Known Issues and Tips](excel-services-known-issues-and-tips.md)
+- [Excel Services Blogs, Forums, and Resources](excel-services-blogs-forums-and-resources.md)

--- a/docs/general-development/excel-services-known-issues-and-tips.md
+++ b/docs/general-development/excel-services-known-issues-and-tips.md
@@ -1,328 +1,163 @@
 ---
 title: Excel Services Known Issues and Tips
 description: Describes known issues and tips for working with Excel Services and provides links to related documentation.
-ms.date: 06/09/2022
+ms.date: 05/09/2023
 ms.assetid: b4a41437-4f00-4f88-8510-627fa0252004
 ms.localizationpriority: medium
 ---
 
-
 # Excel Services Known Issues and Tips
 
 The following are a known issues and tips for working with Excel Services.
-  
-    
-    
-
 
 ## Excel Web Service
-
 
 ### Viewing the WSDL Location
 
 You can view the Excel Web Services Web Services Description Language (WSDL) page by navigating to the following URL on the server:  `http://<server>/<customsite>/_vti_bin/excelservice.asmx?WSDL`
-  
-    
-    
-If you do not have a custom site, you can view the WSDL by using the following URL:
-  
-    
-    
- `http://<server>/_vti_bin/excelservice.asmx?WSDL`
-  
-    
-    
-For more information, see  [Accessing the SOAP API](accessing-the-soap-api.md).
-  
-    
-    
+
+If you do not have a custom site, you can view the WSDL by using the following URL: `http://<server>/_vti_bin/excelservice.asmx?WSDL`
+
+For more information, see [Accessing the SOAP API](accessing-the-soap-api.md).
 
 ### Understanding Excel Web Services and Namespaces
 
 The following are Excel web services and namespaces:
-  
-    
-    
 
 - The single web service object that contains all the API methods: **ExcelService**
-    
-  
-- The schema namespace:  `http://schemas.microsoft.com/office/excel/server/webservices`
-    
-  
-- The web service page name: ExcelService.asmx
-    
-  
+- The schema namespace: `http://schemas.microsoft.com/office/excel/server/webservices`
+- The web service page name: **ExcelService.asmx**
 
 ### Linking Locally or to a Web Service
 
-In certain scenarios, you should link directly to Microsoft.Office.Excel.Server.WebServices.dll and access it as you would any local assembly, instead of calling it as a web service through SOAP over HTTP. 
-  
-    
-    
+In certain scenarios, you should link directly to Microsoft.Office.Excel.Server.WebServices.dll and access it as you would any local assembly, instead of calling it as a web service through SOAP over HTTP.
+
 For more information and guidelines on when to use direct linking, see  [Loop-Back SOAP Calls and Direct Linking](loop-back-soap-calls-and-direct-linking.md).
-  
-    
-    
 
 ### Understanding Invalid Characters
 
 The calls to the **GetCell** and **GetRange** methods will fail if the workbook cells contain characters that are invalid in an XML response.
-  
-    
-    
+
 For example, if a cell contains characters with hexadecimal values 0x1, 0x2 ... 0x8, the ASP.NET parser will throw an exception that the value of the character being written to the XML response is invalid:
-  
-    
-    
- **System.InvalidOperationException: Client found response content type of 'text/html; charset=utf-8', but expected 'text/xml'. The request failed with the error message: -- \<html\> \<head\> \<title\>' ', hexadecimal value 0x01, is an invalid character.</title>**
-  
-    
-    
+
+**System.InvalidOperationException: Client found response content type of 'text/html; charset=utf-8', but expected 'text/xml'. The request failed with the error message: -- \<html\> \<head\> \<title\>' ', hexadecimal value 0x01, is an invalid character.</title>**
+
 This behavior is expected. The XML specification that defines which characters are allowed in a valid XML response specifies that hexadecimal values 0x1, 0x2 ... 0x8 are invalid XML characters:
-  
-    
-    
- **Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF] /* any Unicode character, excluding the surrogate blocks, FFFE, and FFFF. */**
-  
-    
-    
-For more information, see  [W3C Extensible Markup Language (XML) Specification](http://www.w3.org/TR/REC-xml) (http://www.w3.org/TR/REC-xml#NT-Char).
-  
-    
-    
+
+**Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF] /* any Unicode character, excluding the surrogate blocks, FFFE, and FFFF. */**
+
+For more information, see  [W3C Extensible Markup Language (XML) Specification](http://www.w3.org/TR/REC-xml#NT-Char).
 
 ### Saving a Workbook
 
 When you make changes to a workbook—for example, by setting values to a range using Excel Web Services—the changes to the workbook are preserved only for that particular session. The changes are not saved or persisted back to the original workbook. When the current workbook session ends (for example, when you call the **CloseWorkbook** method, or the session times out), changes you made will be lost.
-  
-    
-    
+
 If you want to save changes to a workbook, you can use the **GetWorkbook** method and then save the workbook using the API of the destination file store. For more information, see [How to: Get an Entire Workbook or a Snapshot](how-to-get-an-entire-workbook-or-a-snapshot.md) and [How to: Save a Workbook](https://msdn.microsoft.com/library/feb74f7a-2d8f-4672-911b-de85f8852aea%28Office.15%29.aspx).
-  
-    
-    
 
 ### Understanding the Url Property of an Excel Web Services Proxy Class
 
-Do not use the **Url** property of an Excel Web Services proxy for the location of the workbook you want to open. The **Url** property of a web service proxy class generated by Visual Studio gets or sets the base URL of the XML web service the client is requesting. In the case of Excel Web Services, this is usually:
-  
-    
-    
- `http://<server name>/_vti_bin/ExcelService.asmx`
-  
-    
-    
+Do not use the **Url** property of an Excel Web Services proxy for the location of the workbook you want to open. The **Url** property of a web service proxy class generated by Visual Studio gets or sets the base URL of the XML web service the client is requesting. In the case of Excel Web Services, this is usually: `http://<server name>/_vti_bin/ExcelService.asmx`
+
 To specify the location of a workbook, use the **OpenWorkbook** method instead of the **Url** property as shown in the following code example.
-  
-    
-    
 
-
-
-```
-
+```csharp
 //Instantiate the web service and make a status array object.
 ExcelService xlservice = new ExcelService();
-string sheetName = "Sheet1";         
+string sheetName = "Sheet1";
 
 //Set the path to the workbook to open.
 //TODO: Change the path to the workbook
- //to point to a workbook you have access to.
+//to point to a workbook you have access to.
 //The workbook must be in a trusted location.
-string targetWorkbookPath = 
-   "http://myserver02/example/Shared%20Documents/Book1.xlsx";
+string targetWorkbookPath = "http://myserver02/example/Shared%20Documents/Book1.xlsx";
 
 //Set credentials for requests.
 xlservice.Credentials = System.Net.CredentialCache.DefaultCredentials;
 
-//Call the open workbook, and point to the trusted   
+//Call the open workbook, and point to the trusted
 //location of the workbook to open.
-string sessionId = xlservice.OpenWorkbook(targetWorkbookPath, "en-US", 
-    "en-US", out outStatus);
-                
+string sessionId = xlservice.OpenWorkbook(targetWorkbookPath, "en-US", "en-US", out outStatus);
 ```
 
-For more information, see  [WebClientProtocol.Url Property](https://go.microsoft.com/fwlink/?LinkId=64908) (https://msdn.microsoft.com/library/default.asp?url=/library/cpref/html/frlrfSystemWebServicesProtocolsWebClientProtocolClassUrlTopic.asp).
-  
-    
-    
+For more information, see [WebClientProtocol.Url Property](https://msdn.microsoft.com/library/default.asp?url=/library/cpref/html/frlrfSystemWebServicesProtocolsWebClientProtocolClassUrlTopic.asp).
 
 ## Understanding Security
-
 
 ### Using Workbook Permissions
 
 Beware of the following issues regarding workbook permissions:
-  
-    
-    
 
 - Excel Web Services uses the Microsoft SharePoint Foundation authorization scheme to verify that the caller has the right to call APIs (that is, make web service calls) on the SharePoint Foundation site (that is, the website where Excel Web Services is located) remotely. If the caller does not have the "Use Remote API" right, the Excel Web Services returns an "HTTP 401 (Unauthorized)" error, and logs an "API authorization failed" event. Excel Web Services performs these authorization checks only for calls that originate as SOAP calls. Calls from applications that link locally to Microsoft.Office.Excel.Server.WebServices.dll are not considered remote calls. Therefore, they are not subject to authorization checks. However, if the application that links locally to Microsoft.Office.Excel.Server.WebServices.dll is itself a SOAP service, and handles the service's SOAP calls, the call to Excel Web Services will seem like a SOAP call (even though the application links directly to Microsoft.Office.Excel.Server.WebServices.dll). In this scenario, Excel Web Services will perform the authorization checks.
-    
-  
 - To get the entire workbook (for example, by calling the **GetWorkbook** method using the `WorkbookType.FullWorkbook` argument), the caller needs "open" permission for the workbook or "read" permission in a file share.
-    
-  
 - To call the **GetApiVersion** method, no permission is necessary.
-    
-  
 - For the rest of the Excel Web Services methods, besides credentials, the caller needs "view" permission (in SharePoint Foundation) or "read" permission (in a file share) for the workbook.
-    
-  
 
 ### Trusted Location
 
 The workbooks you want to open in Excel Services must be placed in a trusted location. If not, the Excel Web Services calls to open the workbook will fail.
-  
-    
-    
+
 For information about how to trust a location, see  [How to: Trust a Location](how-to-trust-a-location.md) and [How to: Trust Workbook Locations Using Script](https://msdn.microsoft.com/library/79ab6ced-7a0c-4275-b852-bb246fc6be57%28Office.15%29.aspx).
-  
-    
-    
 
 ## Visual Studio
 
-
 ### Microsoft Visual Studio Proxy Behavior
 
-When Microsoft Visual Studio creates a proxy class for a client project that calls Excel Web Services, it has the following behavior: 
-  
-    
-    
+When Microsoft Visual Studio creates a proxy class for a client project that calls Excel Web Services, it has the following behavior:
+
 If a method has no return value, and one or more **out** arguments, the first **out** argument is moved to become the return value. That is, the method in the proxy class will have one less **out** argument in the method signature. But the signature will have a return value with the type and content of what used to be the first **out** argument.
-  
-    
-    
+
 The affected Excel Web Services methods are:
-  
-    
-    
 
 - **Calculate**
-    
-  
 - **CalculateA1**
-    
-  
 - **CalculateWorkbook**
-    
-  
 - **CancelRequest**
-    
-  
 - **CloseWorkbook**
-    
-  
 - **GetSessionInformation**
-    
-  
 - **Refresh**
-    
-  
 - **SetCell**
-    
-  
 - **SetCellA1**
-    
-  
 - **SetRange**
-    
-  
 - **SetRangeA1**
-    
-  
 
 ## Excel Services User-Defined Functions
-
 
 ### Global Assembly Cache is Checked First, Then the Local Folder
 
 By design in the Microsoft .NET Framework, an assembly in a global assembly cache will be loaded instead of the same assembly in a local folder. The common language runtime will look for an assembly in the global assembly cache first before searching in the local folders.
-  
-    
-    
+
 Therefore, if an assembly is installed in the global assembly cache and is in the UDF list but disabled (or removed from the UDF list altogether), and an identical assembly is installed in a local folder and enabled, the assembly in the global assembly cache will still get loaded and used instead of the same assembly in the local folder.
-  
-    
-    
+
 This does not affect upgrade scenarios in which the assembly version has been modified, which means the assembly is not the same anymore.
-  
-    
-    
 
 ## General
 
-
 ### Order of Strings in Sharedstring.xml is Not Maintained
 
-Excel Services does not maintain the original order of strings in a workbook shared-string table (the Sharedstrings.xml part within the Microsoft Office Excel XML Format file). For example, execute the following steps:
-  
-    
-    
+Excel Services does not maintain the original order of strings in a workbook shared-string table (the **Sharedstrings.xml** part within the Microsoft Office Excel XML Format file). For example, execute the following steps:
 
-1. Open a file using Excel. 
-    
-  
-2. Save the file in .xlsx file format. 
-    
-  
-3. Upload the file to a document library that is a trusted location.
-    
-  
-4. Open the file in the document library by using Excel Web Access.
-    
-  
-5. Click **Open in Excel**.
-    
-  
-6. Save the file in .xlsx file format.
-    
-  
-If you compare the Sharedstrings.xml file created in Step 2 with the one created in Step 6, you will find the order of the Sharedstrings.xml parts might be different.
-  
-    
-    
+1. Open a file using Excel.
+1. Save the file in .xlsx file format.
+1. Upload the file to a document library that is a trusted location.
+1. Open the file in the document library by using Excel Web Access.
+1. Click **Open in Excel**.
+1. Save the file in .xlsx file format.
+
+If you compare the **Sharedstrings.xml** file created in Step 2 with the one created in Step 6, you will find the order of the **Sharedstrings.xml** parts might be different.
+
 You should not write an application that assumes the order of strings in the shared-string table is fixed. For example, you cannot replace the shared-string table with an existing localized translation table. You must adjust to the new ordering of strings in the shared-string table.
-  
-    
-    
 
 ## See also
 
-
 #### Tasks
 
+- [How to: Trust a Location](how-to-trust-a-location.md)
 
-  
-    
-    
- [How to: Trust a Location](how-to-trust-a-location.md)
 #### Concepts
 
-
-  
-    
-    
- [Excel Services Best Practices](excel-services-best-practices.md)
-  
-    
-    
- [Excel Services Alerts](excel-services-alerts.md)
-  
-    
-    
- [Excel Services Architecture](excel-services-architecture.md)
-  
-    
-    
- [Supported and Unsupported Features](supported-and-unsupported-features.md)
-  
-    
-    
- [Accessing the SOAP API](accessing-the-soap-api.md)
-  
-    
-    
- [Excel Services Blogs, Forums, and Resources](excel-services-blogs-forums-and-resources.md)
+- [Accessing the SOAP API](accessing-the-soap-api.md)
+- [Excel Services Alerts](excel-services-alerts.md)
+- [Excel Services Architecture](excel-services-architecture.md)
+- [Excel Services Best Practices](excel-services-best-practices.md)
+- [Excel Services Blogs, Forums, and Resources](excel-services-blogs-forums-and-resources.md)
+- [Supported and Unsupported Features](supported-and-unsupported-features.md)

--- a/docs/general-development/external-events-and-alerts-in-sharepoint.md
+++ b/docs/general-development/external-events-and-alerts-in-sharepoint.md
@@ -1,7 +1,7 @@
 ---
 title: External events and alerts in SharePoint
 description: Learn the concepts behind creating remote event receivers in SharePoint that can be attached to external lists and execute when the external data that the list represents is updated.
-ms.date: 09/25/2017
+ms.date: 05/18/2023
 ms.assetid: e48e4812-a185-43c5-b243-04b1d79b88ee
 ms.localizationpriority: medium
 ---
@@ -10,280 +10,158 @@ ms.localizationpriority: medium
 Learn the concepts behind creating remote event receivers in SharePoint that can be attached to external lists and execute when the external data that the list represents is updated.
 
 ## What are event receivers?
-<a name="Externalevents_overview"> </a>
 
 An event receiver is a piece of managed code that responds to SharePoint triggering events such as adding, moving, deleting, checking in, and checking out. When these events occur, and the event receiver's criteria are met, the code that you write to provide additional functionality is executed. When SharePoint objects, such as lists, workflows and features, are configured to wait on these events to occur, they are called event hosts.
 
-
-
 Event receivers let you perform business logic when a specific event occurs. Essentially, these are the hooks where you can create code to handle certain conditions, make notifications, update other systems, and so on. When you create event receivers, a DLL is generated. You can place that DLL into the global assembly cache, so that the event receivers are invoked in response to any changes in an external system.
-
-
 
 The following example contains a simple external event receiver in C# that executes when a new item is added to the list.
 
-
-
-
-
-
 ```csharp
-
 public class EntryContentEventReceiver : SPItemEventReceiver
 {
-   public override void ItemAdded(SPItemEventProperties properties)
-   {
-      base.ItemAdded(properties);
-
-      // properties.ExternalNotificationMessage holds the message sent by the external
-      // system.
-   }
+  public override void ItemAdded(SPItemEventProperties properties)
+  {
+    base.ItemAdded(properties);
+    // properties.ExternalNotificationMessage holds the message sent by the external system
+  }
+}
 ```
 
 External event receivers can also be extended to work against an entity event receiver and as remote event receivers deployed as a service on-premises or in Microsoft Azure.
 
-
-
-
 ## What are remote event receivers?
-<a name="WhatIsARemoteEventReceiver"> </a>
 
 Remote event receivers are new for SharePoint. In a traditional SharePoint solution, you use an event receiver to handle events such as users creating or deleting lists or items in lists. In an SharePoint Add-in, you use a remote event receiver to handle similar events. Remote event receivers work similarly to regular event receivers, except that remote event receivers handle events that occur when an SharePoint Add-in is on a different system from its host web application.
 
-
-
 Business Connectivity Services (BCS) uses remote event receivers attached to external lists and entities to allow you to write code that can react to changes in data hosted in the external system.
-
-
 
 To accommodate this, two stereotypes have been added to the schema of the BDC model: **EventSubscriber** and **EventUnsubscriber**.
 
 > [!NOTE]
 > Event receivers are not supported in sandboxed solutions.
 
-
-
-
-
 ## What features and capabilities does the new external event receiver infrastructure provide?
-<a name="FeaturesAddedWithRER"> </a>
 
 By using and extending the SharePoint event receiver features, BCS is able to add alerts, external list event receivers, and entity receivers to provide extended functionality.
 
-
-
-
-- **Alerts:** Alerts have been an integral part of SharePoint for several versions, but until SharePoint, they would not work with external lists. Now a user can create alerts on an external list that have the same behavior as alerts on a standard SharePoint list.
-
-
-- **External list event receivers:** Event receivers can now be attached to external lists just like they can for standard lists. This provides an extensibility mechanism that lets you write code that is executed at specific times.
-
-
+- **Alerts:** Alerts have been an integral part of SharePoint for several versions, but until arePoint, they would not work with external lists. Now a user can create alerts on an external list that have the same behavior as alerts on a standard SharePoint list.
+- **External list event receivers:** Event receivers can now be attached to external lists just like they can for standard lists. This provides an extensibility mechanism that lets you write de that is executed at specific times.
 - **Entity event receivers:** Entity event receivers provide flexibility by letting you write more robust code that allows other operations like providing user context for filtering data. This can allow better personalization and customized security.
-
 
 Remote eventing in SharePoint makes several interesting scenarios possible. For example, you might have a "Sales Lead Tracking" application that lets a sales team be notified when new sales leads are entered into an external lead application. When a new sales lead is entered, SharePoint is notified through the notification system that is part of the lead application. SharePoint receives the notification and then creates new tasks for the specified salespeople to follow up on each new lead. By configuring the sales lead entry application on the external system to send a notification to SharePoint on the creation of each new lead, SharePoint is kept completely up to date.
 
-
-
-
 ## Prerequisites for using event receivers for external lists
-<a name="bkmk_Prerequisites"> </a>
 
 To use event receivers for external lists, you need the following:
 
-
-
-
 - SharePoint
-
-
 - Visual Studio 2012
-
 
 For more information about setting up a SharePoint development environment, see  [Set up a general development environment for SharePoint](set-up-a-general-development-environment-for-sharepoint.md).
 
-
-
-
 ## Configure the external system to notify SharePoint of external events
-<a name="Externalevents_components"> </a>
 
 For external events to work, a number of components have to be installed and configured on both the SharePoint host and the external system.
 
-
-
 You have to configure the external system so that it can do the following:
 
-
-
-
 - **Determine when underlying data changes.** For the external system to know when changes have been made, you have to create a mechanism for polling for specific changes. You can do this by using a timed service that polls the data source at specific intervals.
-
-
-- **Receive and record requests for subscriptions to change notifications.** The external system has to implement a subscription store so that it can store who should receive change notifications. The simplest solution is probably a database table. The table (or whatever mechanism you choose) should record SubscriptionID, Delivery Address, Event Type, and Entity Name.
-
-
-- **Post notifications to Representational State Transfer (REST) endpoints.** To let SharePoint subscribers know that a change has occurred, the external system application needs to send an HTTP WebRequest to the delivery address recorded in the subscription store. This delivery address is a RESTful endpoint generated by SharePoint during the subscription process.
-
-
+- **Receive and record requests for subscriptions to change notifications.** The external system has to implement a subscription store so that it can store who should receive change notifications. The simplest solution is probably a database table. The table (or whatever anism you choose) should record SubscriptionID, Delivery Address, Event Type, and Entity Name.
+- **Post notifications to Representational State Transfer (REST) endpoints.** To let SharePoint subscribers know that a change has occurred, the external system application needs to send an HTTPWebRequest to the delivery address recorded in the subscription store. This delivery address is a RESTful endpoint generated by SharePoint during the subscription process
 
 ## Configure SharePoint to allow communication with external systems
-<a name="bkmk_configureSP"> </a>
 
 To allow communication with the external system, SharePoint must be configured with the following:
 
-
-
-
 - A BDC model with **EventSubscriber** and **EventUnsubscriber** stereotypes configured
-
-
 - Event receivers
-
-
 
 ### How is external eventing enabled?
 
 You can enable external eventing in SharePoint through **Site Settings** or by adding the following custom feature id to your project
 
-
-
-
-```XML
-
+```xml
 <ActivationDependency FeatureTitle="BCSEvents" FeatureId="60c8481d-4b54-4853-ab9f-ed7e1c21d7e4" />
 ```
 
 Eventing for an external system is enabled when SharePoint creates the delivery address and sends it to the external system during the Subscribe process.
 
-
-
-
 ## Overall flow of external eventing between SharePoint and external systems
-<a name="bkmk_overallflow"> </a>
 
 In Figure 1, notice that there are three distinct steps involved when using external event receivers: subscribe, notification, and unsubscribe.
 
-
-
-
 **Figure 1 Complete data flow for external notifications**
 
-
-
-
-
-
-
-
-![Data flow for external event notifications](../images/ExtEvtsAndAlrts_Figure1.jpg)
-
-
-
-
-
-
-
-
-
-
-
+[Data flow for external event notifications](../images/ExtEvtsAndAlrts_Figure1.jpg)
 
 ## EventSubscriber: subscribe to notifications
-<a name="bkmk_eventsubscriber"> </a>
 
 For a user (SharePoint object) to receive notifications when the underlying data has changed, the user must subscribe to the notifications for an entity. To allow this, the BDC Model schema has been extended to include the **Subscribe** stereotype. The **Subscribe** stereotype is used by SharePoint to let the external system know that the sender is requesting to be notified of changes to the underlying data.
 
-
-
 Figure 2 demonstrates the flow of information between SharePoint and the external system during the Subscribe process.
-
-
-
 
 **Figure 2. Subscribe process flow**
 
-
-
-
-
-
-
-
 ![External eventing Subscribe method process flow](../images/ExtEvtsAndAlerts_Figure2.jpg)
-
-
 
 The following describes the general flow of the subscription process:
 
-
-
-
-
-
-
-
 1. **User requests a subscription for notifications.** Using a custom user interface (a button on a page or a ribbon), SharePoint initiates a request to the external system app for notifications.
-
-
-2. **SharePoint generates a delivery address.** As part of the Subscribe process, SharePoint creates a REST endpoint where notifications will be delivered.
-
-
-3. **Subscription request is sent to the external system.** SharePoint then encapsulates the requestor information along with the dynamically generated REST URL, and sends a web request to the external system.
-
-
-4. **External system receives request.** There are different possibilities for implementing a subscription store. In this example, you will use a SQL Server database table.
-
-
-5. **External system generates a subscriptionId.** A new **subscriptionId** is generated using code in the line-of-business (LOB) application. The **subscriptionId** should be a GUID.
-
-
-6. **External system records the subscription.** The external system application records the **subscriptionId**, delivery address, event type, and other information sent from SharePoint into the subscription store.
-
-
-7. **External system sends the subscriptionId back to SharePoint.** For SharePoint to correctly route the updates that are sent by the external system, the **subscriptionId** is sent back to SharePoint and SharePoint records that information in its database.
+1. **SharePoint generates a delivery address.** As part of the Subscribe process, SharePoint creates a REST endpoint where notifications will be delivered.
+1. **Subscription request is sent to the external system.** SharePoint then encapsulates the requestor information along with the dynamically generated REST URL, and sends a web request to the external system.
+1. **External system receives request.** There are different possibilities for implementing a subscription store. In this example, you will use a SQL Server database table.
+1. **External system generates a subscriptionId.** A new **subscriptionId** is generated using code in the line-of-business (LOB) application. The **subscriptionId** should be a GUID.
+1. **External system records the subscription.** The external system application records the **subscriptionId**, delivery address, event type, and other information sent from SharePoint into the subscription store.
+1. **External system sends the subscriptionId back to SharePoint.** For SharePoint to correctly route the updates that are sent by the external system, the **subscriptionId** is sent back to SharePoint and SharePoint records that information in its database.
 
     The BDC model is working against a **Subscribe** function import. The metadata for function import is shown in this example.
 
-
-
-```XML
-  FunctionImport
-
+```xml
 <EntityType Name="EntitySubscribe">
    <Key>
       <PropertyRef Name="SubscriptionId" />
    </Key>
-   <Property Name="SubscriptionId" Type="Edm.Int32" Nullable="false"
-      p6:StoreGeneratedPattern="Identity"
-      xmlns:p6="http://schemas.microsoft.com/ado/2009/02/edm/annotation" />
-   <Property Name="EntityName" Type="Edm.String" MaxLength="250" FixedLength="false"
-      Unicode="true" />
-   <Property Name="DeliveryURL" Type="Edm.String" MaxLength="250" FixedLength="false"
-      Unicode="true" />
+   <Property xmlns:p6="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+             Name="SubscriptionId"
+             Type="Edm.Int32"
+             Nullable="false"
+             p6:StoreGeneratedPattern="Identity" />
+   <Property Name="EntityName"
+             Type="Edm.String"
+             MaxLength="250"
+             FixedLength="false"
+             Unicode="true" />
+   <Property Name="DeliveryURL"
+             Type="Edm.String"
+             MaxLength="250"
+             FixedLength="false"
+             Unicode="true" />
    <Property Name="EventType" Type="Edm.Int32" />
-   <Property Name="UserId" Type="Edm.String" MaxLength="50" FixedLength="false"
-      Unicode="true" />
-   <Property Name="SubscribeTime" Type="Edm.Binary" MaxLength="8" FixedLength="true"
-      p6:StoreGeneratedPattern="Computed"
-      xmlns:p6="http://schemas.microsoft.com/ado/2009/02/edm/annotation" />
-   <Property Name="SelectColumns" Type="Edm.String" MaxLength="10" FixedLength="false"
-      Unicode="true" />
+   <Property Name="UserId"
+             Type="Edm.String"
+             MaxLength="50"
+             FixedLength="false"
+             Unicode="true" />
+   <Property xmlns:p6="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+             Name="SubscribeTime"
+             Type="Edm.Binary"
+             MaxLength="8"
+             FixedLength="true"
+             p6:StoreGeneratedPattern="Computed" />
+   <Property Name="SelectColumns"
+             Type="Edm.String"
+             MaxLength="10"
+             FixedLength="false"
+             Unicode="true" />
 </EntityType>
-
 ```
-
 
 ### Code example: BDC model with Subscribe
 
 The following is an example of a BDC model with the **Subscribe** method added.
 
-
-
-
-```XML
-
+```xml
 <Method Name="SubscribeCustomer" DefaultDisplayName="Customer Subscribe" IsStatic="true">
    <Properties>
      <Property Name="ODataEntityUrl" Type="System.String">/EntitySubscribes</Property>
@@ -369,147 +247,71 @@ The following is an example of a BDC model with the **Subscribe** method added.
 
 Table 1 lists the important attributes of the BDC model that are needed to make the **Subscribe** stereotype work.
 
-
-
-
 **Table 1. BDC model attributes**
 
-
-|**Attribute**|**Description**|
-|:-----|:-----|
-|**IsDeliveryAddress** <br/> |A **Boolean** flag used on a **TypeDescriptor** to indicate whether the delivery address provided is to be used to deliver notifications. <br/> |
-|**IsEventType** <br/> |A **Boolean** flag used on a **TypeDescriptor** to indicate whether the event type provided is to be used as the event type. Valid event types are **ItemAdded**, **ItemUpdated**, **ItemDeleted**, and so on.  <br/> |
-|**SubscriptionIdName** <br/> |A string used on a **TypeDescriptor** that represents the name of a **subscriptionId** part. <br/> |
-
+|     **Attribute**      |                                                                                                **Description**                                                                                                 |
+| :--------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **IsDeliveryAddress**  | A **Boolean** flag used on a **TypeDescriptor** to indicate whether the delivery address provided is to be used to deliver notifications.                                                                      |
+| **IsEventType**        | A **Boolean** flag used on a **TypeDescriptor** to indicate whether the event type provided is to be used as the event type. Valid event types are **ItemAdded**, **ItemUpdated**, **ItemDeleted**, and so on. |
+| **SubscriptionIdName** | A string used on a **TypeDescriptor** that represents the name of a **subscriptionId** part.                                                                                                                   |
 
 ## Notifications
-<a name="bkmk_notifications"> </a>
 
 In SharePoint, the event-handling infrastructure has been enhanced to allow external data sources to notify SharePoint when information in the external system has been modified. Then, when SharePoint receives a notification, event receivers that are associated with the SharePoint external list or entity can execute code to perform specified actions.
 
-
-
 When a subscription is created, the external system needs a way to tell SharePoint about the changes that have occurred on a particular entity. The external system is expected to deliver notifications to the delivery address as provided by SharePoint to the external system during the Subscribe process using an OData Atom-formatted payload.
-
-
 
 Figure 3 shows the communication flow between the external system and SharePoint when a new record is added to the data in the external system.
 
-
-
-
 **Figure 3 Notification process**
-
-
-
-
-
-
-
 
 ![External event notification process](../images/ExtEvtsAndAlerts_Figure3.jpg)
 
-
-
-
-
-
-
-
 1. **New record is added to external system.** In this example, a new record is added to the external system using the application user interface or directly into the database.
-
-
-2. **External system application is notified of the change.** The external system application has to be made aware of the changes that are happening to the underlying data. There are a number of ways to do this. You can use SQL triggers that fire when data changes on specific tables, or you can create a polling mechanism to query the data store for changes. There are other ways to accomplish this, but each will have to be evaluated with performance in mind.
-
-
-3. **External system sends notification request to SharePoint through delivery address.** To communicate the changes, an Atom-formatted request has to be sent to the delivery address that is stored in the LOB application's subscription store.
-
-
+1. **External system application is notified of the change.** The external system application has to be made aware of the changes that are happening to the underlying data. There are a number of ways to do this. You can use SQL triggers that fire when data changes on specific tables, or you can create a polling mechanism to query the data store for changes. There are other ways to accomplish this, but each will have to be evaluated with performance in mind.
+1. **External system sends notification request to SharePoint through delivery address.** To communicate the changes, an Atom-formatted request has to be sent to the delivery address that is stored in the LOB application's subscription store.
 
 ### Notification payload
 
 In constructing the notification, the LOB system has to create an HTTP payload that includes either the full details of the item that changed, or just the identity of the item that changed.
 
-
-
-
 - **Identity:** When the payload is sent as an identity, the payload is expected to have only information about the identity of the changed item. For example, for a customer in a Customers entity, the payload would only contain the ID of the customer that has changed.
-
-
 - **Full item:** In this case, the payload is an entire record that has changed in the external system. In the customer example, the entire changed customer record is included.
 
 > [!NOTE]
 > The full item is only supported when you use the OData connector.
 
-
-
-
 The type of payload that is being sent by the external system must be indicated during the subscription process.
-
-
 
 The following is an example of the BDC model property used for notifications.
 
-
-
-
-
-
-```XML
-
+```xml
 <Property Name="NotificationParserType" Type="System.String">
    ODataEntryContentNotificationParser
 </Property>
-
 ```
 
 If it is not specified, the default payload is an identity payload.
-
-
-
 
 ### Notification delivery address (virtual address)
 
 The subscription process initiated from SharePoint results in a virtual address being created by SharePoint, allowing an entry point for the external system to post notifications. The delivery address is used by the external system to post those notifications. The delivery address is also passed to the external system during the subscription request.
 
-
-
-
 ## EventUnsubscriber: remove subscription from the notifications list
-<a name="bkmk_eventunsubscriber"> </a>
 
 The **Unsubscribe** operation removes a subscription from the notifications list.
 
-
-
- Figure 4 shows that the **UnSubscribe** method is much simpler. Because the subscription ID was sent back to SharePoint, and SharePoint recorded it, all that is needed is to send the UnSubscribe request with the correct subscription ID.
-
-
-
+Figure 4 shows that the **UnSubscribe** method is much simpler. Because the subscription ID was sent back to SharePoint, and SharePoint recorded it, all that is needed is to send the UnSubscribe request with the correct subscription ID.
 
 **Figure 4 Code flow for UnSubscribe method**
 
-
-
-
-
-
-
-
 ![External notifications unsubscribe process](../images/ExternalEventsAndAlerts_UnsubscribeFlow.jpg)
-
-
-
 
 ### BDC model for Unsubscribe
 
 The following XML example shows how you can create a BDC model that unsubscribes from the external system event notifications.
 
-
-
-
-```XML
-
+```xml
 <Method Name="UnSubscribeExpenseReport" DefaultDisplayName="ExpenseReport
     Unsubscribe">
     <Properties>
@@ -554,8 +356,6 @@ The following XML example shows how you can create a BDC model that unsubscribes
     </MethodInstances>
 </Method>
 
-
-
 <Method IsStatic="false" Name="Unsubscribe">
     <AccessControlList>
         <AccessControlEntry Principal="NT AUTHORITY\\Authenticated Users">
@@ -588,77 +388,46 @@ The following XML example shows how you can create a BDC model that unsubscribes
         </MethodInstance>
     </MethodInstances>
 </Method>
-
 ```
 
-
 ## Code example: Attach an event receiver to an external list
-<a name="AttachingRER"> </a>
 
 The following code provides an example of how to attach an event receiver to an external list. After it is attached, the event receiver listens for notifications from the external system about updates, additions, and deletions that are performed on the native data.
 
-
-
-
-```XML
-
+```csharp
 private static void AddEventReceiver(string siteUrl, string listTitle)
 {
-   string assembly = "SampleEventReceiver, Culture=neutral, Version=1.0.0.0,
-      PublicKeyToken=1bfafa687d2e46a7";
-   string className = "SampleEventReceiver.EntryContentEventReceiver";
-
-   try
-   {
-      using (SPSite site = new SPSite(siteUrl))
+  string assembly = "SampleEventReceiver, Culture=neutral, Version=1.0.0.0,PublicKeyToken=1bfafa687d2e46a7";
+  string className = "SampleEventReceiver.EntryContentEventReceiver";
+  try
+  {
+    using (SPSite site = new SPSite(siteUrl))
+    {
+      using (SPWeb web = site.OpenWeb())
       {
-         using (SPWeb web = site.OpenWeb())
-         {
-            SPList list = web.Lists[listTitle];
-            list.EventReceivers.Add(SPEventReceiverType.ItemAdded,
-               assembly, className);
-         }
+        SPList list = web.Lists[listTitle];
+        list.EventReceivers.Add(SPEventReceiverType.ItemAdded, assembly, className);
       }
-   }
-   catch (Exception e)
-   {
-      Console.WriteLine(e);
-   }
+    }
+  }
+  catch (Exception e)
+  {
+    Console.WriteLine(e);
+  }
 }
-
 ```
 
-
 ## Beyond the basics: Learn more about using external event receivers
-<a name="Externalevents_Learnmore"> </a>
 
 For more information about external events and alerts, see the following.
 
-
-
-
 **Table 2. Advanced concepts for working with external event receivers**
 
+|                                                                   **Article**                                                                    |                                                                                                                          **Description**                                                                                                                          |
+| :----------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [How to: Create an OData data service for use as a BCS external system](how-to-create-an-odata-data-service-for-use-as-a-bcs-external-system.md) | Learn how to create an Internet-addressable Windows Communication Foundation (WCF) service that uses OData to send notifications to SharePoint when the underlying data changes. These notifications are used to tigger events that are attached to external lists. |
 
-|**Article**|**Description**|
-|:-----|:-----|
-| [How to: Create an OData data service for use as a BCS external system](how-to-create-an-odata-data-service-for-use-as-a-bcs-external-system.md) <br/> |Learn how to create an Internet-addressable Windows Communication Foundation (WCF) service that uses OData to send notifications to SharePoint when the underlying data changes. These notifications are used to trigger events that are attached to external lists.  <br/> |
+## See Also
 
-
-## See also
-<a name="Externalevents_Addres"> </a>
-
-
--  [What's new in Business Connectivity Services in SharePoint](what-s-new-in-business-connectivity-services-in-sharepoint.md)
-
-
--  [Business Connectivity Services in SharePoint](business-connectivity-services-in-sharepoint.md)
-
-
--  [Business Connectivity Services programmers reference for SharePoint](business-connectivity-services-programmers-reference-for-sharepoint.md)
-
-
--  [How to: Create external event receivers](how-to-create-external-event-receivers.md)
-
-
-
+- [What's new in Business Connectivity Services in SharePoint](what-s-new-in-business-connectivity-services-in-sharepoint.md)
+- [Business Connectivity Services in SharePoint](business-connectivity-services-in-sharepoint.md)

--- a/docs/general-development/how-to-access-external-data-with-rest-in-sharepoint.md
+++ b/docs/general-development/how-to-access-external-data-with-rest-in-sharepoint.md
@@ -1,193 +1,130 @@
 ---
 title: Access external data by using REST in SharePoint
 description: Describes how to access external data from SharePoint by using REST URLs for BCS and provides an example that sets up an external list.
-ms.date: 06/09/2022
+ms.date: 05/18/2023
 ms.assetid: 0663cc8c-a736-434d-9858-6ce12ce7f748
 ms.localizationpriority: high
 ---
-
-
 # Access external data by using REST in SharePoint
 
 Learn how to access external data from SharePoint by using Representational State Transfer (REST) URLs for Business Connectivity Services (BCS).
 This article shows how to set up an external list that retrieves data from an Open Data protocol (OData) source.
-  
-    
-    
-
 
 ## Prerequisites for accessing external data using REST
-<a name="bkmk_Prerequisites"> </a>
 
 To access external data from SharePoint by using REST, you need the following:
-  
-    
-    
 
 - SharePoint
-    
-  
 - Visual Studio 2012
-    
-  
 - Office Developer Tools for Visual Studio 2012
-    
-  
 - A functioning SharePoint Add-ins development environment: Follow the instructions in  [Set up a general development environment for SharePoint](set-up-a-general-development-environment-for-sharepoint.md).
-    
-  
 - Access to the public OData.org producers
-    
-  
 
 ### Core concepts to know when accessing external data with REST
 
 The SharePoint REST service provides a way to access external data using a specially constructed URL. To understand how it works and how to use it, see the following articles.
-  
-    
-    
 
 **Table 1. Core concepts for REST in SharePoint**
 
-
-|**Article title**|**Description**|
-|:-----|:-----|
-| [Use OData query operations in SharePoint REST requests](https://msdn.microsoft.com/library/d4b5c277-ed50-420c-8a9b-860342284b72%28Office.15%29.aspx) <br/> |Learn how to use the SharePoint REST service, which provides a REST programming interface comparable to the existing client object model.  <br/> |
-| [Get to know the SharePoint REST service](https://msdn.microsoft.com/library/2de035a0-ac75-43bd-9665-5c5a59c4c590%28Office.15%29.aspx) <br/> |Get the basics of using the SharePoint REST service to access and update SharePoint data, using the REST and OData web protocol standards.  <br/> |
-| [Complete basic operations using SharePoint REST endpoints](/sharepoint/dev/sp-add-ins/complete-basic-operations-using-sharepoint-rest-endpoints) <br/> |Learn how to navigate the SharePoint data structure as it is represented in the REST service, perform common CRUD (create, read, update, and delete) operations on SharePoint items via the REST service, synchronize SharePoint items across applications, and control item concurrency.  <br/> |
-   
+|                                                                   **Article title**                                                                   |                                                                                                                                      **Description**                                                                                                                                      |
+| :---------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Use OData query operations in SharePoint REST requests](https://msdn.microsoft.com/library/d4b5c277-ed50-420c-8a9b-860342284b72%28Office.15%29.aspx) | Learn how to use the SharePoint REST service, which provides a REST programming interface comparable to the existing client object model.                                                                                                                                                 |
+| [Get to know the SharePoint REST service](https://msdn.microsoft.com/library/2de035a0-ac75-43bd-9665-5c5a59c4c590%28Office.15%29.aspx)                | Get the basics of using the SharePoint REST service to access and update SharePoint data, using the REST and OData web protocol standards.                                                                                                                                                |
+| [Complete basic operations using SharePoint REST endpoints](/sharepoint/dev/sp-add-ins/complete-basic-operations-using-sharepoint-rest-endpoints)     | Learn how to navigate the SharePoint data structure as it is represented in the REST service, perform common CRUD (create, read, update, and delete) operations on SharePoint items via the REST service, synchronize SharePoint items across applications, and control item concurrency. |
 
 ## Create an SharePoint Add-in to access external data using REST
-<a name="bkmk_CreateApp"> </a>
 
 The following procedures guide you through setting up an SharePoint Add-in and configuring a webpage to make requests using REST functions to retrieve data from an external data source.
-  
-    
-    
 
 ### To create an SharePoint Add-in
 
-
 1. Open Visual Studio 2012 or later.
-    
-  
-2. Create an **App for SharePoint** project.
-    
-  
-3. Specify the app settings, including app name, the site URL for debugging the app, and how you want to host the app (Autohosted, Provider-hosted, SharePoint-hosted). For more information about hosting options, see  [Choose patterns for developing and hosting your SharePoint Add-in](https://msdn.microsoft.com/library/05ce5435-0a03-4ddc-976b-c33b08d03457%28Office.15%29.aspx).
-    
-  
-4. Choose **Finish** to create the app.
-    
-  
+1. Create an **App for SharePoint** project.
+1. Specify the app settings, including app name, the site URL for debugging the app, and how you want to host the app (Autohosted, Provider-hosted, SharePoint-hosted). For more information about hosting options, see  [Choose patterns for developing and hosting your SharePoint Add-in](https://msdn.microsoft.com/library/05ce5435-0a03-4ddc-976b-c33b08d03457%28Office.15%29.aspx).
+1. Choose **Finish** to create the app.
 
 ### To generate the external content type
 
-
 1. In **Solution Explorer**, open the shortcut menu for the project, and choose **Add**, **Content Types for External Data Source**.
-    
-  
-2. In the **Specify OData Source** page, enter the URL of the OData service you want to connect to. In this case, use the Northwind OData source published at [http://www.odata.org/ecosystem](http://www.odata.org/ecosystem). Set the URL for the OData service to  `http://services.odata.org/Northwind/Northwind.svc/`, and provide a name for the data source.
-    
+1. In the **Specify OData Source** page, enter the URL of the OData service you want to connect to. In this case, use the Northwind OData source published at [https://www.odata.org/ecosystem](https://www.odata.org/ecosystem). Set the URL for the OData service to `http://services.odata.org/Northwind/Northwind.svc/`, and provide a name for the data source.
+
     Choose **Next**.
-    
-  
-3. This displays a list of data entities that are being exposed by the OData Service. Select the **Customers** entity. Ensure that the **Create list instances for the selected data entities (except Service Operations)** check box is selected.
-    
-  
-4. Choose **Finish**.
-    
-  
+
+1. This displays a list of data entities that are being exposed by the OData Service. Select the **Customers** entity. Ensure that the **Create list instances for the selected data entities (except Service Operations)** check box is selected.
+1. Choose **Finish**.
 
 ## Code example: Add scripts and HTML to the Home.aspx page
-<a name="bkmk_AddUIelements"> </a>
 
-At this point, you have an external content type and an external list that will display the data from the Northwind OData source. 
-  
-    
-    
+At this point, you have an external content type and an external list that will display the data from the Northwind OData source.
+
 The next objective is to modify the default.aspx page that was created when you created your app. You will add a container to hold the results of the query that is executed with the page loads. By executing the scripts on the page load event, you ensure that the script is executed every time the page is browsed, and the resulting REST calls are made to the Northwind OData source to add records to the page.
-  
-    
-    
 
 ### To add the container to the Default.aspx page
 
-
 1. In **Solution Explorer**, open the Default.aspx page in the **Pages** module.
-    
-  
-2. Add the following **div** element to the page.
-    
-```HTML
-  
-<div id="displayDiv"></div>
-```
+1. Add the following **div** element to the page.
 
-3. Save the page.
-    
-  
+  ```html
+  <div id="displayDiv"></div>
+  ```
+
+1. Save the page.
+
 Finally, you add code to the App.js file that executes when the page loads.
-  
-    
-    
 
 ### To modify the App.js file to make REST calls
 
+1. Open the **App.js** file in the Scripts module of your SharePoint project.
+1. Paste the following code at the end of the file.
 
-1. Open the App.js file in the Scripts module of your SharePoint project.
-    
-  
-2. Paste the following code at the end of the file.
-    
-```
-  $(document).ready(function () {
+```javascript
+$(document).ready(function () {
 
-    // Namespace
-    window.AppLevelECT = window.AppLevelECT || {};
+  // Namespace
+  window.AppLevelECT = window.AppLevelECT || {};
 
-    // Constructor
-    AppLevelECT.Grid = function (hostElement, surlWeb) {
-        this.hostElement = hostElement;
-        if (surlWeb.length > 0 &amp;&amp; surlWeb.substring(surlWeb.length - 1, surlWeb.length) != "/")
-            surlWeb += "/";
-        this.surlWeb = surlWeb;
-    }
+  // Constructor
+  AppLevelECT.Grid = function (hostElement, surlWeb) {
+      this.hostElement = hostElement;
+      if (surlWeb.length > 0 &amp;&amp; surlWeb.substring(surlWeb.length - 1, surlWeb.length) != "/")
+          surlWeb += "/";
+      this.surlWeb = surlWeb;
+  }
 
-    // Prototype
-    AppLevelECT.Grid.prototype = {
+  // Prototype
+  AppLevelECT.Grid.prototype = {
 
-        init: function () {
+      init: function () {
 
-            $.ajax({
-                url: this.surlWeb + "_api/lists/getbytitle('Customer')/items?$select=BdcIdentity,CustomerID,ContactName",
-                headers: {
-                    "accept": "application/json",
-                    "X-RequestDigest": $("#__REQUESTDIGEST").val()
-                },
-                success: this.showItems
-            });
-        },
+          $.ajax({
+              url: this.surlWeb + "_api/lists/getbytitle('Customer')/items?$select=BdcIdentity,CustomerID,ContactName",
+              headers: {
+                  "accept": "application/json",
+                  "X-RequestDigest": $("#__REQUESTDIGEST").val()
+              },
+              success: this.showItems
+          });
+      },
 
-        showItems: function (data) {
-            var items = [];
+      showItems: function (data) {
+          var items = [];
 
-            items.push("<table>");
-            items.push('<tr><td>Customer ID</td><td>Customer Name</td></tr>');
+          items.push("<table>");
+          items.push('<tr><td>Customer ID</td><td>Customer Name</td></tr>');
 
-            $.each(data.d.results, function (key, val) {
-                items.push('<tr id="' + val.BdcIdentity + '"><td>' +
-                    val.CustomerID + '</td><td>' +
-                    val.ContactName + '</td></tr>');
-            });
+          $.each(data.d.results, function (key, val) {
+              items.push('<tr id="' + val.BdcIdentity + '"><td>' +
+                  val.CustomerID + '</td><td>' +
+                  val.ContactName + '</td></tr>');
+          });
 
-            items.push("</table>");
+          items.push("</table>");
 
-            $("#displayDiv").html(items.join(''));
-        }
-    }
+          $("#displayDiv").html(items.join(''));
+      }
+  }
 
-    ExecuteOrDelayUntilScriptLoaded(getCustomers, "sp.js");
+  ExecuteOrDelayUntilScriptLoaded(getCustomers, "sp.js");
 });
 
 function getCustomers() {
@@ -197,28 +134,11 @@ function getCustomers() {
 ```
 
 Press F5 to deploy the app to SharePoint. Browse to the Default.aspx page in the app, and a list of customers appears on the page.
-  
-    
-    
 
 ## See also
-<a name="bkmk_Addres"> </a>
 
-
--  [Business Connectivity Services in SharePoint](business-connectivity-services-in-sharepoint.md)
-    
-  
--  [Get to know the SharePoint REST service](https://msdn.microsoft.com/library/2de035a0-ac75-43bd-9665-5c5a59c4c590%28Office.15%29.aspx)
-    
-  
--  [Complete basic operations using SharePoint REST endpoints](/sharepoint/dev/sp-add-ins/complete-basic-operations-using-sharepoint-rest-endpoints)
-    
-  
--  [Add-in-scoped external content types in SharePoint](add-in-scoped-external-content-types-in-sharepoint.md)
-    
-  
--  [What's new in Business Connectivity Services in SharePoint](what-s-new-in-business-connectivity-services-in-sharepoint.md)
-    
-  
-
-
+- [Business Connectivity Services in SharePoint](business-connectivity-services-in-sharepoint.md)
+- [Get to know the SharePoint REST service](https://msdn.microsoft.com/library/2de035a0-ac75-43bd-9665-5c5a59c4c590%28Office.15%29.aspx)
+- [Complete basic operations using SharePoint REST endpoints](/sharepoint/dev/sp-add-ins/complete-basic-operations-using-sharepoint-rest-endpoints)
+- [Add-in-scoped external content types in SharePoint](add-in-scoped-external-content-types-in-sharepoint.md)
+- [What's new in Business Connectivity Services in SharePoint](what-s-new-in-business-connectivity-services-in-sharepoint.md)

--- a/docs/general-development/how-to-add-a-device-channel-panel-snippet-in-sharepoint.md
+++ b/docs/general-development/how-to-add-a-device-channel-panel-snippet-in-sharepoint.md
@@ -1,156 +1,92 @@
 ---
 title: Add a Device Channel Panel snippet in SharePoint
 description: Describes how to add a Device Channel Panel that can be added to a master page or page layout to control how content is rendered in created channels.
-ms.date: 06/09/2022
+ms.date: 05/18/2023
 ms.assetid: 612780a8-6267-49f6-a32d-33600bb5f6b4
 ms.localizationpriority: medium
 ---
-
 
 # Add a Device Channel Panel snippet in SharePoint
 
 A Device Channel Panel is a snippet that you can add to a master page or page layout to control what content is rendered for each channel that you create. The primary purpose of a Device Channel Panel is to selectively display different page fields on different channels from a single page layout.
 
 ## Introduction to the Device Channel Panel snippet
-<a name="Introduction"> </a>
 
 A Device Channel Panel is a control that you can add to a master page or page layout to control what content is rendered in each channel that you create. A Device Channel Panel is a container that specifies one or more channels; if one or more of those channels are active when the page is rendered, all of the contents of the Device Channel Panel are also rendered. A Device Channel Panel can include almost any type of content, including a link to a CSS file or a .js file. It is an easy way to include specific content for specific channels.
-  
-    
-    
+
 Perhaps the most common scenario for using Device Channel Panels is to selectively include parts of a page layout for specific channels. For example, you may have a page layout with separate text fields for a long greeting and a short greeting. By placing the page fields inside Device Channel Panels, you can display the short greeting only to phones and the long greeting only to the desktop. The content of a Device Channel Panel is not displayed on non-included channels—in fact, the content is not rendered at all, which prevents bytes from going across the wire. For this reason, using Device Channel Panels is a better way to display content on specific channels than using a CSS class with  `Display:None` because Device Channel Panels help to reduce the page weight for a specific channel.
-  
-    
-    
+
 You can also use Device Channel Panels on master pages. For example, if you have a master page that can accommodate two different devices (or two different browsers) with only minimal changes, you can use Device Channel Panels to hold the content on the master page that is specific to either of those devices.
-  
-    
-    
+
 There are two limitations to using a Device Channel Panel:
-  
-    
-    
 
 - **Display templates** Because display templates are rendered on the client side and Device Channel Panels run on the server side, you cannot use a Device Channel Panel within a display template. Instead, you should use two different Content Search web parts within Device Channel Panels on your page layout, or use the JavaScript variable to trigger the behavior you want within the display template itself.
-    
-  
 - **Web part zones** You cannot insert a web part zone inside a Device Channel Panel. If you want to allow authors to add web parts to a page, and if you are not concerned about the page weight for mobile devices, you can add a Rich Text Editor page field to a Device Channel Panel, and then instruct authors to add web parts there. You can add web parts directly to a Device Channel Panel (without a web part zone).
-    
-  
 
 ## Inserting a Device Channel Panel snippet
-<a name="InsertSnippet"> </a>
 
 Like all snippets, you add a Device Channel Panel snippet from the Snippet Gallery. To navigate to the Snippet Gallery, you must first select a master page or page layout to edit.
-  
-    
-    
-
 ### To insert a Device Channel Panel snippet
 
-
 1. Browse to your publishing site.
-    
-  
-2. In the upper-right corner of the page, choose the Settings gear, and then choose **Design Manager**.
-    
-  
-3. In Design Manager, in the left navigation pane, choose **Edit Master Pages** or **Edit Page Layouts**, depending on what type of file you're editing.
-    
-  
-4. Select the name of the master page or page layout that you want to add the snippet to.
-    
-  
-5. To open the Snippet Gallery, choose **Snippets** in the upper-right corner of the server-side preview.
-    
-  
-6. On the ribbon, on the **Design** tab, choose **Device Channel Panel**.
-    
-  
-7. On the right side of the Snippet Gallery, under **About this Component**, click or select section headers to expand or collapse groups of properties, and then configure any custom settings that you want.
-    
+1. In the upper-right corner of the page, choose the Settings gear, and then choose **Design Manager**.
+1. In Design Manager, in the left navigation pane, choose **Edit Master Pages** or **Edit Page Layouts**, depending on what type of file you're editing.
+1. Select the name of the master page or page layout that you want to add the snippet to.
+1. To open the Snippet Gallery, choose **Snippets** in the upper-right corner of the server-side preview.
+1. On the ribbon, on the **Design** tab, choose **Device Channel Panel**.
+1. On the right side of the Snippet Gallery, under **About this Component**, click or select section headers to expand or collapse groups of properties, and then configure any custom settings that you want.
+
     The section named **Important** contains the properties that are key to how this particular snippet works. For a Device Channel Panel, the **IncludedChannels** property is the most important. For this property, enter the alias of each Device Channel that you want to display the content contained in this Device Channel Panel. If you enter more than one alias, separate each with a comma.
-    
+
     > [!NOTE]
     > If you edit the alias of a channel in the Device Channels list, you must manually find and update that alias wherever it appears in your design files, including updating the **IncludedChannels** property for every Device Channel Panel that uses that alias.
 
-8. After you configure any other properties, choose **Update**. This updates the HTML snippet on the left side of the page, so that the markup reflects your custom settings. You can always choose **Reset** to return all properties to their default settings.
-    
-  
-9. On the left side of the Snippet Gallery, under **HTML Snippet**, choose **Copy to Clipboard**.
-    
-  
-10. In your HTML editor, open the mapped network drive on your computer, and then open the HTML file for the master page or page layout that you're adding the snippet to.
-    
+1. After you configure any other properties, choose **Update**. This updates the HTML snippet on the left side of the page, so that the markup reflects your custom settings. You can always choose **Reset** to return all properties to their default settings.
+1. On the left side of the Snippet Gallery, under **HTML Snippet**, choose **Copy to Clipboard**.
+1. In your HTML editor, open the mapped network drive on your computer, and then open the HTML file for the master page or page layout that you're adding the snippet to.
+
     For more information, see  [How to: Map a network drive to the SharePoint Master Page Gallery](how-to-map-a-network-drive-to-the-sharepoint-master-page-gallery.md).
-    
-  
-11. In the HTML file, paste the snippet where you want the markup to appear.
-    
+
+1. In the HTML file, paste the snippet where you want the markup to appear.
+
     If you are adding the snippet to a page layout, make sure to paste the snippet inside **PlaceHolderMain**.
-    
-  
-12. Replace the **<div>** where `class="DefaultContentBlock"` with your own specific content.
-    
-    Typically, if you're adding a Device Channel Panel to a page layout, you replace the **<div>** by copying page fields inside the panel.
-    
-  
-13. Save the page, and then refresh the server-side preview in Design Manager to make sure the Device Channel Panel appears as expected.
-    
+
+1. Replace the `<div>` where `class="DefaultContentBlock"` with your own specific content.
+
+    Typically, if you're adding a Device Channel Panel to a page layout, you replace the `<div>` by copying page fields inside the panel.
+
+1. Save the page, and then refresh the server-side preview in Design Manager to make sure the Device Channel Panel appears as expected.
+
     To preview the panel on different channels, you can add query string parameters to the URL. For example, you can append the query string variable  `"DeviceChannel=YourChannelAlias"` to the URL of any page in the server-side preview.
-    
-  
 
 ## Understanding the snippet markup
-<a name="UnderstandMarkup"> </a>
 
-The two most important parts of a Device Channel Panel snippet are the **IncludedChannels** property and the **<div>** where `class="DefaultContentBlock"`. By default, the **IncludedChannels** property is empty. In the **Important** section of the property grid, you should enter the aliases, separated by commas, of the device channels that you want to display the content in this panel.
-  
+The two most important parts of a Device Channel Panel snippet are the **IncludedChannels** property and the `<div>` where `class="DefaultContentBlock"`. By default, the **IncludedChannels** property is empty. In the **Important** section of the property grid, you should enter the aliases, separated by commas, of the device channels that you want to display the content in this panel.
+
 > [!NOTE]
 > If you change an alias in the Device Channels list, you must also change that alias wherever it appears in your markup, including in the **IncludedChannels** property for every Device Channel Panel that uses that alias.
-  
-    
-    
-
-The **<div>** where `class="DefaultContentBlock"` should be replaced with whatever specific content you want to display for the included channels. A Device Channel Panel can include almost any type of content, including a link to a CSS file or a .js file. The most common scenario for using Device Channel Panels is to include specific page fields from a page layout for specific channels. In this case, you copy the page field markup where the **<div>** is positioned inside the Device Channel Panel.
-  
-    
-    
 
 
+The `<div>` where `class="DefaultContentBlock"` should be replaced with whatever specific content you want to display for the included channels. A Device Channel Panel can include almost any type of content, including a link to a CSS file or a .js file. The most common scenario for using Device Channel Panels is to include specific page fields from a page layout for specific channels. In this case, you copy the page field markup where the `<div>` is positioned inside the Device Channel Panel.
 
 ```HTML
-
 <div data-name="DeviceChannelPanel">
     <!--CS: Start Device Channel Panel Snippet-->
     <!--SPM:<%@Register Tagprefix="Publishing" Namespace="Microsoft.SharePoint.Publishing.WebControls" Assembly="Microsoft.SharePoint.Publishing, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c"%>-->
     <!--MS:<Publishing:DeviceChannelPanel runat="server" IncludedChannels="MyPhoneChannel, MyTabletChannel">-->
         <!--PS: Start of READ-ONLY PREVIEW (do not modify)--><!--PE: End of READ-ONLY PREVIEW-->
        <div class="DefaultContentBlock" style="border:medium black solid; background:yellow; color:black; margin:20px; padding:10px;">
-        You should replace this div with content that renders based on your Device Channel Panel Properties.    
+        You should replace this div with content that renders based on your Device Channel Panel Properties.
         </div>
         <!--PS: Start of READ-ONLY PREVIEW (do not modify)--><!--PE: End of READ-ONLY PREVIEW-->
     <!--ME:</Publishing:DeviceChannelPanel>-->
     <!--CE: End Device Channel Panel Snippet-->
 </div>
-
 ```
 
-
 ## See also
-<a name="AdditionalResources"> </a>
 
-
--  [SharePoint Design Manager snippets](sharepoint-design-manager-snippets.md)
-    
-  
--  [SharePoint Design Manager device channels](sharepoint-design-manager-device-channels.md)
-    
-  
--  [Build sites for SharePoint](build-sites-for-sharepoint.md)
-    
-  
--  [Develop the site design in SharePoint](develop-the-site-design-in-sharepoint.md)
-    
-  
-
+- [SharePoint Design Manager snippets](sharepoint-design-manager-snippets.md)
+- [SharePoint Design Manager device channels](sharepoint-design-manager-device-channels.md)
+- [Build sites for SharePoint](build-sites-for-sharepoint.md)
+- [Develop the site design in SharePoint](develop-the-site-design-in-sharepoint.md)

--- a/docs/general-development/how-to-add-a-security-trim-snippet-in-sharepoint.md
+++ b/docs/general-development/how-to-add-a-security-trim-snippet-in-sharepoint.md
@@ -1,152 +1,87 @@
 ---
 title: Add a Security Trim snippet in SharePoint
 description: Describes how to add a Security Trim snippet in SharePoint to display content only to specific and authenticated users.
-ms.date: 06/09/2022
+ms.date: 05/18/2023
 ms.assetid: 4beaab08-760b-408a-b768-906312779379
 ms.localizationpriority: high
 ---
-
 
 # Add a Security Trim snippet in SharePoint
 
 You can use a Security Trim snippet to display content only to specific users, based on a specific permission that those users must have and whether the users are authenticated or anonymous.
 
 ## Introduction to the Security Trim snippet
-<a name="Introduction"> </a>
 
 You can use a Security Trim snippet to display content only to specific users, based on a specific permission that those users must have, and whether those users are authenticated or anonymous. You can add a Security Trim panel to a master page or page layout. A Security Trim panel is a container that can include other components or snippets, such as web parts, in addition to static content.
-  
-    
-    
+
 For example, you can use a Security Trim panel to display the following content to specific users:
-  
-    
-    
 
 - A Content by Search web part that displays which documents an authenticated user is currently working on.
-    
-  
 - A list view of recently modified documents so that authenticated users can see what's new on the site.
-    
-  
 - A Content by Search web part that displays to non-authenticated visitors a list of recommended links based on the current article. Such a list of recommendations might be noise to authenticated content authors working in the site, but it's important for non-authenticated visitors.
-    
-  
 - A sign-in link separate from the ribbon, for non-authenticated users or users who have yet to be authenticated.
-    
+
     > [!NOTE]
-    > This sign-in link is inserted automatically into a master page that is created by using Design Manager, but you can delete it if it's not needed. 
+    > This sign-in link is inserted automatically into a master page that is created by using Design Manager, but you can delete it if it's not needed.
 
 A Security Trim panel has two important property settings, one for authentication and one for permissions (or authorization). For example, you can use a Security Trim panel to display the following content to specific users:
-  
-    
-    
 
 - **AuthenticationRestrictions** With this property, you can restrict the panel to either authenticated or anonymous users, or choose all users (all users is the default setting).
-    
-  
 - **Permissions** With this property, you can select a specific permission that users must have to view the content in the panel.
-    
+
     > [!NOTE]
-    > You are selecting an individual permission, not a permission level. (A permission level is a set of granted permissions.) 
+    > You are selecting an individual permission, not a permission level. (A permission level is a set of granted permissions.)
+
 Of course, if you restrict the authentication to only anonymous users, it's typically not necessary to specify a specific permission because anonymous users have usually not been given any SharePoint permissions. It makes sense to use permissions only with all users or with all authenticated users.
-  
-    
-    
-The Security Trim panel has three options on the ribbon, listed in the left column of Table 1. Table 1 shows how these settings determine the specific permission that users are required to have, the lowest default permission level that includes that specific permission, and the group that is linked to that permission level by default.)
-  
+
+The Security Trim panel has three options on the ribbon, listed in the left column of Table 1. Table 1 shows how these settings determine the specific permission that users are required to have, the lowest default permission level that includes that specific permission, and the group that is linked to that permission level by default.
+
 > [!NOTE]
-> These are the default settings, which can be changed for any given scope, such as a site collection, site, list, or item. 
-  
-    
-    
+> These are the default settings, which can be changed for any given scope, such as a site collection, site, list, or item.
 
 For example, if you set a Security Trim panel to **Show to authors**, by default content inside that panel is visible to users in the Members group and the Owners group.
-  
-    
-    
 
 **Table 1. Mapping of panel options to default permission levels and groups**
 
-
 |**Security Trim panel option**|**Permissions property**|**Permission**|**Permission level**|**Group**|
 |:-----|:-----|:-----|:-----|:-----|
-|Show to authors  <br/> |**AddAndCustomizePages** <br/> |Add and Customize Pages  <br/> |Contribute (or higher)  <br/> |Members  <br/> |
-|Show to Authenticated Users  <br/> |**ViewPages** <br/> |View Pages  <br/> |Read (or higher)  <br/> |Visitors  <br/> |
-|Show to Administrators  <br/> |**FullMask** <br/> |Select All  <br/> |Full Control  <br/> |Owners  <br/> |
-   
+|Show to authors   |**AddAndCustomizePages**  |Add and Customize Pages   |Contribute (or higher)   |Members   |
+|Show to Authenticated Users   |**ViewPages**  |View Pages   |Read (or higher)   |Visitors   |
+|Show to Administrators   |**FullMask**  |Select All   |Full Control   |Owners   |
 
 ### Inserting a Security Trim panel
-<a name="InsertSnippet"> </a>
 
 Like all snippets, you add the Security Trim snippet from the Snippet Gallery. To navigate to the Snippet Gallery, you must first select a master page or page layout to edit.
-  
-    
-    
 
 ### To insert a Security Trim panel
 
-
 1. Browse to your publishing site.
-    
-  
-2. In the upper-right corner of the page, choose the Settings gear, and then choose **Design Manager**.
-    
-  
-3. In Design Manager, in the left navigation pane, choose **Edit Master Pages** or **Edit Page Layouts**, depending on what type of file you're editing.
-    
-  
-4. Select the name of the master page or page layout that you want to add the snippet to.
-    
-  
-5. To open the Snippet Gallery, choose **Snippets** in the upper-right corner of the server-side preview.
-    
-  
-6. On the ribbon, on the **Design** tab, choose **Security Trim**.
-    
+1. In the upper-right corner of the page, choose the Settings gear, and then choose **Design Manager**.
+1. In Design Manager, in the left navigation pane, choose **Edit Master Pages** or **Edit Page Layouts**, depending on what type of file you're editing.
+1. Select the name of the master page or page layout that you want to add the snippet to.
+1. To open the Snippet Gallery, choose **Snippets** in the upper-right corner of the server-side preview.
+1. On the ribbon, on the **Design** tab, choose **Security Trim**.
+
     Optionally, in the drop-down list on the **Security Trim** button, you can select the users to whom the panel content will be visible, or you can see more options by configuring the important property values for the panel.
-    
-  
-7. On the right side of the Snippet Gallery, under **About this Component**, click or select section headers to expand or collapse groups of properties, and then configure any custom settings that you want.
-    
-  
-8. After you configure any properties, choose **Update**. This updates the HTML snippet on the left side of the page, so that the markup reflects your custom settings. You can always choose **Reset** to return all properties to their default settings.
-    
-  
-9. On the left side of the Snippet Gallery, under **HTML Snippet**, choose **Copy to Clipboard**.
-    
-  
-10. In your HTML editor, open the mapped network drive on your computer, and then open the HTML file for the master page or page layout that you're adding the snippet to.
-    
-  
-11. In the HTML file, paste the snippet where you want the markup to appear.
-    
+
+1. On the right side of the Snippet Gallery, under **About this Component**, click or select section headers to expand or collapse groups of properties, and then configure any custom settings that you want.
+1. After you configure any properties, choose **Update**. This updates the HTML snippet on the left side of the page, so that the markup reflects your custom settings. You can always choose **Reset** to return all properties to their default settings.
+1. On the left side of the Snippet Gallery, under **HTML Snippet**, choose **Copy to Clipboard**.
+1. In your HTML editor, open the mapped network drive on your computer, and then open the HTML file for the master page or page layout that you're adding the snippet to.
+1. In the HTML file, paste the snippet where you want the markup to appear.
+
     If you are adding the snippet to a page layout, make sure to paste the snippet inside **PlaceHolderMain**.
-    
-  
-12. Replace the **<div>** where `class="DefaultContentBlock"` with your own specific content.
-    
-  
-13. Save the page, and then refresh the server-side preview in Design Manager to make sure the Security Trim panel appears as expected.
-    
-  
+
+1. Replace the `<div>` where `class="DefaultContentBlock"` with your own specific content.
+1. Save the page, and then refresh the server-side preview in Design Manager to make sure the Security Trim panel appears as expected.
 
 ## Understanding the snippet markup
-<a name="UnderstandMarkup"> </a>
 
-The most important parts of a Security Trim snippet are the **AuthenticationRestrictions** property and the **Permissions** property, and the **<div>** in bold below. **AuthenticationRestrictions** appears in the markup only when changed from **AllUsers**, which is the default. If you choose **Reset** for the snippet in the Snippet Gallery, **AuthenticationRestrictions** is removed from the markup, which means the snippet uses the default value, **AllUsers**.
-  
-    
-    
-The **<div>** where `class="DefaultContentBlock"` is what you replace with your own content, which can include other snippets and controls.
-  
-    
-    
+The most important parts of a Security Trim snippet are the **AuthenticationRestrictions** property and the **Permissions** property, and the `<div>` in bold below. **AuthenticationRestrictions** appears in the markup only when changed from **AllUsers**, which is the default. If you choose **Reset** for the snippet in the Snippet Gallery, **AuthenticationRestrictions** is removed from the markup, which means the snippet uses the default value, **AllUsers**.
 
-
+The `<div>` where `class="DefaultContentBlock"` is what you replace with your own content, which can include other snippets and controls.
 
 ```HTML
-
 <div data-name="SecurityTrimmedAuthors">
     <!--CS: Start Security Trim Snippet-->
     <!--SPM:<%@Register Tagprefix="SharePoint" Namespace="Microsoft.SharePoint.WebControls" Assembly="Microsoft.SharePoint, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c"%>-->
@@ -161,21 +96,9 @@ The **<div>** where `class="DefaultContentBlock"` is what you replace with your 
 </div>
 ```
 
-
 ## See also
-<a name="AdditionalResources"> </a>
-   
-  
--  [Understanding permission levels](https://support.office.com/article/understanding-permission-levels-in-sharepoint-87ecbb0e-6550-491a-8826-c075e4859848)
-    
-  
--  [SharePoint Design Manager snippets](sharepoint-design-manager-snippets.md)
-    
-  
--  [Build sites for SharePoint](build-sites-for-sharepoint.md)
-    
-  
--  [Develop the site design in SharePoint](develop-the-site-design-in-sharepoint.md)
-    
-  
 
+- [Understanding permission levels](https://support.office.com/article/understanding-permission-levels-in-sharepoint-87ecbb0e-6550-491a-8826-c075e4859848)
+- [SharePoint Design Manager snippets](sharepoint-design-manager-snippets.md)
+- [Build sites for SharePoint](build-sites-for-sharepoint.md)
+- [Develop the site design in SharePoint](develop-the-site-design-in-sharepoint.md)

--- a/docs/general-development/how-to-add-a-web-part-zone-snippet-in-sharepoint.md
+++ b/docs/general-development/how-to-add-a-web-part-zone-snippet-in-sharepoint.md
@@ -1,209 +1,116 @@
 ---
 title: Add a web part zone snippet in SharePoint
 description: Describes how to add a web part zone snippet in SharePoint and provides a list of Web part zone properties used to restrict content authors.
-ms.date: 06/09/2022
+ms.date: 05/18/2023
 ms.assetid: 7583b217-200c-4569-8f88-fe975c8ebd72
 ms.localizationpriority: high
 ---
 
-
 # Add a web part zone snippet in SharePoint
 
-> [!IMPORTANT] 
+> [!IMPORTANT]
 > This extensibility option is **only** available for classic SharePoint experiences. You cannot use this option with modern experiences in SharePoint Online, like with communication sites. We do not recommend using classic experience or these branding techniques anymore.
 
 A web part zone is a snippet that you can add to a page layout so that content authors can add, edit, or delete web parts in that zone.
 
 ## Introduction to the web part zone snippet
-<a name="Introduction"> </a>
 
 A web part is a server control that provides a specific piece of SharePoint functionality, and a web part zone is a container that determines the layout, behavior, and other properties of the web parts contained in that zone. For example, a web part zone can specify whether the web parts in the zone:
-  
-    
-    
 
-- Are arranged in a horizontal or vertical layout. 
-    
-  
+- Are arranged in a horizontal or vertical layout.
 - Display common user interface (UI) elements such as a title bar or border.
-    
-  
 - Can be customized by content authors when they edit a page in the browser.
-    
-  
 - Can be personalized by site visitors who create a personal view of a web part when they view a page in the browser.
-    
-  
+
 In a publishing site, content authors with the necessary permissions can create or edit pages that reside in the Pages library. As a designer, you can add a web part zone to a page layout. When a content author creates or edits a page based on that page layout, the author can add, edit, or delete web parts in that zone. For example, you may want to add a web part zone to a page layout so that content authors can:
-  
-    
-    
 
 - Display the results of a search query by using a Content Search web part. Authors can update or modify the search query when a search-driven web part resides inside a web part zone.
-    
-  
 - Embed video or audio clips in a webpage by using a Media web part.
-    
-  
 - Create lists of hyperlinks that are easily edited, grouped, or reordered by using a Summary Link web part.
-    
-  
 - Create a site map that lists all pages in a site and that is automatically updated whenever a page is added, deleted, renamed, or moved by using a Table of Contents web part.
-    
-  
 
 ### When to use web part zones
 
 When a page layout includes one or more web part zones, the web part zones are available on all pages that use that layout, which enables authors to insert web parts onto those pages. If you enable authors to insert web parts on pages, you reduce your control over the users' experience of the site. For example, an author could insert a Table of Contents web part onto a page that exposes parts of your site that you don't want visitors to navigate to from the current page.
-  
-    
-    
+
 If you want complete control over how a web part appears on your site, and if you want that web part to appear on all pages of a certain type, add the web part directly to a page layout. If you want a web part to appear on all pages in a site, you can also add a web part directly to a master page.
-  
+
 > [!NOTE]
-> Web part zones are available on page layouts but not on master pages—the purpose of zones is to allow authors to modify web parts, and authors typically don't edit a master page. 
-  
-    
-    
+> Web part zones are available on page layouts but not on master pages—the purpose of zones is to allow authors to modify web parts, and authors typically don't edit a master page.
 
 You can also add web part zones to a page layout but restrict their use. For example, you can add web parts to a zone, and then set a property of that zone so that content authors can edit the properties of existing web parts but not add or remove web parts from the zone. web part zones have a set of properties that serve a dual purpose. You can use one subset of properties to organize the layout and format of web parts on the page. You can use another subset of properties to provide an additional level of protection from modification (or "lock down") of the web parts within the zone.
-  
-    
-    
+
 For varying levels of control over how web parts are presented on your site, you can:
-  
-    
-    
 
 - Add web parts directly to a master page or page layout. This means content authors cannot modify the web parts.
-    
-  
 - Add web parts to zones on page layouts, but restrict those zones to only the default web parts that you add.
-    
-  
 - Add web part zones to page layouts, and give content authors complete control over what web parts appear in those zones and how they are configured.
-    
-  
+
 The properties of a web part zone can specify whether content authors are allowed to change:
-  
-    
-    
 
 - The layout of web parts in the zone by adding, deleting, resizing, or moving the web parts.
-    
-  
 - The web part settings for all users (the shared view of a web part).
-    
-  
 - Their personal web part settings (the personal view of a web part).
-    
-  
+
 Table 1 shows important properties to consider when you want to restrict a web part zone.
-  
-    
-    
 
 **Table 1. Web part zone properties used to restrict content authors**
 
-
 |**Property Name**|**Description**|
 |:-----|:-----|
-|**AllowLayoutChange** <br/> |Specifies whether web parts within the zone can be closed, minimized, deleted, or restored.  <br/> If set to **False**, users cannot close, minimize, delete, or restore web parts in the zone, drag web parts to a different zone, or rearrange or move web parts within the zone. Users also cannot add web parts from the web part catalog, and several properties that affect the UI of web parts in the zone are disabled. This property does not affect the ability to change the layout programmatically.  <br/> If set to **True**, users with appropriate permissions can perform these actions.  <br/> |
-|**LockLayout** <br/> |Specifies whether web parts within the zone can be added, deleted, resized, or moved. This property works the same whether the web part page is in personal view or shared view.  <br/> If set to **True**, the specific web part properties for each web part in the zone that are affected are: **Zone (ZoneID)**, **Part Order (PartOrder)**, **Visible on Page (IsVisible)**, **Height (Height)**, **Width (Width)**, **Allow Close (AllowRemove)**, and **IsIncluded** (the **Close** command on the **web part** menu). Other web part properties are not affected. <br/> If set to **False**, the web part properties determine whether modifications can be made (together with the appropriate site permissions).  <br/> |
-|**AllowCustomization** <br/> |Specifies whether shared property values of web parts within the zone can be modified.  <br/> If set to **True**, users with appropriate permissions can make changes to the web parts in the zone for all users.  <br/> If set to **False**, users cannot make changes to the web parts in the zone in the UI in shared view. But, changes can still be made programmatically and by using the web part Maintenance page.  <br/> |
-|**AllowPersonalization** <br/> |Specifies whether personal property values of web parts within the zone can be modified.  <br/> If set to **True**, users with appropriate permissions can make personal changes to the web parts in the zone.  <br/> If set to **False**, users cannot make personal changes to the web parts through the UI, unless the web part is a private web part and they have appropriate permissions.  <br/> |
-   
-> [!NOTE]
-> You cannot insert a web part zone inside a Device Channel Panel. If you want to allow authors to add web parts to a page, and if you are not concerned about the page weight for mobile devices, you can add a Rich Text Editor page field to a Device Channel Panel, and then instruct authors to add web parts there. You can add web parts directly to a Device Channel Panel (without a web part zone). For more information, see  [How to: Add a Device Channel Panel snippet in SharePoint](how-to-add-a-device-channel-panel-snippet-in-sharepoint.md). 
-  
-    
-    
+|**AllowLayoutChange**  |Specifies whether web parts within the zone can be closed, minimized, deleted, or restored.   If set to **False**, users cannot close, minimize, delete, or restore web parts in the zone, drag web parts to a different zone, or rearrange or move web parts within the zone. Users also cannot add web parts from the web part catalog, and several properties that affect the UI of web parts in the zone are disabled. This property does not affect the ability to change the layout programmatically.   If set to **True**, users with appropriate permissions can perform these actions.   |
+|**LockLayout**  |Specifies whether web parts within the zone can be added, deleted, resized, or moved. This property works the same whether the web part page is in personal view or shared view.   If set to **True**, the specific web part properties for each web part in the zone that are affected are: **Zone (ZoneID)**, **Part Order (PartOrder)**, **Visible on Page (IsVisible)**, **Height (Height)**, **Width (Width)**, **Allow Close (AllowRemove)**, and **IsIncluded** (the **Close** command on the **web part** menu). Other web part properties are not affected.  If set to **False**, the web part properties determine whether modifications can be made (together with the appropriate site permissions).   |
+|**AllowCustomization**  |Specifies whether shared property values of web parts within the zone can be modified.   If set to **True**, users with appropriate permissions can make changes to the web parts in the zone for all users.   If set to **False**, users cannot make changes to the web parts in the zone in the UI in shared view. But, changes can still be made programmatically and by using the web part Maintenance page.   |
+|**AllowPersonalization**  |Specifies whether personal property values of web parts within the zone can be modified.   If set to **True**, users with appropriate permissions can make personal changes to the web parts in the zone.   If set to **False**, users cannot make personal changes to the web parts through the UI, unless the web part is a private web part and they have appropriate permissions.   |
 
+> [!NOTE]
+> You cannot insert a web part zone inside a Device Channel Panel. If you want to allow authors to add web parts to a page, and if you are not concerned about the page weight for mobile devices, you can add a Rich Text Editor page field to a Device Channel Panel, and then instruct authors to add web parts there. You can add web parts directly to a Device Channel Panel (without a web part zone). For more information, see  [How to: Add a Device Channel Panel snippet in SharePoint](how-to-add-a-device-channel-panel-snippet-in-sharepoint.md).
 
 ## Inserting a web part zone snippet
-<a name="InsertSnippet"> </a>
 
 Like all snippets, you add this snippet from the Snippet Gallery. To navigate to the Snippet Gallery, you must first select a page layout to edit. Web part zones can be added to page layouts but cannot be added to master pages.
-  
-    
-    
 
 ### To insert a web part zone snippet
 
-
 1. Browse to your publishing site.
-    
-  
-2. In the upper-right corner of the page, choose the Settings gear, and then choose **Design Manager**.
-    
-  
-3. In Design Manager, in the left navigation pane, choose **Edit Page Layouts**.
-    
-  
-4. Select the name of the page layout that you want to add the snippet to.
-    
-  
-5. To open the Snippet Gallery, choose **Snippets** in the upper-right corner of the server-side preview.
-    
-  
-6. On the ribbon, on the **Design** tab, choose **web part zone**.
-    
-  
-7. On the right side of the Snippet Gallery, under **About this Component**, click or select section headers to expand or collapse groups of properties, and then configure any custom settings that you want.
-    
-    The section named **Important** contains the properties that are key to how this particular snippet works. For a web part zone, the snippet has a unique ID. After you copy the snippet into your page layout, you should not reuse this ID. If you want to add another web part zone snippet, choose **Refresh** to generate a new ID for the next snippet.
-    
-    For descriptions of properties that are necessary for restricting a web part zone ( **LockLayout**, **AllowCustomization**, and **AllowPersonalization**), see Table 1.
-    
-    > [!NOTE]
-    > You may notice that some property names are bold in the property grid of the Snippet Gallery. These properties have values that have been changed from the default setting for this component, but these properties are not necessarily relevant to a designer scenario. In other words, a property may be bold but not necessarily important for your scenario. 
+1. In the upper-right corner of the page, choose the Settings gear, and then choose **Design Manager**.
+1. In Design Manager, in the left navigation pane, choose **Edit Page Layouts**.
+1. Select the name of the page layout that you want to add the snippet to.
+1. To open the Snippet Gallery, choose **Snippets** in the upper-right corner of the server-side preview.
+1. On the ribbon, on the **Design** tab, choose **web part zone**.
+1. On the right side of the Snippet Gallery, under **About this Component**, click or select section headers to expand or collapse groups of properties, and then configure any custom settings that you want.
 
-8. After you configure any properties, choose **Update**. This updates the HTML snippet on the left side of the page, so that the markup reflects your custom settings. You can always choose **Reset** to return all properties to their default settings.
-    
-  
-9. On the left side of the Snippet Gallery, under **HTML Snippet**, choose **Copy to Clipboard**.
-    
-  
-10. In your HTML editor, open the mapped network drive on your computer, and then open the HTML file for the master page or page layout that you're adding the snippet to.
-    
+    The section named **Important** contains the properties that are key to how this particular snippet works. For a web part zone, the snippet has a unique ID. After you copy the snippet into your page layout, you should not reuse this ID. If you want to add another web part zone snippet, choose **Refresh** to generate a new ID for the next snippet.
+
+    For descriptions of properties that are necessary for restricting a web part zone ( **LockLayout**, **AllowCustomization**, and **AllowPersonalization**), see Table 1.
+
+    > [!NOTE]
+    > You may notice that some property names are bold in the property grid of the Snippet Gallery. These properties have values that have been changed from the default setting for this component, but these properties are not necessarily relevant to a designer scenario. In other words, a property may be bold but not necessarily important for your scenario.
+
+1. After you configure any properties, choose **Update**. This updates the HTML snippet on the left side of the page, so that the markup reflects your custom settings. You can always choose **Reset** to return all properties to their default settings.
+1. On the left side of the Snippet Gallery, under **HTML Snippet**, choose **Copy to Clipboard**.
+1. In your HTML editor, open the mapped network drive on your computer, and then open the HTML file for the master page or page layout that you're adding the snippet to.
+
     For more information, see  [How to: Map a network drive to the SharePoint Master Page Gallery](how-to-map-a-network-drive-to-the-sharepoint-master-page-gallery.md).
-    
-  
-11. In the HTML file, paste the snippet where you want the markup to appear.
-    
+
+1. In the HTML file, paste the snippet where you want the markup to appear.
+
     When you are adding the snippet to a page layout, make sure to paste the snippet inside **PlaceHolderMain**.
-    
-  
-12. Replace the **<div>** where `class="DefaultContentBlock"` with your own specific content.
-    
-  
-13. If you want to prepopulate the zone with web parts—for example, if the zone will restrict content authors to modifying only existing web parts and not adding new ones—insert web part snippets where the **<!--DC … -->** tag appears.
-    
-  
-14. Save the page, and then refresh the server-side preview in Design Manager to make sure the page appears as expected.
-    
-  
+
+1. Replace the `<div>` where `class="DefaultContentBlock"` with your own specific content.
+1. If you want to prepopulate the zone with web parts—for example, if the zone will restrict content authors to modifying only existing web parts and not adding new ones—insert web part snippets where the **<!--DC … -->** tag appears.
+1. Save the page, and then refresh the server-side preview in Design Manager to make sure the page appears as expected.
 
 ## Understanding the snippet markup
-<a name="UnderstandMarkup"> </a>
 
 The two most important parts of a web part zone snippet are the **ID** property and the **<!--DC … -->** comment. Each zone should have a unique ID. If you want to add more than one web part zone to your page layout, make sure to choose **Refresh** in the Snippet Gallery before copying each snippet so that a new ID is generated. The **<!--DC … -->** comment should be replaced with any web parts that you want to appear in the zone by default.
-  
-    
-    
+
 Additional properties that can be used to restrict how content authors can use zones ( **AllowCustomization**, **AllowPersonalization**, and **LockLayout**) are shown in the following code.
-  
+
 > [!NOTE]
 > The **AllowCustomization**, **AllowPersonalization**, and **LockLayout** properties appear in the markup only if you change their default values in the property grid.
-  
-    
-    
 
-
-
-
-```HTML
-
+```html
 <div data-name="WebPartZone">
     <!--CS: Start web part zone Snippet-->
     <!--SPM:<%@Register Tagprefix="WebPartPages" Namespace="Microsoft.SharePoint.WebPartPages" Assembly="Microsoft.SharePoint, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c"%>-->
@@ -219,24 +126,10 @@ Additional properties that can be used to restrict how content authors can use z
 
 ```
 
-
 ## See also
-<a name="AdditionalResources"> </a>
 
-
--  [SharePoint Design Manager snippets](sharepoint-design-manager-snippets.md)
-    
-  
--  [WebPartZone class](https://msdn.microsoft.com/library/system.web.ui.webcontrols.webparts.webpartzone.aspx)
-    
-  
--  [WebPartZoneBase properties](https://msdn.microsoft.com/library/335sw9k3.aspx)
-    
-  
--  [Build sites for SharePoint](build-sites-for-sharepoint.md)
-    
-  
--  [Develop the site design in SharePoint](develop-the-site-design-in-sharepoint.md)
-    
-  
-
+- [SharePoint Design Manager snippets](sharepoint-design-manager-snippets.md)
+- [WebPartZone class](https://msdn.microsoft.com/library/system.web.ui.webcontrols.webparts.webpartzone.aspx)
+- [WebPartZoneBase properties](https://msdn.microsoft.com/library/335sw9k3.aspx)
+- [Build sites for SharePoint](build-sites-for-sharepoint.md)
+- [Develop the site design in SharePoint](develop-the-site-design-in-sharepoint.md)


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- n/a

## What's in this Pull Request?

- markdown lists should not have explicit numbers (ie: 1,2,3,4)
- ever bullet should be `1.` & let the rendering engine number accordingly... if not working, it's a indentation issue
- this commit is a partial cleanup of this incorrect use of markdown
- fixed other markdown issues found when addressing the numbering issue
