### PR TITLE
Nick pape patch 1

### DIFF
--- a/docs/spfx/web-parts/guidance/use-sp-pnp-js-with-spfx-web-parts.md
+++ b/docs/spfx/web-parts/guidance/use-sp-pnp-js-with-spfx-web-parts.md
@@ -162,7 +162,7 @@ import "@pnp/sp/lists";
 import "@pnp/sp/items";
 import "@pnp/sp/batching";
 
-var _sp: SPFI = null;
+var _sp: SPFI | null = null;
 
 export const getSP = (context?: WebPartContext): SPFI => {
   if (context != null) {

--- a/docs/spfx/web-parts/guidance/use-sp-pnp-js-with-spfx-web-parts.md
+++ b/docs/spfx/web-parts/guidance/use-sp-pnp-js-with-spfx-web-parts.md
@@ -170,7 +170,7 @@ export const getSP = (context?: WebPartContext): SPFI => {
     // The LogLevel set's at what level a message will be written to the console
     _sp = spfi().using(SPFx(context)).using(PnPLogging(LogLevel.Warning));
   }
-  return _sp;
+  return _sp!;
 };
 ```
 


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- fixes #9143

## What's in this Pull Request?

SPFx 1.17.4 began enabling strict null checks by default. The sample code assumes strict null checks are off, therefore it blocks the developer from assigning `null` to a typed value. We address this by making the type for that variable also include `| null`, however, we must also update the return statement of the helper function to assert that this is non-null. This change only affects types, but does not affect functionality.
