### PR TITLE
Update compatibility.md

### DIFF
--- a/docs/spfx/compatibility.md
+++ b/docs/spfx/compatibility.md
@@ -34,7 +34,7 @@ The following table lists SharePoint Framework and compatible versions of common
 
 |              SPFx               |   Node.js (LTS) |                    NPM                    |   TypeScript   |    React    |
 | ------------------------------- | --------------- | ----------------------------------------- | -------------- | ----------- |
-| [1.17.4](release-1.17.4.md)     | v16.13+         | v5, v6, v7, v8                            | v4.5           | v17.0.1     |
+| [1.17.4](release-1.17.4.md)     | v16.13+         | v5, v6, v7, v8                            | v4.5           | v17.0.2     |
 | [1.17.3](release-1.17.3.md)     | v16.13+         | v5, v6, v7, v8                            | v4.5           | v17.0.1     |
 | [1.17.2](release-1.17.2.md)     | v16.13+         | v5, v6, v7, v8                            | v4.5           | v17.0.1     |
 | [1.17.1](release-1.17.1.md)     | v16.13+         | v5, v6, v7, v8                            | v4.5           | v17.0.1     |


### PR DESCRIPTION
From my testing is appears that SPFx 1.17.4 requires react 17.0.2 not 17.0.1 - I keep getting dependency errors when installing 17.0.1

## Category

- [x] Content fix
- [ ] New article

## Related issues

N/A

## What's in this Pull Request?

An update to the documentation regarding the relevant react version when working with SPFx