### PR TITLE
Add missing bullets to the list of resources

### DIFF
--- a/docs/sp-add-ins/determine-sharepoint-rest-service-endpoint-uris.md
+++ b/docs/sp-add-ins/determine-sharepoint-rest-service-endpoint-uris.md
@@ -11,8 +11,8 @@ ms.service: sharepoint
 > [!TIP]
 > Before you start, review the following resources:
 >
-> [Get to know the SharePoint REST service](get-to-know-the-sharepoint-rest-service.md)
-> [Navigate the SharePoint data structure represented in the REST service](navigate-the-sharepoint-data-structure-represented-in-the-rest-service.md)
+> - [Get to know the SharePoint REST service](get-to-know-the-sharepoint-rest-service.md)
+> - [Navigate the SharePoint data structure represented in the REST service](navigate-the-sharepoint-data-structure-represented-in-the-rest-service.md)
 > - [Use OData query operations in SharePoint REST requests](use-odata-query-operations-in-sharepoint-rest-requests.md)
 
 ## SharePoint REST endpoint URI structure


### PR DESCRIPTION
This commit adds the missing bullets to the elements of the bulleted list that appears in the "Tip" info box at the top of the page.

## Category

- [x] Content fix
- [ ] New article

## What's in this Pull Request?

Fixes a formatting issue by adding bullets to items which are meant to be part of a bulleted list