### PR TITLE
Fix decode base 64 may fail for some client secret

### DIFF
--- a/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
+++ b/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
@@ -51,11 +51,10 @@ Ensure the following before you begin:
     $objectId = $app.ObjectId
 
     $base64secret = New-AzureADServicePrincipalPasswordCredential -ObjectId $objectId -EndDate $endDate
-    $secret = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($base64secret.Value))
-    New-AzureADServicePrincipalKeyCredential -ObjectId $objectId -EndDate $endDate -Type Symmetric -Usage Verify -Value $secret
-    New-AzureADServicePrincipalKeyCredential -ObjectId $objectId -EndDate $endDate -Type Symmetric -Usage Sign -Value $secret
+    New-AzureADServicePrincipalKeyCredential -ObjectId $objectId -EndDate $endDate -Type Symmetric -Usage Verify -Value $base64secret.Value
+    New-AzureADServicePrincipalKeyCredential -ObjectId $objectId -EndDate $endDate -Type Symmetric -Usage Sign -Value $base64secret.Value
 
-    $base64secret.Value
+    [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($base64secret.Value))
     $base64secret.EndDate # Print the end date.
     ```
 


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- fixes #9170 

## What's in this Pull Request?
The base64 decode may fail for some generated client secret from AAD. Use a safe way encode it again to avoid such cases.
