### PR TITLE
wrapped head tags in code so they aren't stripped from output

### DIFF
--- a/docs/general-development/how-to-create-a-page-layout-in-sharepoint.md
+++ b/docs/general-development/how-to-create-a-page-layout-in-sharepoint.md
@@ -98,7 +98,7 @@ If you're using Design Manager to create page layouts and master pages, the most
 - **PlaceHolderMain** The master page contains a content placeholder with `ID="PlaceholderMain"`, which contains the **DefaultContentBlock** `<div>` tag with the yellow box that shows **This area will be filled in by content you create in your page layouts.** You should not put any content inside this placeholder on the master page. The page layout contains a content placeholder with the same ID. You should put markup only inside this placeholder, and put no markup outside this placeholder, on a page layout. The IDs for the two placeholders ( **PlaceholderMain**) should match.
     
   
-- **PlaceHolderAdditionalPageHead** When you work with a page layout, you typically don't insert elements into the **<head>** tag of the page layout. Instead, you add elements to the content placeholder with `id="PlaceHolderAdditionalPageHead"`. When a content page is rendered in the browser, this additional page head gets merged into the end of the head of the master page. 
+- **PlaceHolderAdditionalPageHead** When you work with a page layout, you typically don't insert elements into the `<head>` tag of the page layout. Instead, you add elements to the content placeholder with `id="PlaceHolderAdditionalPageHead"`. When a content page is rendered in the browser, this additional page head gets merged into the end of the head of the master page. 
     
   
 
@@ -184,7 +184,7 @@ When you create HTML mockups for your site, you may have HTML files that represe
   
     
     
-You can simply put the styles for one or more page layouts into the same style sheet that the master page links to. But, if you want to minimize the weight of the CSS that is loaded per page, you can also use different style sheets for different page layouts. When you do this, it's important to know that a link to a style sheet cannot go in the **<head>** tag of a page layout. Instead, the link must go in the content placeholder named **PlaceHolderAdditionalPageHead**. 
+You can simply put the styles for one or more page layouts into the same style sheet that the master page links to. But, if you want to minimize the weight of the CSS that is loaded per page, you can also use different style sheets for different page layouts. When you do this, it's important to know that a link to a style sheet cannot go in the `<head>` tag of a page layout. Instead, the link must go in the content placeholder named **PlaceHolderAdditionalPageHead**. 
   
 > [!NOTE]
 > In this markup, the attribute  `ms-design-css-conversion="no"` excludes the style sheet from theming. Also, the link to the style sheet should appear after the lines commented **<!--SPM**. 

--- a/docs/general-development/how-to-make-custom-css-files-themable-in-sharepoint.md
+++ b/docs/general-development/how-to-make-custom-css-files-themable-in-sharepoint.md
@@ -1,7 +1,7 @@
 ---
 title: Make custom CSS files themable in SharePoint
 description: Learn how to add comment-style markup to a CSS file so that it can be used in the SharePoint theming engine.
-ms.date: 06/13/2022
+ms.date: 09/28/2023
 ms.assetid: b8c82c77-c836-47f9-a11e-6c9c656d436b
 ms.localizationpriority: high
 ---

--- a/docs/general-development/how-to-make-custom-css-files-themable-in-sharepoint.md
+++ b/docs/general-development/how-to-make-custom-css-files-themable-in-sharepoint.md
@@ -130,5 +130,4 @@ The following is an example of an **\<SharePoint:CssRegistration\>** element.
 - [Upgrade custom themes and CSS to SharePoint](upgrade-custom-themes-and-css-to-sharepoint.md)
 - [How to: Create a master page preview file in SharePoint](how-to-create-a-master-page-preview-file-in-sharepoint.md)
 - [Color palettes and fonts in SharePoint](color-palettes-and-fonts-in-sharepoint.md)
-- [SharePoint Team Blog: Show off your style with SharePoint theming](https://www.microsoft.com/microsoft-365/blog/2012/10/29/show-off-your-style-with-sharepoint-theming/)
 - [SharePoint Design Manager branding and design capabilities](sharepoint-design-manager-branding-and-design-capabilities.md)

--- a/docs/general-development/how-to-make-custom-css-files-themable-in-sharepoint.md
+++ b/docs/general-development/how-to-make-custom-css-files-themable-in-sharepoint.md
@@ -103,7 +103,7 @@ CSS files must be checked in and published. If CSS files are changed, you must r
 
 ## Register the CSS file
 
-You must register the CSS file with a master page before the CSS file can be used by the theming engine. This directs the master page to the CSS file when you apply a theme to a site. To register a CSS file, you add a **\<SharePoint:CssRegistration\>** element to the **<head>** element of the master page. The following shows the format of the **\<SharePoint:CssRegistration\>** element.
+You must register the CSS file with a master page before the CSS file can be used by the theming engine. This directs the master page to the CSS file when you apply a theme to a site. To register a CSS file, you add a **\<SharePoint:CssRegistration\>** element to the `<head>` element of the master page. The following shows the format of the **\<SharePoint:CssRegistration\>** element.
 
 ```HTML
 <SharePoint:CssRegistration Name="CSSFileLocation" runat="server" />


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

In reviewing instances of the soon to be disallowed head HTML tag across Learn, I found that this article refers to head without escaping it. Learn doesn't know what to do with this tag, so it results in content loss.

## Related issues

n/a

## What's in this Pull Request?

Changed references to the head HTML tag to inline code. I didn't update ms.date because this isn't a substantive update.


