### PR TITLE
Update spod-copy-move-api.md

### DIFF
--- a/docs/apis/spod-copy-move-api.md
+++ b/docs/apis/spod-copy-move-api.md
@@ -1,10 +1,10 @@
 ---
 title: Microsoft 365 Copy and Move API (CreateCopyJobs)
 description: "Microsoft 365 Copy and Move API (CreateCopyJobs)"
-ms.date: 06/29/2022
+ms.date: 09/29/2023
 ms.author: jhendr
 author: JoanneHendrickson
-manager: pamgreen
+manager: serdars
 audience: ITPro
 f1.keywords:
 - NOCSH
@@ -140,6 +140,6 @@ Currently, the following limitations are:
 
 |       What        |             Limitation              |
 | :---------------- | :---------------------------------- |
-| File size         | A file must be less than 2 GB.      |
+| File size         | [SharePoint Limits](/office365/servicedescriptions/sharepoint-online-service-description/sharepoint-online-limits#moving-and-copying-across-sites) |
 | Number of items   | No more than 30,000 items in a job. |
 | Total size of job | Job size not to exceed 100 GB.      |


### PR DESCRIPTION
Updated line 143 to insert a link to SharePoint limits for copy move limits.

## Category

- [X] Content fix

## What's in this Pull Request?

An update to line 143 that corrects outdating file size limitation in copy and move.  Instead inserted a link to the Sharepoint Limits article to avoid it being out of date in the future.