### PR TITLE
Update overview.md to include "TeamsModern" option

### DIFF
--- a/docs/spfx/office/overview.md
+++ b/docs/spfx/office/overview.md
@@ -39,7 +39,8 @@ Use the SPFx's `context` property on the web part's class and the Microsoft Team
 if (!!this.context.sdks.microsoftTeams) {
   const teamsContext = await this.context.sdks.microsoftTeams.teamsJs.app.getContext();
   switch (teamsContext.app.host.name.toLowerCase()) {
-    case 'teams':
+    case 'teams': // this is the host name for the "classic" Teams client
+    case 'teamsmodern': // this is the host name for the "new" Teams client
       // RUNNING IN MICROSOFT TEAMS
     case 'office':
       // RUNNING IN OFFICE / OFFICE.COM


### PR DESCRIPTION
Added the "teamsmodern" value for host.name to include the new Microsoft Teams client option.

## Category

- [x] Content fix
- [ ] New article
- [ ] Example checked item (*delete this line*)

## Related issues

The original document was missing the "TeamsModern" option and as such code would fail in the new Microsoft Teams client.

## What's in this Pull Request?

I simply added the "teamsmodern" option to the case switch.