### PR TITLE
Fix teams manifest in sample code

### DIFF
--- a/docs/spfx/build-for-teams-meeting-app.md
+++ b/docs/spfx/build-for-teams-meeting-app.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial: Build meeting apps for Microsoft Teams with SPFx"
 description: Build meeting apps for Microsoft Teams with the SharePoint Framework.
-ms.date: 04/28/2021
+ms.date: 12/30/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/spfx/build-for-teams-meeting-app.md
+++ b/docs/spfx/build-for-teams-meeting-app.md
@@ -130,7 +130,7 @@ Add the following JSON to the file:
   "manifestVersion": "1.8",
   "packageName": "{{SPFX_PACKAGE_NAME}}",
   "id": "{{SPFX_COMPONENT_ID}}",
-  "version": "1.0",
+  "version": "1.0.0",
   "developer": { .. },
   "name": {
     "short": "{{SPFX_COMPONENT_NAME}}"


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## What's in this Pull Request?

Small fix to a Teams manifest.json file. With the given version value there's an error when validating the manifest because the expected format of the version is "x.x.x" and not, like the example, "1.0".
