### PR TITLE
🐞 change links for spe tutorials > msl modules

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -51,9 +51,9 @@ landingContent:
       - linkListType: tutorial
         links:
           - text: SharePoint Embedded - Overview & Configuration
-            url: /sharepoint/dev/embedded/mslearn/m01-01-intro
+            url: /training/modules/sharepoint-embedded-setup
           - text: SharePoint Embedded - Building an App
-            url: /sharepoint/dev/embedded/mslearn/m02-01-intro
+            url: /training/modules/sharepoint-embedded-create-app
 
   # Card (optional)
   - title: Samples


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- fix #9477

## What's in this Pull Request?

fix broken links on spdev docs landing page to spe tutorials moved > ms learning