### PR TITLE
Add redirects for moved SPE MSL modules

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -99,6 +99,16 @@
       "source_path": "docs/spfx/sharepoint-2019-support.md",
       "redirect_url": "/sharepoint/dev/spfx/sharepoint-2019-and-subscription-edition-support",
       "redirect_document_id": false
+    },
+    {
+      "source_path": "docs/embedded/mslearn/m01-01-intro.md",
+      "redirect_url": "/training/modules/sharepoint-embedded-setup/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "docs/embedded/mslearn/m02-01-intro.md",
+      "redirect_url": "/training/modules/sharepoint-embedded-create-app/",
+      "redirect_document_id": false
     }
   ]
 }


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article
- [x] Example checked item (*delete this line*)

## Related issues

- n/a

## What's in this Pull Request?

Noticed some external links not under this repo's control created hard links to previously relocated content (sharepoint embedded learning modules). This PR includes redirects from the old path => new path.