### PR TITLE
♻️ remove incorrect statements about `{tenantdomain}`

### DIFF
--- a/docs/spfx/viva/features/focus-feature/FocusFeatureTutorial.md
+++ b/docs/spfx/viva/features/focus-feature/FocusFeatureTutorial.md
@@ -25,7 +25,7 @@ When prompted, enter the following values (select the default option for all pro
 
 At this point, Yeoman installs the required dependencies and scaffolds the solution files. This process might take few minutes.
 
-Before moving forward, update the title and description fields of your ACE to give it a personal touch.
+Before moving forward, update the `title` and `description` fields of your ACE to give it a personal touch.
 
 ```json
 {
@@ -57,25 +57,7 @@ Before moving forward, update the title and description fields of your ACE to gi
 }
 ```
 
-## Update your project's hosted workbench URL
-
-When you use the gulp task **serve**, by default it will launch a browser with the specified hosted workbench URL specified in your project. The default URL for the hosted workbench in a new project points to an invalid URL.
-
-- Locate and open the file **./config/serve.json** in your project.
-- Locate the property `initialPage`:
-
-    ```json
-    {
-      "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/spfx-serve.schema.json",
-      "port": 4321,
-      "https": true,
-      "initialPage": "https://{tenantDomain}/_layouts/workbench.aspx"
-    }
-    ```
-
-- Change the `{tenantDomain}` domain to the URL of your SharePoint tenant and site you want to use for testing. For example: `https://contoso.sharepoint.com/sites/devsite/_layouts/workbench.aspx`.
-
-At this point, if you do **gulp serve**, then you'll see the **FocusFeature** card:
+Next, run **gulp serve** from the command line in the root of the project to start the build and debugging process. In the hosted workbench, you'll see the **FocusFeature** card:
 
 ![See the FocusFeature card icon in the webpart toolbox](./img/focusFeatureTutorialACE.png)
 

--- a/docs/spfx/viva/get-started/actions/geolocation/GeolocationTutorial.md
+++ b/docs/spfx/viva/get-started/actions/geolocation/GeolocationTutorial.md
@@ -30,25 +30,7 @@ When prompted, enter the following values (select the default option for all pro
 
 At this point, Yeoman installs the required dependencies and scaffolds the solution files. This process might take few minutes.
 
-## Update your project's hosted workbench URL
-
-When you use the gulp task **serve**, by default it will launch a browser with the specified hosted workbench URL specified in your project. The default URL for the hosted workbench in a new project points to an invalid URL.
-
-- Locate and open the file **./config/serve.json** in your project.
-- Locate the property `initialPage`:
-
-    ```json
-    {
-      "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/spfx-serve.schema.json",
-      "port": 4321,
-      "https": true,
-      "initialPage": "https://{tenantDomain}/_layouts/workbench.aspx"
-    }
-    ```
-
-- Change the `{tenantDomain}` domain to the URL of your SharePoint tenant and site you want to use for testing. For example: `https://contoso.sharepoint.com/sites/devsite/_layouts/workbench.aspx`.
-
-At this point, if you do **gulp serve**, then you will see the **GeoLocation** card:
+Next, run **gulp serve** from the command line in the root of the project. When the hosted workbench loads, you'll see the **GeoLocation** card:
 
 ![See the GeoLocation card icon in the webpart toolbox](../../../../../../docs/images/viva-extensibility/geolocation/geoloactionAppIcon.png)
 

--- a/docs/spfx/viva/get-started/actions/media-upload/MediaUploadTutorial.md
+++ b/docs/spfx/viva/get-started/actions/media-upload/MediaUploadTutorial.md
@@ -25,25 +25,7 @@ When prompted, enter the following values (select the default option for all pro
 
 At this point, Yeoman installs the required dependencies and scaffolds the solution files. This process might take few minutes.
 
-## Update your project's hosted workbench URL
-
-When you use the gulp task **serve**, by default it will launch a browser with the specified hosted workbench URL specified in your project. The default URL for the hosted workbench in a new project points to an invalid URL.
-
-- Locate and open the file **./config/serve.json** in your project.
-- Locate the property `initialPage`:
-
-    ```json
-    {
-      "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/spfx-serve.schema.json",
-      "port": 4321,
-      "https": true,
-      "initialPage": "https://{tenantDomain}/_layouts/workbench.aspx"
-    }
-    ```
-
-- Change the `{tenantDomain}` domain to the URL of your SharePoint tenant and site you want to use for testing. For example: `https://contoso.sharepoint.com/sites/devsite/_layouts/workbench.aspx`.
-
-At this point, if you do **gulp serve**, then you'll see the **MediaUpload** card:
+Next, run **gulp serve** from the command line in the root of the project. When the hosted workbench loads, you'll see the **MediaUpload** card:
 
 ![See the MediaUpload card icon in the webpart toolbox](./img/mediaUploadTutorialACE.PNG)
 
@@ -51,9 +33,7 @@ At this point, if you do **gulp serve**, then you'll see the **MediaUpload** car
 
 At this point, we have out of the box Adaptive Card Extension code. Now it's time to flare things up with selecting media from the Card and Quick views.
 
-In the Card View, we'll provide a button that will perform the following actions:
-
-- Upload an image file
+In the Card View, we'll provide a button that will perform the following actions: **Upload an image file**
 
 ### Update the labels that will show up on the card
 

--- a/docs/spfx/viva/get-started/build-data-visualization-adaptive-card-extension.md
+++ b/docs/spfx/viva/get-started/build-data-visualization-adaptive-card-extension.md
@@ -32,25 +32,7 @@ When prompted, enter the following values (select the default option for all oth
 
 At this point, Yeoman installs the required dependencies and scaffolds the solution files. This process might take few minutes.
 
-## Update your project's hosted workbench URL
-
-When you use the gulp task **serve**, by default it will launch a browser with the specified hosted workbench URL specified in your project. The default URL for the hosted workbench in a new project points to an invalid URL.
-
-- Locate and open the file **./config/serve.json** in your project.
-- Locate the property `initialPage`:
-
-    ```json
-    {
-      "$schema": "https://developer.microsoft.com/json-schemas/core-build/serve.schema.json",
-      "port": 4321,
-      "https": true,
-      "initialPage": "https://{tenantDomain}/ _layouts/workbench.aspx"
-    }
-    ```
-
-- Change the `{tenantDomain}` domain to the URL of your SharePoint tenant and site you want to use for testing. For example: `https://contoso.sharepoint.com/sites/devsite/_layouts/workbench.aspx`.
-
-At this point, if you do `gulp serve`, and select the add icon in the hosted workbench to open the toolbox, you'll see the **Data Visualization** card:
+Next, run **gulp serve** from the command line in the root of the project. Select the add icon in the hosted workbench to open the toolbox, you'll see the **Data Visualization** card:
 
 ![See the Data Visualization card icon in the workbench toolbox](../../../../docs/images/viva-extensibility/data-visualization/toolbox.png)
 

--- a/docs/spfx/viva/get-started/build-first-sharepoint-adaptive-card-extension.md
+++ b/docs/spfx/viva/get-started/build-first-sharepoint-adaptive-card-extension.md
@@ -30,31 +30,6 @@ When prompted, enter the following values (*select the default option for all pr
 
 At this point, Yeoman installs the required dependencies and scaffolds the solution files. This process might take few minutes.
 
-### Update your project's hosted workbench URL
-
-When you use the gulp task **serve**, by default it will launch a browser with the specified hosted workbench URL specified in your project. The default URL for the hosted workbench in a new project points to an invalid URL.
-
-- Locate and open the file **./config/serve.json** in your project.
-- Locate the property `initialPage`:
-
-    ```json
-    {
-      "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/spfx-serve.schema.json",
-      "port": 4321,
-      "https": true,
-      "initialPage": "https://{tenantDomain}/_layouts/workbench.aspx"
-    }
-    ```
-
-- Change the `{tenantDomain}` domain to the URL of your SharePoint tenant and site you want to use for testing. For example: `https://contoso.sharepoint.com/sites/devsite/_layouts/workbench.aspx`.
-
-> [!TIP]
-> You can also start the local web server without launching a browser by including the `nobrowser` argument to the **gulp serve** command. For example, you may not want to modify the **serve.json** file in all your projects and instead, use a bookmark to launch your hosted workbench.
->
-> ```console
-> gulp serve --nobrowser
-> ```
-
 ## Serve the ACE in the workbench
 
 Before digging into the code, run the scaffolded output and see what an Adaptive Card Extension looks like.

--- a/docs/spfx/viva/get-started/build-people-search-adaptive-card-extension.md
+++ b/docs/spfx/viva/get-started/build-people-search-adaptive-card-extension.md
@@ -39,25 +39,7 @@ When prompted, enter the following values (select the default option for all que
 
 At this point, Yeoman installs the required dependencies and scaffolds the solution files. This process might take few minutes.
 
-## Update your project's hosted workbench URL
-
-When you use the gulp task **serve**, by default it opens a browser with the specified hosted workbench URL specified in your project. The default URL for the hosted workbench in a new project points to an invalid URL.
-
-- Locate and open the file **./config/serve.json** in your project
-- Locate the property `initialPage`
-
-    ```json
-    {
-      "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/spfx-serve.schema.json",
-      "port": 4321,
-      "https": true,
-      "initialPage": "https://{tenantDomain}/ _layouts/workbench.aspx"
-    }
-    ```
-
-- Change the `{tenantDomain}` domain to the URL of your SharePoint tenant and site you want to use for testing. For example: `https://contoso.sharepoint.com/sites/devsite/_layouts/workbench.aspx`.
-
-At this point, if you do **gulp serve**, then you see the **People Search** card:
+Next, run **gulp serve** from the command line in the root of the project. Once the hosted workbench loads, you'll see the **People Search** card:
 
 ![See the People Search card icon in the workbench toolbox](../../../../docs/images/viva-extensibility/people-search/toolbox.png)
 

--- a/docs/spfx/web-parts/get-started/build-a-hello-world-web-part.md
+++ b/docs/spfx/web-parts/get-started/build-a-hello-world-web-part.md
@@ -81,31 +81,6 @@ The client-side toolchain uses HTTPS endpoints by default. Part of the [Set up y
 >
 > If you didn't trust the dev cert, follow the steps outlined on this page: [Set up your development environment: Trusting the self-signed developer certificate](../../set-up-your-development-environment.md#trusting-the-self-signed-developer-certificate).
 
-### Update your project's hosted workbench URL
-
-When you use the gulp task **serve**, by default it will launch a browser with the specified hosted workbench URL specified in your project. The default URL for the hosted workbench in a new project points to an invalid URL.
-
-- Locate and open the file **./config/serve.json** in your project.
-- Locate the property `initialPage`:
-
-    ```json
-    {
-      "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/spfx-serve.schema.json",
-      "port": 4321,
-      "https": true,
-      "initialPage": "https://{tenantDomain}/_layouts/workbench.aspx"
-    }
-    ```
-
-- Change the `tenantDomain` to the URL of your SharePoint tenant. For example: `https://contoso.sharepoint.com/_layouts/workbench.aspx`.
-
-> [!TIP]
-> You can also start the local web server without launching a browser by including the `nobrowser` argument to the **gulp serve** command. For example, you may not want to modify the **serve.json** file in all your projects and instead, use a bookmark to launch your hosted workbench.
->
-> ```console
-> gulp serve --nobrowser
-> ```
-
 ### Start the local web server & launch the hosted workbench
 
 Assuming you've installed & trusted developer certificate, execute the following command in the console to build and preview your web part:
@@ -115,11 +90,6 @@ gulp serve
 ```
 
 This command executes a series of gulp tasks to create and start a local webserver hosting the endpoints **localhost:4321** and **localhost:5432**. It will then open your default browser and load the hosted workbench preview web parts from your local dev environment.
-
-> [!NOTE]
-> If you're seeing issues working with the hosted workbench, please see details on installing a developer certificate: [Set up your development environment: Trusting the self-signed developer certificate](../../set-up-your-development-environment.md#trusting-the-self-signed-developer-certificate).
->
-> If you're still seeing issues, see: [SharePoint Framework known issues and frequently asked questions](../../known-issues-and-common-questions.yml)
 
 ```console
 gulp serve


### PR DESCRIPTION
## Category

- [x] Content fix

## Related issues

- n/a

## What's in this Pull Request?

Multiple docs incorrectly referneced the `{tenantdomain}` placeholder in the serve.json configuration. This comment removes those incorrect statements.
