### PR TITLE
import override is missing from current generated file

### DIFF
--- a/docs/spfx/extensions/get-started/building-simple-cmdset-with-dialog-api.md
+++ b/docs/spfx/extensions/get-started/building-simple-cmdset-with-dialog-api.md
@@ -89,7 +89,7 @@ You can follow these steps by watching the video on the Microsoft 365 Platform C
 
 Open the file **./src/extensions/helloWorld/HelloWorldCommandSet.ts**.
 
-Notice the base class for the ListView Command Set is imported from the **\@microsoft/sp-listview-extensibility** package, which contains SharePoint Framework (SPFx) code required by the ListView Command Set.
+Notice the base class for the ListView Command Set is imported from the **\@microsoft/sp-listview-extensibility** package, which contains SharePoint Framework (SPFx) code required by the ListView Command Set.  Update the file to match this.
 
 ```typescript
 import { override } from '@microsoft/decorators';


### PR DESCRIPTION
Update ./src/extensions/helloWorld/HelloWorldCommandSet.ts to include
import { override } from '@microsoft/decorators';

## Category

- [x] Content fix

## What's in this Pull Request?

import { override } from '@microsoft/decorators'; is missing from ./src/extensions/helloWorld/HelloWorldCommandSet.ts
Added text to update the file.


