### PR TITLE
Removing import { override } from '@microsoft/decorators';

### DIFF
--- a/docs/spfx/extensions/get-started/building-simple-cmdset-with-dialog-api.md
+++ b/docs/spfx/extensions/get-started/building-simple-cmdset-with-dialog-api.md
@@ -92,7 +92,6 @@ Open the file **./src/extensions/helloWorld/HelloWorldCommandSet.ts**.
 Notice the base class for the ListView Command Set is imported from the **\@microsoft/sp-listview-extensibility** package, which contains SharePoint Framework (SPFx) code required by the ListView Command Set.
 
 ```typescript
-import { override } from '@microsoft/decorators';
 import { Log } from '@microsoft/sp-core-library';
 import {
   BaseListViewCommandSet,


### PR DESCRIPTION
import { override } from '@microsoft/decorators'; is not used in this sample

## Category

- [x ] Content fix

## Related issues

## What's in this Pull Request?
import { override } from '@microsoft/decorators'; is not used in this sample.  Removed line.

## Submission guidelines

