### PR TITLE
Propose removing the card for SharePoint Add-Ins

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -157,20 +157,6 @@ landingContent:
             url: /sharepoint/dev/apis/webhooks/get-started-webhooks
 
   # Card
-  - title: SharePoint Add-ins
-    linkLists:
-      - linkListType: overview
-        links:
-          - text: Overview of SharePoint Add-ins
-            url: /sharepoint/dev/sp-add-ins/sharepoint-add-ins
-      - linkListType: get-started
-        links:
-          - text: Create provider-hosted SharePoint Add-ins
-            url: /sharepoint/dev/sp-add-ins/get-started-creating-provider-hosted-sharepoint-add-ins
-          - text: Create SharePoint-hosted SharePoint Add-ins
-            url: /sharepoint/dev/sp-add-ins/get-started-creating-sharepoint-hosted-sharepoint-add-ins
-
-  # Card
   - title: Solution guidance
     linkLists:
       - linkListType: overview


### PR DESCRIPTION
SharePoint Add-Ins have been retired.  I propose removing this card.

https://learn.microsoft.com/en-us/sharepoint/dev/sp-add-ins/retirement-announcement-for-add-ins

## Category

- [x] Content fix

## Related issues


## What's in this Pull Request?
Removed SharePoint Add-In card.
