### PR TITLE
Fix webhook renewal link

### DIFF
--- a/docs/apis/webhooks/webhooks-reference-implementation.md
+++ b/docs/apis/webhooks/webhooks-reference-implementation.md
@@ -157,7 +157,7 @@ Create a web job that on a weekly basis reads all the subscription IDs from the 
 > [!NOTE]
 > This web job is not part of this reference implementation.
 
-The actual renewal of a SharePoint list webhook can be done by using a `[PATCH /_api/web/lists('list-id')/subscriptions(‘subscriptionID’)](./lists/update-subscription.md)` REST call.
+The actual renewal of a SharePoint list webhook can be done by using a [`PATCH /_api/web/lists('list-id')/subscriptions(‘subscriptionID’)`](./lists/update-subscription.md) REST call.
 
 In the reference implementation, updating of webhooks is implemented in the [WebHookManager](https://github.com/SharePoint/sp-dev-samples/blob/master/Samples/WebHooks.List/SharePoint.WebHooks.Common/WebHookManager.cs) class of the **SharePoint.WebHooks.Common** project.
 


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues
N/A

## What's in this Pull Request?

This fixes a broken link caused by misplaced backticks.
![image](https://github.com/SharePoint/sp-dev-docs/assets/32133502/ee24326e-8396-49e7-b073-438a929a3ea8)

## Submission guidelines

I'm not sure if I need to update `ms.date` for an inconsequential change.