### PR TITLE
Fixed the broken URL for CLI M365 Login

### DIFF
--- a/docs/features/hub-site/hub-site-o365cli.md
+++ b/docs/features/hub-site/hub-site-o365cli.md
@@ -1,7 +1,7 @@
 ---
 title: CLI for Microsoft 365 commands for SharePoint hub sites
 description: Use CLI for Microsoft 365 to create and manage SharePoint hub sites.
-ms.date: 06/28/2022
+ms.date: 06/26/2024
 ms.localizationpriority: high
 ---
 
@@ -17,7 +17,7 @@ To run the CLI for Microsoft 365 commands, you'll need to do the following:
 
 1. Download and install [NodeJS LTS version](https://nodejs.org/en/)
 1. Follow the instructions at [Installing the CLI](https://pnp.github.io/cli-microsoft365/user-guide/installing-cli/) to install the CLI for Microsoft 365 on your machine
-1. Follow the instructions at [Logging in to Office 365](https://pnp.github.io/cli-microsoft365/user-guide/connecting-office-365/) to connect to your SharePoint tenant.
+1. Follow the instructions at [Logging in to Office 365](https://pnp.github.io/cli-microsoft365/user-guide/connecting-microsoft-365) to connect to your SharePoint tenant.
 
 To verify your setup and connection, try using the [hubsite list](https://pnp.github.io/cli-microsoft365/cmd/spo/hubsite/hubsite-list/) command to list the current hub sites. If the cmdlet runs and returns with no errors, you're ready to proceed.
 

--- a/docs/features/hub-site/hub-site-o365cli.md
+++ b/docs/features/hub-site/hub-site-o365cli.md
@@ -1,7 +1,7 @@
 ---
 title: CLI for Microsoft 365 commands for SharePoint hub sites
 description: Use CLI for Microsoft 365 to create and manage SharePoint hub sites.
-ms.date: 06/26/2024
+ms.date: 06/27/2024
 ms.localizationpriority: high
 ---
 


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- N/A

## What's in this Pull Request?

This pull request fixes the faulty URL for Logging in to Office 365 which was in the section, [Getting Started](https://learn.microsoft.com/en-us/sharepoint/dev/features/hub-site/hub-site-o365cli#get-started)
