### PR TITLE
Update custom formatter docs[Image field]

### DIFF
--- a/docs/declarative-customization/formatting-syntax-reference.md
+++ b/docs/declarative-customization/formatting-syntax-reference.md
@@ -963,6 +963,25 @@ The following example shows how a hyperlink field might be used on a current fie
 
 **Image fields**
 
+The image field object has the following properties (deprecated):
+
+```json
+{
+  "fileName": "image.png",
+  "id": "6bb1d843-0633-4c9a-9a16-90bc5abd1d8e",
+  "serverRelativeUrl": "/teams/Discovery/SiteAssets/Lists/ad6ed939-0db2-4d85-8a39-8f3497f41eee/image.png",
+  "serverUrl": "https://contoso.sharepoint.com",
+  "thumbnailRenderer": {
+        "spItemUrl": "https://contoso.sharepoint.com:443/_api/v2.1/drives/b!7196759210defdc0/items/2303b15bfa48c74a74758135a0df1201",
+        "fileVersion": 3,
+        "sponsorToken": "3u+UR6n8AgABAAAAHxxdXKmiOmUoqKnZlf8lTOhlPYy93EAkbPfs5+49YLFd/B1+omSKbW7DoqNM40/EeVnwJ8kYoXv9zy9D5C5m5A=="
+      }
+}
+```
+> [!NOTE]
+> All the properties above other than `fileName` don't have any values anymore. Use the below `@currentField` method wherever you can.
+
+
 The following example shows how an image field can be used on a current field.
 
 ```json

--- a/docs/declarative-customization/formatting-syntax-reference.md
+++ b/docs/declarative-customization/formatting-syntax-reference.md
@@ -963,22 +963,6 @@ The following example shows how a hyperlink field might be used on a current fie
 
 **Image fields**
 
-The image field object has the following properties (with example values):
-
-```json
-{
-  "fileName": "image.png",
-  "id": "6bb1d843-0633-4c9a-9a16-90bc5abd1d8e",
-  "serverRelativeUrl": "/teams/Discovery/SiteAssets/Lists/ad6ed939-0db2-4d85-8a39-8f3497f41eee/image.png",
-  "serverUrl": "https://contoso.sharepoint.com",
-  "thumbnailRenderer": {
-        "spItemUrl": "https://contoso.sharepoint.com:443/_api/v2.1/drives/b!7196759210defdc0/items/2303b15bfa48c74a74758135a0df1201",
-        "fileVersion": 3,
-        "sponsorToken": "3u+UR6n8AgABAAAAHxxdXKmiOmUoqKnZlf8lTOhlPYy93EAkbPfs5+49YLFd/B1+omSKbW7DoqNM40/EeVnwJ8kYoXv9zy9D5C5m5A=="
-      }
-}
-```
-
 The following example shows how an image field can be used on a current field.
 
 ```json

--- a/docs/declarative-customization/formatting-syntax-reference.md
+++ b/docs/declarative-customization/formatting-syntax-reference.md
@@ -963,23 +963,15 @@ The following example shows how a hyperlink field might be used on a current fie
 
 **Image fields**
 
-The image field object has the following properties (deprecated):
+The image field object has the following `fileName` property:
 
 ```json
 {
   "fileName": "image.png",
-  "id": "6bb1d843-0633-4c9a-9a16-90bc5abd1d8e",
-  "serverRelativeUrl": "/teams/Discovery/SiteAssets/Lists/ad6ed939-0db2-4d85-8a39-8f3497f41eee/image.png",
-  "serverUrl": "https://contoso.sharepoint.com",
-  "thumbnailRenderer": {
-        "spItemUrl": "https://contoso.sharepoint.com:443/_api/v2.1/drives/b!7196759210defdc0/items/2303b15bfa48c74a74758135a0df1201",
-        "fileVersion": 3,
-        "sponsorToken": "3u+UR6n8AgABAAAAHxxdXKmiOmUoqKnZlf8lTOhlPYy93EAkbPfs5+49YLFd/B1+omSKbW7DoqNM40/EeVnwJ8kYoXv9zy9D5C5m5A=="
-      }
 }
 ```
 > [!NOTE]
-> All the properties above other than `fileName` don't have any values anymore. Use the below `@currentField` method wherever you can.
+> As of July 2024, just the `fileName` property has a value.
 
 
 The following example shows how an image field can be used on a current field.


### PR DESCRIPTION
## Category

- [X] Content fix


## Related issues

- fixes #9411

## What's in this Pull Request?
There were some changes in the way image fields are stored on the server. They don't have the properties `serverUrl`, `id` etc anymore. Only the filename is present. Updating the custom formatter documentation to reflect the same.
