### PR TITLE
Update user-experiences-overview.md and containertypes.md

### DIFF
--- a/docs/embedded/concepts/app-concepts/containertypes.md
+++ b/docs/embedded/concepts/app-concepts/containertypes.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint Embedded Container Types
 description: This article explains how Container Types work.
-ms.date: 05/21/2024
+ms.date: 07/30/2024
 ms.localizationpriority: high
 ---
 
@@ -13,15 +13,15 @@ Each container type is strongly coupled with one SharePoint Embedded application
 
 Container type is represented on each container instance as an immutable property (ContainerTypeID) and is used across the entire SharePoint Embedded ecosystem, including:
 
-- Access authorization. A SharePoint Embedded application must be associated to a container type to get access to container instances of that type. Once associated, the application has access to all container instances of that type. The actual access privilege is determined by the application-ContainerTypeID permission setting. The owning application by default has full access privilege to all container instances of the container type it's strongly coupled with. Learn more about [SharePoint Embedded Authorization](../app-concepts/auth.md).
+- Access authorization. A SharePoint Embedded application must be associated with a container type to get access to container instances of that type. Once associated, the application has access to all container instances of that type. The actual access privilege is determined by the application-ContainerTypeID permission setting. The owning application by default has full access privilege to all container instances of the container type it's strongly coupled with. Learn more about [SharePoint Embedded Authorization](../app-concepts/auth.md).
 - Easy exploration. Container type can be created for trial purposes, allowing developers to explore SharePoint Embedded application development and assess its features for free.
-- Billing. Container types for non-trial purposes are billable and must be created with an Azure Subscription. Usage of containers is metered and charged. Learn more about [metering](../admin-exp/billing/meters.md) and the [SharePoint Embedded billing experience](../admin-exp/billing/billing.md).
+- Billing. Container types for non-trial purposes are billable and must be created with an Azure Subscription. The usage of containers is metered and charged. Learn more about [metering](../admin-exp/billing/meters.md) and the [SharePoint Embedded billing experience](../admin-exp/billing/billing.md).
 - Configurable behaviors. Container type defines selected behaviors for all container instances of that type. Learn more about setting [Container type configuration](../app-concepts/containertypes.md#configuring-container-types).
 
 > [!NOTE]
 >
-> 1. You must specify the purpose of the container type you are creating at creation time. Dependent on the purpose, you may or may not need to provide your Azure Subscription ID. A container type set for trial purpose cannot be converted for production; or vice versa.
-> 2. You must use the latest version of SharePoint Powershell for container type configurations.
+> 1. You must specify the purpose of the container type you are creating at creation time. Depending on the purpose, you may or may not need to provide your Azure Subscription ID. A container type set for trial purpose cannot be converted for production; or vice versa.
+> 1. You must use the latest version of SharePoint Powershell for container type configurations.
 
 ## Trial use
 
@@ -42,7 +42,7 @@ The following restrictions are applied to container type in the trial status:
 - Up to five active containers of the container type can be created.
 - Each container has up to 1 GB of storage space.
 - The container type expires after 30 days and access to any existing containers of that container type will be removed.
-- Developer must permanently delete all containers of an existing container type in trial status to create a new container type for trial. This includes containers in the deleted container collection.
+- The developer must permanently delete all containers of an existing container type in trial status to create a new container type for trial. This includes containers in the deleted container collection.
 - The container type is restricted to work in the developer tenant. It can't be deployed in other consuming tenants.
 
 ## Standard/Non-trial use
@@ -63,13 +63,13 @@ New-SPOContainerType
 ```
 
 > [!NOTE]
-> The user or admin who will set up billing relationship for SharePoint Embedded will need to have owner or contributor permissions on the Azure subscription.
+> The user or admin who will set up a billing relationship for SharePoint Embedded will need to have owner or contributor permissions on the Azure subscription.
 
 ## Configuring Container Types
 
 Developer Admin can set selected settings on the SharePoint Embedded container types created by using this PowerShell cmdlet.
 
-This cmdlet allows admins to set [Microsoft 365 content discoverability](../content-experiences/user-experiences-overview.md) and [sharing](../app-concepts/sharing-and-perm.md) settings on container types. The setting is applicable to all container instances of the container type
+This cmdlet allows admins to set [Microsoft 365 content discoverability](../content-experiences/user-experiences-overview.md) and [sharing](../app-concepts/sharing-and-perm.md) settings on container types. The setting applies to all container instances of the container type
 
 ```powershell
 Set-SPOContainerTypeConfiguration -ContainerTypeId 4f0af585-8dcc-0000-223d-661eb2c604e4 -DiscoverabilityDisabled $False
@@ -97,7 +97,7 @@ Region              : EastUS
 
 ## Registering Container Types
 
-In order to create and interact with containers, you must [register](../app-concepts/register-api-documentation.md) the container type within the Consuming Tenant. The owning application defines the permissions for the container type by invoking the [registration API](../app-concepts/register-api-documentation.md).
+To create and interact with containers, you must [register](../app-concepts/register-api-documentation.md) the container type within the Consuming Tenant. The owning application defines the permissions for the container type by invoking the [registration API](../app-concepts/register-api-documentation.md).
 
 ## Deleting Container Types
 

--- a/docs/embedded/concepts/app-concepts/containertypes.md
+++ b/docs/embedded/concepts/app-concepts/containertypes.md
@@ -42,7 +42,7 @@ The following restrictions are applied to container type in the trial status:
 - Up to five active containers of the container type can be created.
 - Each container has up to 1 GB of storage space.
 - The container type expires after 30 days and access to any existing containers of that container type will be removed.
-- Developer must delete all containers of an existing container type in trial status to create a new container type for trial.
+- Developer must permanently delete all containers of an existing container type in trial status to create a new container type for trial. This includes containers in the deleted container collection.
 - The container type is restricted to work in the developer tenant. It can't be deployed in other consuming tenants.
 
 ## Standard/Non-trial use

--- a/docs/embedded/concepts/content-experiences/user-experiences-overview.md
+++ b/docs/embedded/concepts/content-experiences/user-experiences-overview.md
@@ -28,7 +28,7 @@ You can use [Microsoft Graph's Download DriveItem API](/graph/api/driveitem-get-
 
 ## Content discovery in Microsoft 365
 
-You can control how your content appears in the Microsoft 365 experience. The default behavior is SharePoint Embedded application content will be hidden in Microsoft 365 environments including office.com, oneDrive.com, or other Microsoft intelligent file discovery features.
+You can control how your content appears in the Microsoft 365 experience. The default behavior is SharePoint Embedded application content will be hidden in Microsoft 365 environments including office.com, oneDrive.com, or other Microsoft intelligent file discovery features. The default behavior also excludes M365 Copilot from grounding with your SharePoint Embedded application content.
 
 If you want to opt into the Microsoft 365 experience, during container type creation, you can change the default settings using cmdlet [Set-SPOContainerTypeConfiguration](../admin-exp/developer-admin/dev-admin.md#container-type-configuration-properties) as per this example:
 

--- a/docs/embedded/concepts/content-experiences/user-experiences-overview.md
+++ b/docs/embedded/concepts/content-experiences/user-experiences-overview.md
@@ -1,19 +1,19 @@
 ---
 title: Content Experiences Overview
 description: Experiences with SharePoint Embedded content
-ms.date: 05/21/2024
+ms.date: 07/30/2024
 ms.localizationpriority: high
 ---
 
 # User experiences overview
 
-SharePoint Embedded provides a comprehensive set of user experience features like open & edit of Office files, file preview or in-app search that you can use to build the right user experiences for your applications.
+SharePoint Embedded provides a comprehensive set of user experience features like open and editing Office files, file preview, or in-app search that you can use to build the right user experiences for your applications.
 
 ## Open & edit using Office
 
-Office documents from SharePoint Embedded applications can be opened for viewing, editing and collaborating using either on the web, or Office applications for a richer viewing and editing experience. Learn more about [Office experiences available on SharePoint Embedded](./office-experience.md).
+Office documents from SharePoint Embedded applications can be opened for viewing, editing, and collaborating using either the web or Office applications for a richer viewing and editing experience. Learn more about [Office experiences available on SharePoint Embedded](./office-experience.md).
 
-You can set up your applications to launch Office when a user selects on an Office document within your application. This includes options to directly launch an Office application or to open it in a specific mode, such as view (for read-only content) or edit (for editing mode). Learn how to [configure the right Office Experience for your Office Documents](../../tutorials/launch-experience.md)
+You can set up your applications to launch Office when a user selects an Office document within your application. This includes options to directly launch an Office application or to open it in a specific mode, such as view (for read-only content) or edit (for editing mode). Learn how to [configure the right Office Experience for your Office Documents](../../tutorials/launch-experience.md)
 
 ## Preview content
 
@@ -21,14 +21,14 @@ Integrate your application with SharePoint Embedded player plugin to offer file 
 
 ## Download
 
-You can use [Microsoft Graph's Download DriveItem API](/graph/api/driveitem-get-content) to offer download file user experiences for your applications. This will generate  a short lived, preauthenticated Url allows users to download files from your applications.
+You can use [Microsoft Graph's Download DriveItem API](/graph/api/driveitem-get-content) to offer download file user experiences for your applications. This will generate  a short-lived, pre-authenticated URL that allows users to download files from your applications.
 
 > [!NOTE]
->A direct link to the file lacks the appropriate authorization from your application. If used directly in a browser, this would yield an access denied.
+> A direct link to the file lacks the appropriate authorization from your application. If used directly in a browser, this would yield an access denied.
 
 ## Content discovery in Microsoft 365
 
-You can control how your content appears in the Microsoft 365 experience. The default behavior is SharePoint Embedded application content will be hidden in Microsoft 365 environments including office.com, oneDrive.com, or other Microsoft intelligent file discovery features. The default behavior also excludes M365 Copilot from grounding with your SharePoint Embedded application content.
+You can control how your content appears in the Microsoft 365 experience. The default behavior is SharePoint Embedded application content will be hidden in Microsoft 365 environments including office.com, oneDrive.com, or other Microsoft intelligent file discovery features. The default behavior also excludes Copilot for Microsoft 365 from grounding with your SharePoint Embedded application content.
 
 If you want to opt into the Microsoft 365 experience, during container type creation, you can change the default settings using cmdlet [Set-SPOContainerTypeConfiguration](../admin-exp/developer-admin/dev-admin.md#container-type-configuration-properties) as per this example:
 
@@ -43,8 +43,7 @@ In this way, your files will be integrated into the Microsoft 365 environment, p
 > [!NOTE]
 >
 > 1. If you modify the settings after creating some content, it may take up to 30 days for these changes to achieve full consistency across all consuming tenants.
->
-> 2. To enable the sharing user experience for your content in Office.com, additional application permissions **must** be added at the time of the container type registration process. To add more permission to enable sharing dialog, refer to the following code:
+> 1. To enable the sharing user experience for your content in Office.com, additional application permissions **must** be added at the time of the container type registration process. To add more permission to enable sharing dialog, refer to the following code:
 
 ```http
 PUT /storageContainerTypes/{containerTypeId}/applicationPermissions
@@ -59,4 +58,4 @@ Content-Type: application/json
 
 ## Recycle bin
 
-You can use Microsoft Graph to either delete or permanently delete items in containers. Deleted items are moved to the container’s recycle bin and retained for 93 days. During this period, the items can be restored or permanently deleted using Microsoft Graph. An item in recycle bin is permanently deleted when it exceeds the 93-day retention period. Permanently deleted items can't be restored.
+You can use Microsoft Graph to either delete or permanently delete items in containers. Deleted items are moved to the container’s recycle bin and retained for 93 days. During this period, the items can be restored or permanently deleted using Microsoft Graph. An item in the recycle bin is permanently deleted when it exceeds the 93-day retention period. Permanently deleted items can't be restored.


### PR DESCRIPTION
## Category

- [ x] Content fix
- [ ] New article
- [x Example checked item (*delete this line*)

## Related issues

- fixes unclear explanation of M365 discoverability and Copilot.
- fixes unclear explanation on container type for trial.

## What's in this Pull Request?
Explicitly call out default behavior of M365 discoverability for SPE is to hide SPE app content from M365 surfaces, and the default behavior includes hiding these content from M365 Copilot grounding.

Explicitly call out to create a new container type for trial, all containers of an existing container type must be permanently deleted, including the ones in the deleted container collection.

## Submission guidelines

