### PR TITLE
Update replace-an-expiring-client-secret-in-a-sharepoint-add-in.md

### DIFF
--- a/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
+++ b/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
@@ -17,7 +17,7 @@ Client secrets for SharePoint Add-ins that are registered by using the **AppRegN
 
 ## Recommended maintenance schedule
 
-We recommend creating new secrets a minimum of 30 days before they expire. This gives you a month of time before the old credentials expire.
+We recommend creating new secrets a minimum of 30 days before they expire. This gives you a month before the old credentials expire.
 
 We recommend only removing secrets a minimum of 7 days after expiration, provided you have removed them from the application configuration.
 
@@ -28,7 +28,7 @@ Removing an expired secret from ACS before you remove it from the application co
 Ensure the following before you begin:
 
 - You have installed Microsoft Graph Powershell SDK: [Install the Microsoft Graph PowerShell SDK](/powershell/microsoftgraph/installation)
-- You're a tenant administrator (or having `Application.ReadWrite.All` permission) for the Microsoft 365 tenant where the add-in was registered with the **AppRegNew.aspx** page.
+- You're a tenant administrator (or having **Application.ReadWrite.All** permission) for the Microsoft 365 tenant where the add-in was registered with the **AppRegNew.aspx** page.
 
 ## Generate a new secret
 
@@ -38,13 +38,13 @@ Ensure the following before you begin:
     $clientId = 'client id of the add-in'
     ```
 
-2. Connect to graph with `Application.ReadWrite.All, Directory.ReadWrite.All` scope.
+1. Connect to Microsoft Graph with **Application.ReadWrite.All**, **Directory.ReadWrite.All** scope.
 
     ```powershell
-    Connect-MgGraph -Scopes "Application.ReadWrite.All,Directory.ReadWrite.All" # Login with corresponding scope. Should be tenant admin or anyone have the permission.
+    Connect-MgGraph -Scopes "Application.ReadWrite.All,Directory.ReadWrite.All" # Login with corresponding scope. Should the tenant admin or anyone else have the permission.
     ```
     
-3. Generate a new client secret with the following lines:
+1. Generate a new client secret with the following lines:
 
     ```powershell
     $appPrincipal = Get-MgServicePrincipal -Filter "AppId eq '$clientId'" # Get principal id by AppId
@@ -80,12 +80,12 @@ Ensure the following before you begin:
     $result.EndDateTime # Print the end date.
     ```
 
-4. The new client secret appears on the Windows PowerShell console. Copy it to a text file. You use it in the next procedure.
+1. The new client secret appears on the Windows PowerShell console. Copy it to a text file. You use it in the next procedure.
 
     > [!TIP]
-    > By default, the secret lasts two years if you didn't specify the EndDateTime. You can customize by leveraging the example below to specify the EndDateTime.
+    > By default, the secret lasts two years if you didn't specify the EndDateTime. You can customize by using the example below to specify the EndDateTime.
     > 
-    > ``` powershell
+    > ```powershell
     > $params = @{
     >     PasswordCredential = @{
     >         DisplayName = "NewSecret" # Replace with a firendly name.
@@ -97,7 +97,7 @@ Ensure the following before you begin:
 ## Update the remote web application in Visual Studio to use the new secret
 
 > [!IMPORTANT]
-> If your add-in was originally created with a pre-release version of the Microsoft Office Developer Tools for Visual Studio, it may contain an out-of-date version of the **TokenHelper.[cs|vb]** file. If the file does not contain the string `secondaryClientSecret`, it is out of date and must be replaced before you can update the web application with a new secret. To obtain a copy of a release version of the file, you need Visual Studio 2012 or later. Create a new SharePoint Add-in project in Visual Studio. Copy the **TokenHelper.[cs|vb]** file from it to the web application project of your SharePoint Add-in.
+> If your add-in was created with a pre-release version of the Microsoft Office Developer Tools for Visual Studio, it may contain an out-of-date version of the **TokenHelper.[cs|vb]** file. If the file does not contain the string `secondaryClientSecret`, it is out of date and must be replaced before you can update the web application with a new secret. To obtain a copy of a release version of the file, you need Visual Studio 2012 or later. Create a new SharePoint Add-in project in Visual Studio. Copy the **TokenHelper.[cs|vb]** file from it to the web application project of your SharePoint Add-in.
 
 1. Open the SharePoint Add-in project in Visual Studio, and open the **web.config** file for the web application project. In the `appSettings` section, there are keys for the client ID and client secret. The following is an example:
 

--- a/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
+++ b/docs/sp-add-ins/replace-an-expiring-client-secret-in-a-sharepoint-add-in.md
@@ -1,7 +1,7 @@
 ---
 title: Replace an expiring client secret in a SharePoint Add-in
 description: Add a new client secret for a SharePoint Add-in that is registered with AppRegNew.aspx.
-ms.date: 09/26/2023
+ms.date: 09/09/2024
 ms.localizationpriority: high
 ms.service: sharepoint
 ---
@@ -27,8 +27,8 @@ Removing an expired secret from ACS before you remove it from the application co
 
 Ensure the following before you begin:
 
-- You have installed Azure Active Directory PowerShell 2.0: [Install Azure Active Directory PowerShell for Graph](/powershell/azure/active-directory/install-adv2)
-- You're a tenant administrator for the Microsoft 365 tenant where the add-in was registered with the **AppRegNew.aspx** page.
+- You have installed Microsoft Graph Powershell SDK: [Install the Microsoft Graph PowerShell SDK](/powershell/microsoftgraph/installation)
+- You're a tenant administrator (or having `Application.ReadWrite.All` permission) for the Microsoft 365 tenant where the add-in was registered with the **AppRegNew.aspx** page.
 
 ## Generate a new secret
 
@@ -38,35 +38,60 @@ Ensure the following before you begin:
     $clientId = 'client id of the add-in'
     ```
 
-1. Connect to AzureAD PowerShell.
+2. Connect to graph with `Application.ReadWrite.All, Directory.ReadWrite.All` scope.
 
     ```powershell
-    $AzureAdCred = Get-Credential
-    Connect-AzureAD -Credential $AzureAdCred # Login to AzureAD
+    Connect-MgGraph -Scopes "Application.ReadWrite.All,Directory.ReadWrite.All" # Login with corresponding scope. Should be tenant admin or anyone have the permission.
     ```
     
-1. Generate a new client secret with the following lines:
+3. Generate a new client secret with the following lines:
 
     ```powershell
-    $endDate = (Get-Date).AddYears(1)
-    $app = Get-AzureADServicePrincipal -Filter "AppId eq '$clientId'"
-    $objectId = $app.ObjectId
-
-    $base64secret = New-AzureADServicePrincipalPasswordCredential -ObjectId $objectId -EndDate $endDate
-    New-AzureADServicePrincipalKeyCredential -ObjectId $objectId -EndDate $endDate -Type Symmetric -Usage Verify -Value $base64secret.Value
-    New-AzureADServicePrincipalKeyCredential -ObjectId $objectId -EndDate $endDate -Type Symmetric -Usage Sign -Value $base64secret.Value
-
-    [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($base64secret.Value))
-    $base64secret.EndDate # Print the end date.
+    $appPrincipal = Get-MgServicePrincipal -Filter "AppId eq '$clientId'" # Get principal id by AppId
+    $params = @{
+        PasswordCredential = @{
+            DisplayName = "NewSecret" # Replace with a friendly name.
+        }
+    }
+    $result = Add-MgServicePrincipalPassword -ServicePrincipalId $appPrincipal.Id -BodyParameter $params    # Update the secret
+    $base64Secret = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($result.SecretText)) # Convert to base64 string.
+    $app = Get-MgServicePrincipal -ServicePrincipalId $appPrincipal.Id # get existing app information
+    $existingKeyCredentials = $app.KeyCredentials # read existing credentials
+    $dtStart = [System.DateTime]::Now # Start date
+    $dtEnd = $dtStart.AddYears(2) # End date (equals to secret end date)
+    $keyCredentials = @( # construct keys
+        @{
+            Type = "Symmetric"
+            Usage = "Verify"
+            Key = [System.Text.Encoding]::ASCII.GetBytes($result.SecretText)
+            StartDateTime = $dtStart
+            EndDateTIme = $dtEnd
+        },
+        @{
+            type = "Symmetric"
+            usage = "Sign"
+            key = [System.Text.Encoding]::ASCII.GetBytes($result.SecretText)
+            StartDateTime = $dtStart
+            EndDateTIme = $dtEnd
+        }
+    ) + $existingKeyCredentials # combine with existing
+    Update-MgServicePrincipal -ServicePrincipalId $appPrincipal.Id -KeyCredentials $keyCredentials # Update keys
+    $base64Secret # Print base64 secret
+    $result.EndDateTime # Print the end date.
     ```
 
-1. The new client secret appears on the Windows PowerShell console. Copy it to a text file. You use it in the next procedure.
+4. The new client secret appears on the Windows PowerShell console. Copy it to a text file. You use it in the next procedure.
 
     > [!TIP]
-    > By default, the secret lasts one year. You can customize by leveraging the example below to specify the EndDateTime.
+    > By default, the secret lasts two years if you didn't specify the EndDateTime. You can customize by leveraging the example below to specify the EndDateTime.
     > 
     > ``` powershell
-    > $endDate = (Get-Date).AddYears(2) # 2 year.
+    > $params = @{
+    >     PasswordCredential = @{
+    >         DisplayName = "NewSecret" # Replace with a firendly name.
+    >         EndDateTime = "2025-01-01T00:00:00Z" # Optional. Specify the end date you want. Using ISO 8601 format.
+    >     }
+    > }
     > ```
 
 ## Update the remote web application in Visual Studio to use the new secret


### PR DESCRIPTION
Since Azure AD PowerShell was deprecated on March 30, 2024 (https://techcommunity.microsoft.com/t5/microsoft-entra-blog/important-azure-ad-graph-retirement-and-powershell-module/ba-p/3848270), we need to change the sample scripts to Microsoft Graph PowerShell SDK. The commit 020d3e0 (https://github.com/SharePoint/sp-dev-docs/commit/020d3e0e51537028fdd916299b08f369e694256d)  changed the scripts from Microsoft Graph PowerShell SDK to Auzre AD PowerShell on Sep 13, 2023. I've reverted this again.

## Category

- [x] Content fix
- [ ] New article

## Related issues
N/A

## What's in this Pull Request?

Change the sample scripts from Azure AD PowerShell to Microsoft Graph PowerShell SDK in "Generate a new secret" section.

## Submission guidelines

> - **!!IMPORTANT!!** - All submissions must complete the baseline sections included in this template. Ignoring or deleting this template may result in closing the issue with the label **type:incomplete-submission**.
> - Follow our guidance on [How To Create Good Pull Requests](https://github.com/SharePoint/sp-dev-docs/wiki/How-to-Create-Good-Pull-Requests).
> - Target the `main` branch of this repo.
> - When changing a page, ensure you update the `ms.date` front matter wih the current date in the format `MM/DD/YYYY`.
> - Review all build checks and address the automated errors, warnings, and suggestions.
> - *NOTE: The live site is based on the `live` branch. Site owners periodically refresh `live` branch from the `main` branch so merged PRs won't immediately appear on the live site. Please be patient to see your changes appear on the live site.*
>
> **DELETE THIS SECTION BEFORE SUBMITTING**
