### PR TITLE
Add note to Entra PS and az CLI in SPE auth page

### DIFF
--- a/docs/embedded/concepts/app-concepts/auth.md
+++ b/docs/embedded/concepts/app-concepts/auth.md
@@ -108,7 +108,7 @@ Any user accessing a container must be a member of the container. Membership to 
 
 Here are some actions you can take next:
 
-1. Configure your SharePoint Embedded [application manifest](/entra/identity-platform/reference-app-manifest#requiredresourceaccess-attribute) to request the required permissions:
+1. Configure your SharePoint Embedded [application manifest](/entra/identity-platform/reference-app-manifest#requiredresourceaccess-attribute) (you may use [Entra PowerShell](/powershell/entra-powershell/manage-apps?view=entra-powershell#assign-permissions-to-an-app) or [Azure CLI](/cli/azure/ad/app/permission?view=azure-cli-latest#az-ad-app-permission-add)) to request the required permissions:
    - Microsoft Graph (resourceAppId: `00000003-0000-0000-c000-000000000000`)
      - `FileStorageContainer.Selected` (type: `Scope`, ID: `085ca537-6565-41c2-aca7-db852babc212`) to access containers on consuming tenants
    - Office 365 SharePoint Online (resourceAppId: `00000003-0000-0ff1-ce00-000000000000`)

--- a/docs/embedded/concepts/app-concepts/auth.md
+++ b/docs/embedded/concepts/app-concepts/auth.md
@@ -83,7 +83,7 @@ SharePoint Embedded applications need to be granted container type application p
 | UpdatePermissions    | Can update (change roles of) existing memberships in the container for containers of this container type.          |
 | DeletePermissions    | Can delete other members (but not self) from the container for containers of this container type.                  |
 | DeleteOwnPermissions | Can remove own membership from the container for containers of this container type.                                |
-| ManagePermissions    | Can add, remove (including self) or update members in the container roles for containers of this container type.   |
+| ManagePermissions    | Can add, remove (including self), or update members in the container roles for containers of this container type.  |
 | ManageContent        | Can manage the content of the container                                                                            |
 | Full                 | Has all permissions for containers of this container type.                                                         |
 
@@ -100,15 +100,15 @@ Any user accessing a container must be a member of the container. Membership to 
 | Permission |                                                                                 Description                                                                                 |
 | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Reader     | This role allows the user to read the properties and the contents of the container.                                                                                         |
-| Writer     | This role has all permissions a Reader has, plus the permission to create, update, and delete content inside the container, and to update applicable  container properties. |
-| Manager    | This role has all permissions a Writer has, plus the permission to manage membership of the container.                                                                      |
-| Owner      | This role has all permissions a Manager has, plus the permission to delete containers.                                                                                      |
+| Writer     | This role has all the permissions a Reader has, plus the permission to create, update, and delete content inside the container, and to update applicable  container properties. |
+| Manager    | This role has all the permissions a Writer has, plus the permission to manage membership of the container.                                                                      |
+| Owner      | This role has all the permissions a Manager has, plus the permission to delete containers.                                                                                      |
 
 ## What's next
 
 Here are some actions you can take next:
 
-1. Configure your SharePoint Embedded [application manifest](/entra/identity-platform/reference-app-manifest#requiredresourceaccess-attribute) (you may use [Entra PowerShell](/powershell/entra-powershell/manage-apps#assign-permissions-to-an-app) or [Azure CLI](/cli/azure/ad/app/permission#az-ad-app-permission-add)) to request the required permissions:
+1. Configure your SharePoint Embedded [application manifest](/entra/identity-platform/reference-app-manifest#requiredresourceaccess-attribute) (you may use [Entra PowerShell](/powershell/entra-powershell/manage-apps#assign-permissions-to-an-app) or the [Azure CLI](/cli/azure/ad/app/permission#az-ad-app-permission-add)) to request the required permissions:
    - Microsoft Graph (resourceAppId: `00000003-0000-0000-c000-000000000000`)
      - `FileStorageContainer.Selected` (type: `Scope`, ID: `085ca537-6565-41c2-aca7-db852babc212`) to access containers on consuming tenants
    - Office 365 SharePoint Online (resourceAppId: `00000003-0000-0ff1-ce00-000000000000`)

--- a/docs/embedded/concepts/app-concepts/auth.md
+++ b/docs/embedded/concepts/app-concepts/auth.md
@@ -108,7 +108,7 @@ Any user accessing a container must be a member of the container. Membership to 
 
 Here are some actions you can take next:
 
-1. Configure your SharePoint Embedded [application manifest](/entra/identity-platform/reference-app-manifest#requiredresourceaccess-attribute) (you may use [Entra PowerShell](/powershell/entra-powershell/manage-apps?view=entra-powershell#assign-permissions-to-an-app) or [Azure CLI](/cli/azure/ad/app/permission?view=azure-cli-latest#az-ad-app-permission-add)) to request the required permissions:
+1. Configure your SharePoint Embedded [application manifest](/entra/identity-platform/reference-app-manifest#requiredresourceaccess-attribute) (you may use [Entra PowerShell](/powershell/entra-powershell/manage-apps#assign-permissions-to-an-app) or [Azure CLI](/cli/azure/ad/app/permission#az-ad-app-permission-add)) to request the required permissions:
    - Microsoft Graph (resourceAppId: `00000003-0000-0000-c000-000000000000`)
      - `FileStorageContainer.Selected` (type: `Scope`, ID: `085ca537-6565-41c2-aca7-db852babc212`) to access containers on consuming tenants
    - Office 365 SharePoint Online (resourceAppId: `00000003-0000-0ff1-ce00-000000000000`)

--- a/docs/embedded/concepts/app-concepts/auth.md
+++ b/docs/embedded/concepts/app-concepts/auth.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint Embedded Authentication and Authorization
 description: This article describes the authentication and authorization model for SharePoint Embedded applications.
-ms.date: 08/26/2024
+ms.date: 09/23/2024
 ms.localizationpriority: high
 ---
 


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## What's in this Pull Request?

Added a link to the Entra PowerShell cmdlet they can use to add app permissions, and also to the Azure CLI command. A customer thought they can only perform this action by editing the application manifest as text. This makes it explicit that there are other options for them to add app permissions.

