### PR TITLE
Adds to the tutorial the requirement of installing the correct React version

### DIFF
--- a/docs/spfx/extensions/guidance/using-custom-dialogs-with-spfx.md
+++ b/docs/spfx/extensions/guidance/using-custom-dialogs-with-spfx.md
@@ -1,7 +1,7 @@
 ---
 title: Tutorial - Use custom dialog boxes with SharePoint Framework Extensions
 description: Create a custom dialog box and use it within the context of a ListView Command Set extension.
-ms.date: 12/13/2021
+ms.date: 10/10/2024
 ms.localizationpriority: high
 ---
 
@@ -38,6 +38,12 @@ You can access the sample code that this article is based on in the [sp-dev-fx-e
 
     ```console
     npm install office-ui-fabric-react  --save
+    ```
+
+1. Install the correct version of React and React-dom indicated in [SPFx development environment compatibility](../../compatibility.md#spfx-development-environment-compatibility).
+
+    ```console
+    npm instal react@17.0.1 react-dom@17.0.1 --save-exact
     ```
 
 1. Open your project folder in your code editor. This article uses Visual Studio Code in the steps and screenshots, but you can use any editor that you prefer. To open the folder in Visual Studio Code, use the following command in the console:


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- fixes
- partially
- mentioned in #8795

## What's in this Pull Request?

Adds a console command to the tutorial that installs the correct React and React-dom version

Following the tutorials with SPFx 1.20, can cause it to target 17.0.2 instead of 17.0.1 causing the extension to fail.

I think the issue of needing to specify the version is known since last year https://github.com/SharePoint/sp-dev-docs/issues/8795#issuecomment-1450319157