### PR TITLE
SharePoint site scripts - Invalid properties in json examples

### DIFF
--- a/docs/declarative-customization/site-design-json-schema.md
+++ b/docs/declarative-customization/site-design-json-schema.md
@@ -1,7 +1,7 @@
 ---
 title: Site template JSON schema
 description: JSON schema reference for building site templates for SharePoint.
-ms.date: 09/23/2022
+ms.date: 11/18/2024
 ms.localizationpriority: high
 ---
 

--- a/docs/declarative-customization/site-design-json-schema.md
+++ b/docs/declarative-customization/site-design-json-schema.md
@@ -18,9 +18,7 @@ The overall JSON structure is specified as follows:
     ...
     <one or more verb actions>
     ...
-  ],
-  "bindata": { },
-  "version": 1
+  ]
 }
 ```
 

--- a/docs/declarative-customization/site-design-overview.md
+++ b/docs/declarative-customization/site-design-overview.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint site template and site script overview
 description: Use SharePoint site scripts and site templates to provide custom configurations to apply when new sites are created.
-ms.date: 06/28/2022
+ms.date: 11/18/2024
 ms.localizationpriority: high
 ---
 

--- a/docs/declarative-customization/site-design-overview.md
+++ b/docs/declarative-customization/site-design-overview.md
@@ -102,8 +102,7 @@ The following example is a script that has two top-level actions. First, it appl
         }
       ]
     }
-  ],
-  "version": 1
+  ]
 }
 ```
 


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- fixes -
- partially - 
- mentioned in - 

## What's in this Pull Request?

Removed properties ("version", "bindata") in the json because they are not part of the linked schema.json and the example json is not valid like that. Please either fix the doku (e.g. with this PR), fix the schema to match the given examples or describe a use case for this fields. Maybe more pages need to be fixed?