### PR TITLE
docs: fix non-auxillary use of you've

### DIFF
--- a/docs/solution-guidance/security-apponly.md
+++ b/docs/solution-guidance/security-apponly.md
@@ -12,7 +12,7 @@ ms.localizationpriority: medium
 
 There are two approaches for doing app-only for SharePoint: 
 
- - Using an **Azure AD application**: this is the preferred method when using SharePoint Online because you can also grant permissions to other Office 365 services (if needed) + you’ve a user interface (Azure portal) to maintain your app principals.
+ - Using an **Azure AD application**: this is the preferred method when using SharePoint Online because you can also grant permissions to other Office 365 services (if needed) + you have a user interface (Azure portal) to maintain your app principals.
  - Using a **SharePoint App-Only principal**: this method is older and only works for SharePoint access, but is still relevant. This method is also the recommended model when you’re still working in SharePoint on-premises since this model works in both SharePoint on-premises as SharePoint Online.
 
 Both methods are detailed in following articles: 


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

n/a

## What's in this Pull Request?

Fixes use of "you've".  As indicated by https://www.oxfordlearnersdictionaries.com/us/definition/english/you-ve, the use of the contraction would be used as an auxiliary verb, but in this case, "you have (a user interface)" is more appropriate because "have" is the primary verb in the sentence.  This makes the sentence more clear to English readers from many different backgrounds.  

(By contrast, "if you've maintained principals in the azure portal..." would also be correct)


