### PR TITLE
Fix the navigation for article "SharePoint webhooks using azd"

### DIFF
--- a/docs/apis/webhooks/sharepoint-webhooks-using-azd-template.md
+++ b/docs/apis/webhooks/sharepoint-webhooks-using-azd-template.md
@@ -1,7 +1,8 @@
 ---
 title: Create Azure Functions for SharePoint webhooks using an azd template
-description: Use Azure Developer cli (azd) to deploy an Azure function app that connects to your SharePoint Online tenant, to register and manage webhooks, and process the notifications from SharePoint.
-ms.date: 02/27/2025
+description: Use Azure Developer cli (azd) to deploy an Azure function app that connects to your SharePoint Online 
+  tenant, to register and manage webhooks, and process the notifications from SharePoint.
+ms.date: 03/11/2025
 ms.localizationpriority: low
 ---
 # Azure Functions for SharePoint webhooks using azd

--- a/docs/apis/webhooks/sharepoint-webhooks-using-azd-template.md
+++ b/docs/apis/webhooks/sharepoint-webhooks-using-azd-template.md
@@ -56,7 +56,8 @@ This tutorial assumes the system-assigned managed identity is used.
 
 Navigate to your function app in the [Azure portal](https://portal.azure.com/#blade/HubsExtension/BrowseResourceBlade/resourceType/Microsoft.Web%2Fsites/kind/functionapp) > select **Identity** and note the **Object (principal) ID** of the system-assigned managed identity.  
 
-In this tutorial, it is **d3e8dc41-94f2-4b0f-82ff-ed03c363f0f8**.  
+> [!NOTE]
+> In this tutorial, it is **d3e8dc41-94f2-4b0f-82ff-ed03c363f0f8**.  
 
 Then, use one of the scripts below to grant this identity the app-only permission **Sites.Selected** on the SharePoint API:
 

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -114,6 +114,8 @@
       href: apis/webhooks/webhooks-reference-implementation.md
     - name: Use Azure Functions
       href: apis/webhooks/sharepoint-webhooks-using-azure-functions.md
+    - name: Use Azure Functions through azd
+      href: apis/webhooks/sharepoint-webhooks-using-azd-template.md
     - name: List webhooks
       href: apis/webhooks/lists/overview-sharepoint-list-webhooks.md
       items:


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## What's in this Pull Request?

Article https://learn.microsoft.com/en-us/sharepoint/dev/apis/webhooks/sharepoint-webhooks-using-azd-template is not referenced in the menu, and when viewing the article, it is not integrated to the navigation.
I assume this might be a problem with the markdown header, so I open this PR to try to fix it
