### PR TITLE
Deprecating float style prop in custom formatter

### DIFF
--- a/docs/declarative-customization/formatting-syntax-reference.md
+++ b/docs/declarative-customization/formatting-syntax-reference.md
@@ -53,6 +53,9 @@ An optional property that specifies the text content of the element specified by
 
 An optional property that specifies style attributes to apply to the element specified by `elmType`. This is an object with name-value pairs that correspond to CSS names and values. The values of each property in the style object can either be a string (including special strings) or an Expression object. The following style attributes are allowed.
 
+> [!CAUTION]
+> Certain CSS properties, such as float, may no longer be supported in Microsoft Lists custom formatting. Users are encouraged to use Gallery View as a more stable alternative.
+
 ```javascript
 'background-color'
 'fill'
@@ -163,7 +166,7 @@ An optional property that specifies style attributes to apply to the element spe
 'clear'
 'clip'
 'display'
-'float'
+'float' (Deprecated)
 'left'
 'overflow'
 'position'

--- a/docs/declarative-customization/formatting-syntax-reference.md
+++ b/docs/declarative-customization/formatting-syntax-reference.md
@@ -54,7 +54,7 @@ An optional property that specifies the text content of the element specified by
 An optional property that specifies style attributes to apply to the element specified by `elmType`. This is an object with name-value pairs that correspond to CSS names and values. The values of each property in the style object can either be a string (including special strings) or an Expression object. The following style attributes are allowed.
 
 > [!CAUTION]
-> Certain CSS properties, such as float, may no longer be supported in Microsoft Lists custom formatting. Users are encouraged to use Gallery View as a more stable alternative.
+> Float style prop no longer supported in custom formatter. Users are encouraged to use Gallery View as a more stable alternative.
 
 ```javascript
 'background-color'


### PR DESCRIPTION
## Category

- [X] Content fix
- [ ] New article

## What's in this Pull Request?

🎯 Update Important Notice on CSS Support in Microsoft Lists Custom Formatter
🔧 Changes Made
Updated the formatting guidance to highlight that float style prop no longer supported in custom formatter

Introduced an CAUTIONcallout using [!CAUTION] Markdown syntax to improve visibility and clarity for users.

Recommended Gallery View as a more stable alternative for users relying on unsupported styling.

📌 Why This Change?
Ensures users are aware of the deprecation of float in custom formatter styles.
Encourages a smoother transition by suggesting a more reliable solution (Gallery View).

Enhances readability and provides a clear, visually distinct warning.