### PR TITLE
Update `list-form-conditional-show-hide.md` - unsupported mutli lookup column info

### DIFF
--- a/docs/declarative-customization/list-form-conditional-show-hide.md
+++ b/docs/declarative-customization/list-form-conditional-show-hide.md
@@ -1,7 +1,7 @@
 ---
 title: Show or hide columns in a list form
 description: Customize which columns to show or hide using a conditional formula in the list form by constructing a simple formula that are equations performing conditional checks on values in a SharePoint list or library.
-ms.date: 10/30/2024
+ms.date: 04/03/2025
 ms.localizationpriority: high
 ---
 
@@ -66,6 +66,7 @@ While the formula supports many of the available column types, we do not current
 
 - Person or Group with multiple selections
 - Choice with multiple selections
+- Lookup with multiple selections
 - Time calculations in **Date and Time** column
 - Currency columns
 - Location columns


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article


## What's in this Pull Request?

During testing of the form's conditional column visibility, I observed that the multi-value lookup column is not supported. When this type of column is used in the formula, a message is displayed. 

![image](https://github.com/user-attachments/assets/6642433f-3828-433a-b1e7-c508b1f8544b)

In the code, there is a message indicating that it is not supported at this time.

![image](https://github.com/user-attachments/assets/350a9c9c-3dbd-4c93-83e6-fc04c89b6305)

In the list of unsupported columns, `Lookup with multiple selections` is missing, which may be confusing for some users.

Of course, if I am wrong or if this is a temporary issue, then please remove this PR.


