### PR TITLE
Update view-commandbar-formatting.md

### DIFF
--- a/docs/declarative-customization/view-commandbar-formatting.md
+++ b/docs/declarative-customization/view-commandbar-formatting.md
@@ -87,6 +87,8 @@ Mandatory property to uniquely identify a command in the Command bar. Valid keys
 'pinToQuickAccess'
 'unpinFromQuickAccess'
 'manageForms'
+'favoriteCommand'
+'createCopilot'
 ```
 
 ## 🚀 Recent updates to `commandBarCustomization` Keys
@@ -96,11 +98,13 @@ Mandatory property to uniquely identify a command in the Command bar. Valid keys
 > 
 > | Original Key | Current Key |
 > |--------------|-------------|
-> | `new`        | `newComposite` |
+> | `new`        | `newComposite` (Document Library)|
 > | `upload`     | `uploadCommand` |
 > | `sync`       | `syncCommand` |
 > | `addShortcut`| `addShortcutToOneDriveCommand` |
 > | `pinToQuickAccess` | `PinToQuickAccessCommand` |
+> | `pinItem` | `pinItemCommand` |
+> | `properties` | `propertiesCommand` |
 
 ## hide
 

--- a/docs/declarative-customization/view-commandbar-formatting.md
+++ b/docs/declarative-customization/view-commandbar-formatting.md
@@ -1,13 +1,13 @@
 ---
 title: Command bar customization syntax reference
 description: Command bar customization syntax reference
-ms.date: 03/14/2025
+ms.date: 05/15/2025
 ms.localizationpriority: high
 ---
 
 # Command bar customization syntax reference
 
-Command bar customization helps personalize a list to suit specific requirements. The JSON based feature allows basic changes to the command bar, including modification of icon and/or text, hiding existing options or repositioning commands.
+Command bar customization helps personalize a list to suit specific requirements. The JSON-based feature allows basic changes to the command bar, including modification of icon and/or text, hiding existing options, or repositioning commands.
 
 ## commandBarProps
 
@@ -94,7 +94,7 @@ Mandatory property to uniquely identify a command in the Command bar. Valid keys
 ## 🚀 Recent updates to `commandBarCustomization` Keys
 
 > [NOTE!]
-> Some keys in the `commandBarCustomization` schema have been updated. To ensure your custom formatter works correctly, update your existing JSON with these new keys.  
+> Some keys in the `commandBarCustomization` schema have been updated. To ensure your custom formatter works correctly, could you update your existing JSON with these new keys?  
 > 
 > | Original Key | Current Key |
 > |--------------|-------------|
@@ -158,7 +158,7 @@ The following example shows a sample Command bar formatting JSON to do the follo
 
 ## position
 
-An optional property that specifies the position where the command will be placed in the command bar. The value of this property can either be a number, string or an Expression object. If the value is not provided then the command will be placed in it's default position. This property follows zero-based indexing.
+An optional property that specifies the position where the command will be placed in the command bar. The value of this property can either be a number, a string, or an Expression object. If the value is not provided then the command will be placed in it's default position. This property follows zero-based indexing.
 
 ## sectionType
 
@@ -168,8 +168,9 @@ An optional property that specifies the section where the customized command wil
 - Overflow
 
 The following example shows a sample Command bar formatting JSON to do the following:
+
 - Puts the 'New' command at the third position in the primary section of the Command bar.
-- Puts the 'Share' command at the second position in the overflow menu of the Command bar.
+- Puts the 'Share' command in the second position in the overflow menu of the Command bar.
 - Puts the 'Alert me' command at the fourth position in the primary section of the Command bar.
 
 ```JSON
@@ -197,7 +198,7 @@ The following example shows a sample Command bar formatting JSON to do the follo
 
 ## selectionModes
 
-An optional property that specifies the selection modes in which the command customization will be applied. If the value is not provided then the customization will be applied in all the selection modes in which the command is available. The value of this property can be array of strings where the following strings are allowed:
+An optional property that specifies the selection modes in which the command customization will be applied. If the value is not provided, then the customization will be applied in all the selection modes in which the command is available. The value of this property can be an array of strings where the following strings are allowed:
 
 - NoSelection
 - SingleSelection


### PR DESCRIPTION
## Category

- [x] Content fix


## What's in this Pull Request?

Add and update a few commands.

favoriteCommand
createCopilot
pinItem => pinItemCommand
properties => propertiesCommand

The `newComposite` applies only to Document Library, while Lists continues to use `new` command.
