### PR TITLE
Minor fixup in 1.21.1 release notes

### DIFF
--- a/docs/spfx/release-1.21.1.md
+++ b/docs/spfx/release-1.21.1.md
@@ -9,7 +9,7 @@ ms.localizationpriority: high
 This is a _minor bump_ that fixes the issues around SharePoint Framework solution packaging, provides a fix on a regression related on the CSS handling with the previous [released 1.21 version](release-1.21.md).
 
 > [!TIP]
-> It's safe to keep on using SharePoint Framework 1.21 version (if you don't have CSS issues with it), but we do recommend using always the latest version in the production, which in this case would be the 1.17.1, which has fixes on the reported GitHub issues as listed below.
+> It's safe to keep on using SharePoint Framework 1.21 version (if you don't have CSS issues with it), but we do recommend using always the latest version in the production, which in this case would be the 1.21.1, which has fixes on the reported GitHub issues as listed below.
 
 **Released:** May 3, 2025
 


### PR DESCRIPTION
## Category

- [X] Content fix

I am super sorry for opening a PR without a related issue but I just wanted to do a quick and small fixup in the release notes tip where I think we mention version 1.17.1 by mistake 

![image](https://github.com/user-attachments/assets/3bcdd5b1-503f-4390-91eb-33d2ad18f068)

It most probably should be 1.21.1