### PR TITLE
Update toc.yml

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -2305,7 +2305,7 @@
       href: apis/migration-manifest.md
     - name: Events
       href: apis/migration-events.md
-  - name: Microsoft Syntex REST API
+  - name: Document processing REST API
     items:
       - name: Overview
         href: apis/syntex/syntex-model-rest-api.md


### PR DESCRIPTION
Removed "Syntex" to adhere to new naming guidelines.

## Category

- [x] Content fix

## What's in this Pull Request?

Removed "Syntex" from the TOC node name.
