### PR TITLE
Update list-form-conditional-show-hide.md

### DIFF
--- a/docs/declarative-customization/list-form-conditional-show-hide.md
+++ b/docs/declarative-customization/list-form-conditional-show-hide.md
@@ -1,7 +1,7 @@
 ---
 title: Show or hide columns in a list form
 description: Customize which columns to show or hide using a conditional formula in the list form by constructing a simple formula that are equations performing conditional checks on values in a SharePoint list or library.
-ms.date: 04/03/2025
+ms.date: 07/28/2025
 ms.localizationpriority: high
 ---
 
@@ -58,7 +58,7 @@ For example, the following formula checks if the value for the *Category* column
 
 Returning _true_ shows the column on the form while returning _false_ hides the column.
 
-The column is represented by specifying the **internal name** of the field surrounded by square brackets and preceded by a dollar sign: `[$InternalName]`. For example, to get the value of a field with an internal name of "ProductName", use `[$ProductName]`.
+The column is represented by specifying the **internal name** of the field preceded by a dollar sign and surrounded by square brackets: `[$InternalName]`. For example, to get the value of a field with an internal name of "ProductName", use `[$ProductName]`.
 
 #### Unsupported column types in conditional formulas
 


### PR DESCRIPTION
Fixed semantic error in the description of internal name representation.

## Category

- [x] Content fix
- [ ] New article

## Related issues

- fixes N/A
- partially N/A
- mentioned in N/A

## What's in this Pull Request?

This PR offers a semantic fix for the written description of how to represent and internal name within the formatting.  It previously may have been interpreted such that he dollar sign was to precede the bracketed internal name.  This semantic change updates the order so that it is clearer within the verbal order that the bracketing surrounds the dollar sign and internal name.  This semantic difference may be a problem for screen readers or content ingestors, among other scenarios which could "misread" or parse out all or part of the code-formatted internal name. 