### PR TITLE
Fix syntax error in onExecute callback example in documentation

### DIFF
--- a/docs/spfx/web-parts/guidance/getting-started-with-top-actions.md
+++ b/docs/spfx/web-parts/guidance/getting-started-with-top-actions.md
@@ -1,7 +1,7 @@
 ---
 title: Adding support for web part Top Actions
 description: Top Actions is a SharePoint Framework feature that allows web part developers to add commands to a web part's toolbar.
-ms.date: 04/12/2023
+ms.date: 11/09/2025
 ms.localizationpriority: high
 ---
 # Adding support for web part Top Actions
@@ -55,7 +55,7 @@ export default class HelloWorldWebPart extends BaseClientSideWebPart<IHelloWorld
   public getTopActionsConfiguration(): ITopActions | undefined {
     return {
       topActions: [],
-      onExecute: (actionName: string, newValue: any): void { }
+      onExecute: (actionName: string, newValue: any): void => { }
     };
   }
 
@@ -104,7 +104,7 @@ return {
       }
     }
   ],
-  onExecute: (actionName: string, newValue: any): void { }
+  onExecute: (actionName: string, newValue: any): void => { }
 }
 ```
 
@@ -137,7 +137,7 @@ return {
       }
     }
   ],
-  onExecute: (actionName: string, newValue: any): void { }
+  onExecute: (actionName: string, newValue: any): void => { }
 }
 ```
 


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article
- [] Example checked item (*delete this line*)


## Related issues

- fixes #issuenumber
- partially #issuenumber
- mentioned in #issuenumber


## What's in this Pull Request?

Fix syntax error in onExecute callback example in documentation

