### PR TITLE
Fix typo in Postman import instructions

### DIFF
--- a/docs/embedded/getting-started/spembedded-for-vscode.md
+++ b/docs/embedded/getting-started/spembedded-for-vscode.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint Embedded for Visual Studio Code
 description: Installation and getting started with SharePoint Embedded for Visual Studio Code
-ms.date: 07/16/2025
+ms.date: 11/26/2025
 ms.localizationpriority: high
 ---
 


### PR DESCRIPTION
Postal worker => Postman

## Category

- [x] Content fix
- [ ] New article

## Related issues

N/A


## What's in this Pull Request?

Fixing typo, apparently in some previous commit Postman was incorrectly renamed as "Postal Worker"


