### PR TITLE
fix: casing in TOC for toolchain section

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -430,7 +430,7 @@
       href: spfx/image-helper-api.md
     - name: Microsoft Graph Toolkit
       href: spfx/use-microsoft-graph-toolkit.md
-  - name: Build Toolchain & Dependencies
+  - name: Build toolchain & dependencies
     items:
     - name: Overview
       href: spfx/tools-and-libraries.md


### PR DESCRIPTION
## Category

- [x] Content fix

## Related issues

- n/a

## What's in this Pull Request?

Fix incorrect casing for node in TOC