### PR TITLE
Fixed typing error in install command

### DIFF
--- a/docs/spfx/toolchain/customize-heft-toolchain-overview.md
+++ b/docs/spfx/toolchain/customize-heft-toolchain-overview.md
@@ -35,7 +35,7 @@ npx @rushstack/heft --help
 > Similar to Gulp, Heft is installed locally within your project. However, [unlike Gulp that requires installing the Gulp CLI globally](https://www.voitanos.io/blog/mea-culpa-always-install-gulp-cli-globally-not-gulp/), you can install the same Heft npm package globally to simplify running Heft commands.
 >
 > ```console
-> npm install @rushstsack/heft --global
+> npm install @rushstack/heft --global
 > ```
 
 > [!TIP]


### PR DESCRIPTION
the package name @rushstack/heft had a typing error.

## Category

- [x] Content fix
- [ ] New article


## Related issues
not in any issues as far as I've seen

## What's in this Pull Request?
Just a small typo fix

