### PR TITLE
Update note on setTitle usage in site design schema

### DIFF
--- a/docs/declarative-customization/site-design-json-schema.md
+++ b/docs/declarative-customization/site-design-json-schema.md
@@ -477,7 +477,7 @@ Associates a ListViewCommandSet to the list
 Renames the list. To create a new list with a specific name, instead of using setTitle use the `listName` parameter in the `CreateSPList` action.
 
 > [!NOTE]
-> Using `setTitle` will rename the list, preventing the list from updating if the site template is reapplied.
+> Using `setTitle` will rename the list, preventing the list from updating if the site template is reapplied. Avoid using `setTitle` in the `CreateSPList` as it will conflict with  the `listName` parameter, use another site script applied separately for the rename.
 
 #### JSON value
 


### PR DESCRIPTION
Clarified note about using setTitle in CreateSPList action to avoid conflicts with listName parameter. See both below for reason of the update proposal: https://onedrive.visualstudio.com/STS/_workitems/edit/2826803 https://github.com/SharePoint/sp-dev-docs/issues/10483

## Category

- [x] Content fix
- [ ] New article
- [ ] Example checked item (*delete this line*)

## Related issues

- mentioned in #10483 https://github.com/SharePoint/sp-dev-docs/issues/10483 also see https://onedrive.visualstudio.com/STS/_workitems/edit/2826803 

## What's in this Pull Request?
Updating the Note on 'setTitle' to reflect the currently known behavior which is being worked on.

