### PR TITLE
Add SharePoint Embedded audit log events article for container type activities

### DIFF
--- a/docs/embedded/compliance/audit-events.md
+++ b/docs/embedded/compliance/audit-events.md
@@ -13,14 +13,14 @@ For general information about searching the audit log, see [Search the audit log
 
 ## Container type activities
 
-The following events are logged when a container type is created, updated, or deleted. Container types define the relationship between a SharePoint Embedded application and its containers. For more information, see [SharePoint Embedded container types](../getting-started/containertypes.md).
+The following events are logged when a container type is created, updated, or deleted. For more information, see [SharePoint Embedded container types](../getting-started/containertypes.md).
 
 These events use `Workload` value `SharePoint` in the unified audit log.
 
 | Friendly name | Operation | Description |
 |:--|:--|:--|
-| Created container type | ContainerTypeCreated | A new SharePoint Embedded container type definition was provisioned. |
-| Deleted container type | ContainerTypeDeleted | A SharePoint Embedded container type was deleted. |
+| Created container type | ContainerTypeCreated | A new SharePoint Embedded container type definition was created. |
+| Deleted container type | ContainerTypeDeleted | A SharePoint Embedded container type owned by the tenant was deleted. |
 | Updated container type | ContainerTypeUpdated | Properties of a SharePoint Embedded container type, such as name or configuration, were changed. |
 | Updated container type owners | ContainerTypeOwnersUpdated | Owners were added to or removed from a SharePoint Embedded container type. |
 
@@ -28,21 +28,15 @@ These events appear in the Microsoft Purview audit log under the **SharePoint Em
 
 ## Searching for SharePoint Embedded audit events
 
-To search for SharePoint Embedded container type audit events:
+To search for these events, use the [Microsoft Purview audit log search](/purview/audit-search). When searching, set the activity category filter to **SharePoint Embedded Container Type activities** to find the relevant events.
 
-1. Go to the [Microsoft Purview portal](https://purview.microsoft.com) and select **Audit**.
-1. On the **Search** page, filter by the **SharePoint Embedded Container Type activities** category.
-1. Set the date range and select **Search**.
-
-You can also use PowerShell to search for these events:
+You can also search using PowerShell:
 
 ```powershell
 Search-UnifiedAuditLog -Operations ContainerTypeCreated,ContainerTypeDeleted,ContainerTypeUpdated,ContainerTypeOwnersUpdated -StartDate (Get-Date).AddDays(-7) -EndDate (Get-Date)
 ```
 
 Container type audit events include the `ContainerTypeId` property to identify the relevant container type. Unlike container-level file events, container type events don't include `ContainerInstanceId` because they apply at the type level, not to individual container instances.
-
-For more information on how to search and filter audit results for SharePoint Embedded content, see the [Audit section](security-and-compliance.md#audit) of the Security and Compliance article.
 
 ## Schema reference
 

--- a/docs/embedded/compliance/audit-events.md
+++ b/docs/embedded/compliance/audit-events.md
@@ -1,0 +1,56 @@
+---
+title: SharePoint Embedded audit log events
+description: Learn about audit log events for SharePoint Embedded container type operations in the Microsoft Purview unified audit log.
+ms.date: 04/15/2026
+ms.localizationpriority: medium
+---
+
+# SharePoint Embedded audit log events
+
+SharePoint Embedded operations on container types are captured in the Microsoft 365 unified audit log through [Microsoft Purview](/purview/audit-solutions-overview). These events let compliance administrators and developers track changes to container type definitions.
+
+For general information about searching the audit log, see [Search the audit log](/purview/audit-search). For a broader overview of all compliance capabilities available for content stored in SharePoint Embedded, see [Security and Compliance](security-and-compliance.md).
+
+## Container type activities
+
+The following events are logged when a container type is created, updated, or deleted. Container types define the relationship between a SharePoint Embedded application and its containers. For more information, see [SharePoint Embedded container types](../getting-started/containertypes.md).
+
+These events use `Workload` value `SharePoint` in the unified audit log.
+
+| Friendly name | Operation | Description |
+|:--|:--|:--|
+| Created container type | ContainerTypeCreated | A new SharePoint Embedded container type definition was provisioned. |
+| Deleted container type | ContainerTypeDeleted | A SharePoint Embedded container type was deleted. |
+| Updated container type | ContainerTypeUpdated | Properties of a SharePoint Embedded container type, such as name or configuration, were changed. |
+| Updated container type owners | ContainerTypeOwnersUpdated | Owners were added to or removed from a SharePoint Embedded container type. |
+
+These events appear in the Microsoft Purview audit log under the **SharePoint Embedded Container Type activities** category. For the full reference of all audit activities, see [Audit log activities](/purview/audit-log-activities#sharepoint-embedded-container-type-activities).
+
+## Searching for SharePoint Embedded audit events
+
+To search for SharePoint Embedded container type audit events:
+
+1. Go to the [Microsoft Purview portal](https://purview.microsoft.com) and select **Audit**.
+1. On the **Search** page, filter by the **SharePoint Embedded Container Type activities** category.
+1. Set the date range and select **Search**.
+
+You can also use PowerShell to search for these events:
+
+```powershell
+Search-UnifiedAuditLog -Operations ContainerTypeCreated,ContainerTypeDeleted,ContainerTypeUpdated,ContainerTypeOwnersUpdated -StartDate (Get-Date).AddDays(-7) -EndDate (Get-Date)
+```
+
+Container type audit events include the `ContainerTypeId` property to identify the relevant container type. Unlike container-level file events, container type events don't include `ContainerInstanceId` because they apply at the type level, not to individual container instances.
+
+For more information on how to search and filter audit results for SharePoint Embedded content, see the [Audit section](security-and-compliance.md#audit) of the Security and Compliance article.
+
+## Schema reference
+
+Container type audit events use the SharePoint base schema. For the full schema definition and enum values, see the [Office 365 Management Activity API schema](/office/office-365-management-api/office-365-management-activity-api-schema#sharepoint-base-schema).
+
+## Related content
+
+- [SharePoint Embedded container types](../getting-started/containertypes.md)
+- [Security and Compliance](security-and-compliance.md)
+- [Audit log activities](/purview/audit-log-activities#sharepoint-embedded-container-type-activities)
+- [Office 365 Management Activity API schema](/office/office-365-management-api/office-365-management-activity-api-schema)

--- a/docs/embedded/compliance/audit-events.md
+++ b/docs/embedded/compliance/audit-events.md
@@ -15,7 +15,7 @@ For general information about searching the audit log, see [Search the audit log
 
 The following events are logged when a container type is created, updated, or deleted. For more information, see [SharePoint Embedded container types](../getting-started/containertypes.md).
 
-These events use `Workload` value `SharePoint` in the unified audit log.
+These events use **Workload** value **SharePoint** in the unified audit log.
 
 | Friendly name | Operation | Description |
 |:--|:--|:--|

--- a/docs/embedded/compliance/security-and-compliance.md
+++ b/docs/embedded/compliance/security-and-compliance.md
@@ -41,6 +41,8 @@ For information on how to retrieve the `ContainerSiteURL` to set the various com
 
 The Audit capabilities provided by SharePoint Embedded mirror the existing Audit functionalities currently supported within SharePoint. All user and admin operations performed in various applications hosted in SharePoint Embedded are captured, recorded, and retained in your organization's unified audit log. For more information on Audit, see [Auditing solutions in Microsoft Purview](/purview/audit-solutions-overview).
 
+For a detailed list of container type audit events, see [SharePoint Embedded audit log events](audit-events.md).
+
 In addition to existing file properties, Audit events related to SharePoint Embedded are logged with the following more data to help filter the Audit search results to isolate the relevant SharePoint Embedded content:
 
 - `ContainerInstanceId`

--- a/docs/embedded/compliance/security-and-compliance.md
+++ b/docs/embedded/compliance/security-and-compliance.md
@@ -1,7 +1,7 @@
 ---
 title: Security and Compliance
 description: Details Security and Compliance methods provided by SharePoint Embedded
-ms.date: 02/04/2026
+ms.date: 03/05/2025
 ms.localizationpriority: high
 ---
 

--- a/docs/embedded/compliance/security-and-compliance.md
+++ b/docs/embedded/compliance/security-and-compliance.md
@@ -1,7 +1,7 @@
 ---
 title: Security and Compliance
 description: Details Security and Compliance methods provided by SharePoint Embedded
-ms.date: 03/03/2025
+ms.date: 04/20/2026
 ms.localizationpriority: high
 ---
 
@@ -15,7 +15,7 @@ Since SharePoint Embedded by design doesn’t have any user interface, some Comp
 
 ## Compliance Policies using Microsoft Purview
 
-Currently, SharePoint Embedded supports the following Compliance features under Microsoft Purview.  You can follow the following steps to retrieve the details of a container that the policy needs to be applied to.
+Currently, SharePoint Embedded supports the following Compliance features under Microsoft Purview. You can follow the following steps to retrieve the details of a container that the policy needs to be applied to.
 
 1. View a list of registered SharePoint Embedded applications registered in the specified tenant:
 
@@ -32,7 +32,7 @@ Currently, SharePoint Embedded supports the following Compliance features under 
 1. Retrieve the details of a container including the ContainerSiteURL by providing the ContainerID returned in Step #2:
 
     ```powershell
-    Get-SPOContainer -OwningApplicationId <ApplicationID> -Identity<ContainerID>
+    Get-SPOContainer -OwningApplicationId <ApplicationID> -Identity <ContainerID>
     ```
 
 For information on how to retrieve the `ContainerSiteURL` to set the various compliance policies described in this article at a container level, see [Get-SPOContainer](/powershell/module/sharepoint-online/get-spocontainer).

--- a/docs/embedded/compliance/security-and-compliance.md
+++ b/docs/embedded/compliance/security-and-compliance.md
@@ -1,7 +1,7 @@
 ---
 title: Security and Compliance
 description: Details Security and Compliance methods provided by SharePoint Embedded
-ms.date: 04/20/2026
+ms.date: 02/04/2026
 ms.localizationpriority: high
 ---
 

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -660,6 +660,8 @@
     items:
     - name: Security and Compliance
       href: embedded/compliance/security-and-compliance.md
+    - name: Audit log events
+      href: embedded/compliance/audit-events.md
   - name: SharePoint Embedded Learning Modules
     items:
       - name: SharePoint Embedded - overview & configuration


### PR DESCRIPTION
## Category

- [ ] Content fix
- [x] New article

## Related issues

- n/a

## What's in this Pull Request?

Adds a new article documenting SharePoint Embedded container type audit log events in Microsoft Purview.

- New article: `docs/embedded/compliance/audit-events.md` — documents 4 container type operations (ContainerTypeCreated, ContainerTypeDeleted, ContainerTypeUpdated, ContainerTypeOwnersUpdated) with search procedures, PowerShell examples, and schema references
- TOC update: Added `Audit log events` entry under Compliance in `docs/toc.yml`
- Cross-reference: Added link to the new article from the Audit section of `docs/embedded/compliance/security-and-compliance.md`

### Related documentation PRs

- Purview-pr [PR #7279](https://github.com/MicrosoftDocs/Purview-pr/pull/7279) — Container Type activities section in audit-log-activities.md
- office-365-management-api [PR #547](https://github.com/MicrosoftDocs/office-365-management-api/pull/547) — SharePointAuditOperation enum additions