### PR TITLE
Add container type registration audit events to SharePoint Embedded docs

### DIFF
--- a/docs/embedded/compliance/audit-events.md
+++ b/docs/embedded/compliance/audit-events.md
@@ -1,13 +1,13 @@
 ---
 title: SharePoint Embedded audit log events
-description: Learn about audit log events for SharePoint Embedded container type operations in the Microsoft Purview unified audit log.
-ms.date: 04/15/2026
+description: Learn about audit log events for SharePoint Embedded container type and container type registration operations in the Microsoft Purview unified audit log.
+ms.date: 06/19/2026
 ms.localizationpriority: medium
 ---
 
 # SharePoint Embedded audit log events
 
-SharePoint Embedded operations on container types are captured in the Microsoft 365 unified audit log through [Microsoft Purview](/purview/audit-solutions-overview). These events let compliance administrators and developers track changes to container type definitions.
+SharePoint Embedded container type and container type registration operations are captured in the Microsoft 365 unified audit log through [Microsoft Purview](/purview/audit-solutions-overview). These events let compliance administrators and developers track changes to container type definitions and their tenant registrations.
 
 For general information about searching the audit log, see [Search the audit log](/purview/audit-search). For a broader overview of all compliance capabilities available for content stored in SharePoint Embedded, see [Security and Compliance](security-and-compliance.md).
 
@@ -26,25 +26,40 @@ These events use **Workload** value **SharePoint** in the unified audit log.
 
 These events appear in the Microsoft Purview audit log under the **SharePoint Embedded Container Type activities** category. For the full reference of all audit activities, see [Audit log activities](/purview/audit-log-activities#sharepoint-embedded-container-type-activities).
 
+## Container type registration activities
+
+The following events are logged when a container type registration is created, updated, or deleted in a consuming tenant. Container type registrations are required for a SharePoint Embedded application to operate in a given tenant. For more information, see [Consuming Tenant Admin](../administration/consuming-tenant-admin/cta.md).
+
+These events use **Workload** value **SharePoint** in the unified audit log.
+
+| Friendly name | Operation | Description |
+|:--|:--|:--|
+| Created container type registration | ContainerTypeRegistrationCreated | A SharePoint Embedded container type registration was created in a tenant. |
+| Deleted container type registration | ContainerTypeRegistrationDeleted | A SharePoint Embedded container type registration was deleted from a tenant. |
+| Updated container type registration | ContainerTypeRegistrationUpdated | A SharePoint Embedded container type registration was updated in a tenant. |
+
+These events appear in the Microsoft Purview audit log under the **SharePoint Embedded Container Type Registration activities** category. For the full reference of all audit activities, see [Audit log activities](/purview/audit-log-activities#sharepoint-embedded-container-type-registration-activities).
+
 ## Searching for SharePoint Embedded audit events
 
-To search for these events, use the [Microsoft Purview audit log search](/purview/audit-search). When searching, set the activity category filter to **SharePoint Embedded Container Type activities** to find the relevant events.
+To search for these events, use the [Microsoft Purview audit log search](/purview/audit-search). When searching, set the activity category filter to **SharePoint Embedded Container Type activities** or **SharePoint Embedded Container Type Registration activities** to find the relevant events.
 
 You can also search using PowerShell:
 
 ```powershell
-Search-UnifiedAuditLog -Operations ContainerTypeCreated,ContainerTypeDeleted,ContainerTypeUpdated,ContainerTypeOwnersUpdated -StartDate (Get-Date).AddDays(-7) -EndDate (Get-Date)
+Search-UnifiedAuditLog -Operations ContainerTypeCreated,ContainerTypeDeleted,ContainerTypeUpdated,ContainerTypeOwnersUpdated,ContainerTypeRegistrationCreated,ContainerTypeRegistrationDeleted,ContainerTypeRegistrationUpdated -StartDate (Get-Date).AddDays(-7) -EndDate (Get-Date)
 ```
 
 Container type audit events include the `ContainerTypeId` property to identify the relevant container type. Unlike container-level file events, container type events don't include `ContainerInstanceId` because they apply at the type level, not to individual container instances.
 
 ## Schema reference
 
-Container type audit events use the SharePoint base schema. For the full schema definition and enum values, see the [Office 365 Management Activity API schema](/office/office-365-management-api/office-365-management-activity-api-schema#sharepoint-base-schema).
+Container type and container type registration audit events use the SharePoint base schema. For the full schema definition and enum values, see the [Office 365 Management Activity API schema](/office/office-365-management-api/office-365-management-activity-api-schema#sharepoint-base-schema).
 
 ## Related content
 
 - [SharePoint Embedded container types](../getting-started/containertypes.md)
 - [Security and Compliance](security-and-compliance.md)
+- [Consuming Tenant Admin](../administration/consuming-tenant-admin/cta.md)
 - [Audit log activities](/purview/audit-log-activities#sharepoint-embedded-container-type-activities)
 - [Office 365 Management Activity API schema](/office/office-365-management-api/office-365-management-activity-api-schema)

--- a/docs/embedded/compliance/audit-events.md
+++ b/docs/embedded/compliance/audit-events.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint Embedded audit log events
 description: Learn about audit log events for SharePoint Embedded container type and container type registration operations in the Microsoft Purview unified audit log.
-ms.date: 06/19/2026
+ms.date: 04/24/2026
 ms.localizationpriority: medium
 ---
 
@@ -18,7 +18,7 @@ The following events are logged when a container type is created, updated, or de
 These events use **Workload** value **SharePoint** in the unified audit log.
 
 | Friendly name | Operation | Description |
-|:--|:--|:--|
+| :-- | :-- | :-- |
 | Created container type | ContainerTypeCreated | A new SharePoint Embedded container type definition was created. |
 | Deleted container type | ContainerTypeDeleted | A SharePoint Embedded container type owned by the tenant was deleted. |
 | Updated container type | ContainerTypeUpdated | Properties of a SharePoint Embedded container type, such as name or configuration, were changed. |
@@ -33,7 +33,7 @@ The following events are logged when a container type registration is created, u
 These events use **Workload** value **SharePoint** in the unified audit log.
 
 | Friendly name | Operation | Description |
-|:--|:--|:--|
+|:-- | :-- | :-- |
 | Created container type registration | ContainerTypeRegistrationCreated | A SharePoint Embedded container type registration was created in a tenant. |
 | Deleted container type registration | ContainerTypeRegistrationDeleted | A SharePoint Embedded container type registration was deleted from a tenant. |
 | Updated container type registration | ContainerTypeRegistrationUpdated | A SharePoint Embedded container type registration was updated in a tenant. |

--- a/docs/embedded/compliance/security-and-compliance.md
+++ b/docs/embedded/compliance/security-and-compliance.md
@@ -1,7 +1,7 @@
 ---
 title: Security and Compliance
 description: Details Security and Compliance methods provided by SharePoint Embedded
-ms.date: 03/05/2025
+ms.date: 06/19/2026
 ms.localizationpriority: high
 ---
 
@@ -41,7 +41,7 @@ For information on how to retrieve the `ContainerSiteURL` to set the various com
 
 The Audit capabilities provided by SharePoint Embedded mirror the existing Audit functionalities currently supported within SharePoint. All user and admin operations performed in various applications hosted in SharePoint Embedded are captured, recorded, and retained in your organization's unified audit log. For more information on Audit, see [Auditing solutions in Microsoft Purview](/purview/audit-solutions-overview).
 
-For a detailed list of container type audit events, see [SharePoint Embedded audit log events](audit-events.md).
+For a detailed list of container type and container type registration audit events, see [SharePoint Embedded audit log events](audit-events.md).
 
 In addition to existing file properties, Audit events related to SharePoint Embedded are logged with the following more data to help filter the Audit search results to isolate the relevant SharePoint Embedded content:
 

--- a/docs/embedded/compliance/security-and-compliance.md
+++ b/docs/embedded/compliance/security-and-compliance.md
@@ -1,7 +1,7 @@
 ---
 title: Security and Compliance
 description: Details Security and Compliance methods provided by SharePoint Embedded
-ms.date: 06/19/2026
+ms.date: 11/21/2023
 ms.localizationpriority: high
 ---
 


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- depends on #10772

## What's in this Pull Request?

Adds container type registration audit events section to the SharePoint Embedded audit log events article.

- Updated article: `docs/embedded/compliance/audit-events.md` — adds 3 container type registration operations (ContainerTypeRegistrationCreated, ContainerTypeRegistrationDeleted, ContainerTypeRegistrationUpdated)
- Updated search section with both activity categories
- Updated cross-reference in `security-and-compliance.md` to mention registration events

### Related documentation PRs

- Purview-pr [PR #7280](https://github.com/MicrosoftDocs/Purview-pr/pull/7280) — Container Type Registration activities section
- office-365-management-api [PR #548](https://github.com/MicrosoftDocs/office-365-management-api/pull/548) — SharePointAuditOperation enum additions
- Auditing PR #5033059 — AuditOperationsGateConfig.csv + SharePointBaseSchema.xml onboarding
- M365SCC-Client PR #5033060 — Purview portal UI