### PR TITLE
Add PDF viewer documentation

### DIFF
--- a/docs/embedded/development/tutorials/using-file-preview.md
+++ b/docs/embedded/development/tutorials/using-file-preview.md
@@ -1,7 +1,7 @@
 ---
 title: File Previews
 description: Preview SharePoint Embedded content
-ms.date: 04/22/2026
+ms.date: 03/05/2025
 ms.localizationpriority: high
 ---
 
@@ -31,7 +31,9 @@ POST https://graph.microsoft.com/{version}/drives/{driveId}/items/{itemId}/previ
 If you're using the Microsoft Graph C# SDK, the code would be similar to the following:
 
 ```csharp
-ItemPreviewInfo preview = await graphServiceClient.Drives[driveId].Items[itemId]
+ItemPreviewInfo preview = await graphServiceClient
+    .Drives[driveId]
+    .Items[itemId]
     .Preview()
     .Request()
     .PostAsync();
@@ -48,11 +50,11 @@ The JSON response includes the preview URLs for each document. Use the one obtai
 ```
 
 > [!TIP]
-> It is possible to remove the banner at the top by adding the parameter `nb=true` to the obtained URL. E.g.
+> It's possible to remove the banner at the top by adding the parameter `nb=true` to the obtained URL. E.g.,
 > `https://contoso.sharepoint.com/restOfUrl/embed.aspx?param1=value&nb=true`
 
 > [!CAUTION]
-> Currently **getUrl** contains a parameter with an encrypted token that can only be used with your application. However, this may change in the near future and you may be asked to add an auth header as you do with  other requests.
+> Currently **getUrl** contains a parameter with an encrypted token that can only be used with your application. However, this may change soon and you may be asked to add an auth header as you do with  other requests.
 
 ## Use the URL in an `iframe`
 
@@ -95,7 +97,7 @@ The client-side application can then use the browser's `fetch` API to request an
 async function preview(driveId, itemId) {
   const url = `/GetPreviewUrl?driveId=${driveId}&itemId=${itemId}`;
   const response = await fetch(url, {
-      credentials: 'include',
+    credentials: 'include',
   }).then(response => response.text());
 
   document.getElementById('preview').src = response + "&nb=true"; //Use nb=true to suppress banner
@@ -109,7 +111,7 @@ SharePoint Embedded includes a PDF previewer that you can enhance with query par
 The parameters are passed as a JSON-encoded `embed` query string:
 
 ```text
-<webUrl>&embed={"<param1>":<value>,"<param2>":<value>}
+<webUrl>?&embed={"<param1>":<value>,"<param2>":<value>}
 ```
 
 You can include one or more parameters in the same object.
@@ -122,7 +124,7 @@ You can include one or more parameters in the same object.
 Enables the print icon and Ctrl+P functionality.
 
 ```text
-<webUrl>&embed={"mpp":true}
+<webUrl>?&embed={"mpp":true}
 ```
 
 ### Sticky Notes (`mpsn`)
@@ -130,5 +132,5 @@ Enables the print icon and Ctrl+P functionality.
 Shows sticky note content if sticky notes are present in the PDF.
 
 ```text
-<webUrl>&embed={"mpsn":true}
+<webUrl>?&embed={"mpsn":true}
 ```

--- a/docs/embedded/development/tutorials/using-file-preview.md
+++ b/docs/embedded/development/tutorials/using-file-preview.md
@@ -104,7 +104,7 @@ async function preview(driveId, itemId) {
 
 ## PDF Preview
 
-SharePoint Embedded includes a PDF previewer that you can enhance with query parameters appended to the driveItem's `webUrl` property. To get `webUrl`, call the [driveItem Graph endpoint](/graph/api/resources/driveitem) and retrieve the `webUrl` field.
+SharePoint Embedded includes a PDF previewer that you can enhance with query parameters appended to the driveItem's `webUrl` property. To get `webUrl`, call the [driveItem GET API](/graph/api/driveitem-get), for example `GET /drives/{drive-id}/items/{item-id}?$select=webUrl`, and retrieve the `webUrl` field.
 
 The parameters are passed as a JSON-encoded `embed` query string:
 

--- a/docs/embedded/development/tutorials/using-file-preview.md
+++ b/docs/embedded/development/tutorials/using-file-preview.md
@@ -1,7 +1,7 @@
 ---
 title: File Previews
 description: Preview SharePoint Embedded content
-ms.date: 05/21/2024
+ms.date: 04/22/2026
 ms.localizationpriority: high
 ---
 
@@ -100,4 +100,35 @@ async function preview(driveId, itemId) {
 
   document.getElementById('preview').src = response + "&nb=true"; //Use nb=true to suppress banner
 }
+```
+
+## PDF Preview
+
+SharePoint Embedded includes a PDF previewer that you can enhance with query parameters appended to the driveItem's `webUrl` property. To get `webUrl`, call the [driveItem Graph endpoint](/graph/api/resources/driveitem) and retrieve the `webUrl` field.
+
+The parameters are passed as a JSON-encoded `embed` query string:
+
+```text
+<webUrl>&embed={"<param1>":<value>,"<param2>":<value>}
+```
+
+You can include one or more parameters in the same object.
+
+> [!NOTE]
+> Additional query parameters will be added to this section as the PDF previewer expands.
+
+### Print (`mpp`)
+
+Enables the print icon and Ctrl+P functionality.
+
+```text
+<webUrl>&embed={"mpp":true}
+```
+
+### Sticky Notes (`mpsn`)
+
+Shows sticky note content if sticky notes are present in the PDF.
+
+```text
+<webUrl>&embed={"mpsn":true}
 ```


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## What's in this Pull Request?

This PR adds a new PDF Preview section to the Using File Previews article, documenting the query parameters available for enhancing the SharePoint Embedded static PDF previewer.

Changes

  - Added ## PDF Preview section to using-file-preview.md introducing the embed query parameter mechanism, including:
    - An explanation of what webUrl is and how to retrieve it from the driveItem Graph endpoint
    - A syntax example showing how to combine multiple parameters in a single embed JSON object
    - A note that additional parameters will be documented as the PDF previewer grows
    - Print (`mpp`) — documents the mpp boolean parameter that enables the print icon and Ctrl+P functionality
    - Sticky Notes (`mpsn`) — documents the mpsn boolean parameter that shows sticky note content in a PDF
  - Updated ms.date to reflect the current revision date
