### PR TITLE
Fix broken links to SharePoint-Embedded-Samples repo after PR #209 reorg

### DIFF
--- a/docs/embedded/development/declarative-agent/spe-da-adv.md
+++ b/docs/embedded/development/declarative-agent/spe-da-adv.md
@@ -162,7 +162,7 @@ Grounding in the context of SPE agent refers to the process of providing input s
 
 ### Scoping your agent to specific content
 
-SharePoint Embedded (SPE) agent has the ability to restrict the data sources it has access to. The sample code below shows the available data source types. [This example](https://github.com/microsoft/SharePoint-Embedded-Samples/blob/main/Samples/spe-typescript-react-azurefunction/react-client/src/providers/ChatController.ts#L15) shows how to configure the SDK.
+SharePoint Embedded (SPE) agent has the ability to restrict the data sources it has access to. The sample code below shows the available data source types. [This example](https://github.com/microsoft/SharePoint-Embedded-Samples/blob/main/Custom%20Apps/boilerplate-typescript-react/react-client/src/providers/ChatController.ts#L15) shows how to configure the SDK.
 
 ```typescript
 export type IDataSourcesProps =

--- a/docs/embedded/development/declarative-agent/spe-da-adv.md
+++ b/docs/embedded/development/declarative-agent/spe-da-adv.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint Embedded agent Advanced Topics
 description: Learn how the semantic index powers Retrieval-Augmented Generation (RAG) to provide accurate, context-aware AI responses in SharePoint Embedded agent.
-ms.date: 03/17/2026
+ms.date: 03/06/2025
 ms.localizationpriority: high
 ---
 
@@ -26,13 +26,13 @@ The [`discoverabilityDisabled`](../../administration/developer-admin/dev-admin.m
 
 If you’re updating an existing container type to set this property to `false`, allow up to **24 hours** for the configuration change to fully propagate before:
 
-- Creating new containers,  
-- Uploading files to containers, or  
+- Creating new containers,
+- Uploading files to containers, or
 - Using SPE agent to interact with folders or files.
 
 This ensures the agent can correctly access and surface the content.
 
-Here is an example of how to set `discoverabilityDisabled` to `false` with [Set-SPOContainerTypeConfiguration](/powershell/module/SharePoint-online/set-spocontainertypeconfiguration#examples)
+Here's an example of how to set `discoverabilityDisabled` to `false` with [Set-SPOContainerTypeConfiguration](/powershell/module/SharePoint-online/set-spocontainertypeconfiguration#examples)
 
 ```powershell
 Set-SPOContainerTypeConfiguration -ContainerTypeId 4f0af585-8dcc-0000-223d-661eb2c604e4 -DiscoverabilityDisabled $false
@@ -57,7 +57,7 @@ Connect-SPOService "https://<domain>-admin.sharepoint.com"
 
 Set-SPOContainerTypeConfiguration -ContainerTypeId XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX -CopilotEmbeddedChatHosts @("http://localhost:3000", "https://contoso.sharepoint.com", "https://fabrikam.com")
 
-# This will set the container type configuration “CopilotEmbeddedChatHosts” accordingly. 
+# This will set the container type configuration “CopilotEmbeddedChatHosts” accordingly.
 # Replication of this configuration on consuming tenants can take up to 24 hours
 # ...
 
@@ -86,8 +86,7 @@ A SharePoint Embedded Administrator on a consuming tenant may override the value
 > [!NOTE]
 >
 > A consuming tenant override must be a subset of what the owning tenant configured for `CopilotEmbeddedChatHosts`. An administrator
-> in a consuming tenant cannot set values that the application owner has not specified for the container type. The override capabilities
-> is intended for consuming tenant administrators to enable the agent in only a subset of hosts that the owning application has defined.
+> in a consuming tenant can't set values that the application owner hasn't specified for the container type. The override capability is intended for consuming tenant administrators to enable the agent in only a subset of hosts that the owning application has defined.
 
 Here's an example of how a consuming tenant can override the setting:
 
@@ -98,7 +97,7 @@ Connect-SPOService "https://<domain>-admin.sharepoint.com"
 # Login with your admin account.
 # ...
 
-Set-SPOApplication -OwningApplicationId  XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX -CopilotEmbeddedChatHosts @("https://contoso.sharepoint.com", "https://fabrikam.com") 
+Set-SPOApplication -OwningApplicationId  XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX -CopilotEmbeddedChatHosts @("https://contoso.sharepoint.com", "https://fabrikam.com")
 
 # This will set the container type configuration “CopilotEmbeddedChatHosts” accordingly
 # Note that @("https://contoso.sharepoint.com", "https://fabrikam.com") is a subset of what we defined in the owning tenant
@@ -116,7 +115,7 @@ CopilotEmbeddedChatHosts        : {https://contoso.sharepoint.com, https://fabri
 
 #### Optional Configuration
 
-##### Authentication and 3P Cookies
+##### Authentication and Third-Party Cookies
 
 The `iframe` used by SharePoint Embedded agent authenticates users using third-party cookies. If third-party cookies are disabled in the user's browser, the iframe can't authenticate automatically. In this case, a popup prompts the user to sign in manually, ensuring that authentication can still be completed.
 
@@ -213,7 +212,7 @@ You can have this localized by setting your language options in the SharePoint a
 
 > [!NOTE]
 >
-> If your M365 language setting is different from your SharePoint account language setting, your M365 language setting takes precedence. You can change your M365 language setting here: [Change your display language in Microsoft 365](https://support.microsoft.com/topic/change-your-display-language-and-time-zone-in-microsoft-365-for-business-6f238bff-5252-441e-b32b-655d5d85d15b).
+> If your Microsoft 365 language setting is different from your SharePoint account language setting, your Microsoft 365 language setting takes precedence. You can change your Microsoft 365 language setting here: [Change your display language in Microsoft 365](https://support.microsoft.com/topic/change-your-display-language-and-time-zone-in-microsoft-365-for-business-6f238bff-5252-441e-b32b-655d5d85d15b).
 
 An additional locale option can be passed in through the `ChatLaunchConfig` to further set the language the agent responds in:
 

--- a/docs/embedded/development/tutorials/migrate-abs-to-spe.md
+++ b/docs/embedded/development/tutorials/migrate-abs-to-spe.md
@@ -1,7 +1,7 @@
 ---
 title: Tutorial to Migrate from Azure Blob Storage container to SharePoint Embedded container
 description: Tutorial in how to migrate from Azure Blob Storage container to SharePoint Embedded container Using C#
-ms.date: 07/31/2024
+ms.date: 08/02/2024
 ms.localizationpriority: high
 ---
 
@@ -278,10 +278,10 @@ It uses Azure.Storage.Blobs and Newtonsoft.Json libraries for working with ABS a
 ### Running The Sample App
 
 1.	Open a terminal or command prompt.
-1.	Navigate to the directory where the Program.cs file is located.
-1.	Make sure you have the .NET Core SDK installed on your machine. You can check this by running the command dotnet --version in the terminal. If the command isn't recognized, you can download and install the .NET Core SDK from the official Microsoft website.
-1.	Once you have confirmed that the .NET Core SDK is installed, you can build the application by running the command `dotnet build`. This will compile the code and generate the necessary binaries.
-1.	After the build process is complete, you can run the application by executing the command dotnet run followed by the required arguments. The required arguments are:
+1.	Navigate to the directory where the **Program.cs** file is located.
+1.	Make sure you have the .NET Core SDK installed on your machine. You can check this by running the command **dotnet --version** in the terminal. If the command isn't recognized, you can download and install the .NET Core SDK from the official Microsoft website.
+1.	Once you have confirmed that the .NET Core SDK is installed, you can build the application by running the command **dotnet build**. This will compile the code and generate the necessary binaries.
+1.	After the build process is complete, you can run the application by executing the command **dotnet run** followed by the required arguments. The required arguments are:
 
     - The container-level SAS URL: This is an Azure Blob container level SAS URL. It provides access to the container and its blobs.
     - The SPE tenant ID: This is the tenant you're authenticating against in the SPE.
@@ -292,7 +292,15 @@ It uses Azure.Storage.Blobs and Newtonsoft.Json libraries for working with ABS a
 
 For example, the command to run the application with the required arguments would look like this:
 
-`dotnet run Program.cs -- --sasurl "<sas url>" --tenantid "<tenant id>" --clientid "<client id>" --containerid "<container id>" [ --blobfile "<file name>" --outputfile "<file name>" ]`
+```console
+# line breaks added for readability
+dotnet run Program.cs -- \
+  --sasurl "<sas url>" \
+  --tenantid "<tenant id>" \
+  --clientid "<client id>" \
+  --containerid "<container id>" \
+  [ --blobfile "<file name>" --outputfile "<file name>" ]
+```
 
 ### Blob and SPE Item Structure
 
@@ -322,17 +330,17 @@ ABS container doesn't adhere to a folder structure, all the blobs are stored in 
 
 1. File already exists in the destination
 
-    - This app checks to see if the file name exists in the destination before it uploads. If there's a file with the exact same name, it will not do the upload again. It will print to stdout a message that the file already exists. To fix it, you can either delete the file from the destination or change the conflictBehavior to replace and not call `CheckIfItemExists` on upload.
+    - This app checks to see if the file name exists in the destination before it uploads. If a file with the exact same name exists, it will not do the upload again. It will print to stdout a message that the file already exists. To fix it, you can either delete the file from the destination or change the `conflictBehavior` to replace and not call `CheckIfItemExists` on upload.
 
 1. The file for the list of blobs isn't found
 1. The format for the list of blobs - one blob per line, without quotes around the blob name
 1. Not giving enough permission to access the ABS container
 
-    - The minimum permissions are Read and List
+    - The minimum permissions are **Read** and **List**
 
 1. Not giving enough permissions to the SPE container
 
-    - The required scope is "User.Read" and "FileStorageContainer.Selected"
+    - The required scope is **User.Read** and **FileStorageContainer.Selected**
     - Remember to grant admin consent
     - Remember to create the mobile & console platform app
 

--- a/docs/embedded/development/tutorials/migrate-abs-to-spe.md
+++ b/docs/embedded/development/tutorials/migrate-abs-to-spe.md
@@ -371,4 +371,4 @@ Happy coding!
 
 ### Code Repository
 
-The sample app can be found in the [SharePoint Embedded Samples repository](https://github.com/microsoft/SharePoint-Embedded-Samples/tree/main/Samples/migrate-abs-to-spe).
+The sample app can be found in the [SharePoint Embedded Samples repository](https://github.com/microsoft/SharePoint-Embedded-Samples/tree/main/Tools/migrate-from-blob-storage).

--- a/docs/embedded/development/tutorials/spe-da-vscode.md
+++ b/docs/embedded/development/tutorials/spe-da-vscode.md
@@ -311,7 +311,7 @@ function App() {
 
     ![SPE VS Code notification prompting user to allow it to create a secret for the application if it does not exist.](../../images/speco-createclientsecret.png)
   
-1. Select a folder to host the application, this will clone the following [repository for SharePoint Embedded Samples](https://github.com/microsoft/SharePoint-Embedded-Samples/tree/main/Samples/spe-typescript-react-azurefunction) into the folder
+1. Select a folder to host the application, this will clone the following [repository for SharePoint Embedded Samples](https://github.com/microsoft/SharePoint-Embedded-Samples/tree/main/Custom%20Apps/boilerplate-typescript-react) into the folder
 
     ![windows File Explorer folder to save project on local machine](../../images/speco-cloneproject.png)
 
@@ -330,7 +330,7 @@ function App() {
 1. You can follow the instructions of the `README.md` file in the root of the project for further npm commands. Run `npm run start` in the root of the project to start your application with the SPE agent functionality enabled.
 
     > [!NOTE]
-    > `npm run start` Should be done in the root folder of the sample project. `\SharePoint-Embedded-Samples\Samples\spe-typescript-react-azurefunction`
+    > `npm run start` Should be done in the root folder of the sample project. `\SharePoint-Embedded-Samples\Custom Apps\boilerplate-typescript-react`
 
     ![VS Code terminal in root folder of SPE Typescript project cloned earlier and npm run start command typed in](../../images/speco-runnpmrunstart.png)
 
@@ -352,4 +352,4 @@ function App() {
 
 ### Examples
 
-The [SharePoint Embedded Samples](https://github.com/microsoft/SharePoint-Embedded-Samples/tree/main/Samples/spe-typescript-react-azurefunction) repository has examples for how to use SharePoint Embedded in your custom applications.
+The [SharePoint Embedded Samples](https://github.com/microsoft/SharePoint-Embedded-Samples/tree/main/Custom%20Apps/boilerplate-typescript-react) repository has examples for how to use SharePoint Embedded in your custom applications.

--- a/docs/embedded/development/tutorials/spe-da-vscode.md
+++ b/docs/embedded/development/tutorials/spe-da-vscode.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint Embedded agent Tutorial
-description: Sharepoint Embedded agent tutorial with the SDK and the VS Code SharePoint Embedded Extension
-ms.date: 06/10/2025
+description: SharePoint Embedded agent tutorial with the SDK and the VS Code SharePoint Embedded Extension
+ms.date: 03/06/2025
 ms.localizationpriority: high
 ---
 
@@ -11,15 +11,15 @@ ms.localizationpriority: high
 
 > [!NOTE]
 >
-> 1. You will need to create a SharePoint Embedded application. If you don't have one, you can easily build a sample application using the instructions [here](#getting-started-using-the-sharepoint-embedded-visual-studio-code-extension).
+> 1. You'll need to create a SharePoint Embedded application. If you don't have one, you can easily build a sample application using the instructions [here](#getting-started-using-the-sharepoint-embedded-visual-studio-code-extension).
 > 1. You must specify a standard container type at creation time. Depending on the purpose, you may or may not need to provide your Azure Subscription ID. A container type set for trial purposes can't be converted for production, or vice versa.
 > 1. You must use the latest version of SharePoint PowerShell to configure a container type. For permissions and the most current information about Windows PowerShell for SharePoint Embedded, see the documentation at [Intro to SharePoint Embedded Management Shell](/powershell/SharePoint/SharePoint-online/introduction-SharePoint-online-management-shell).
 >
-> - Set the **CopilotChatEmbeddedHosts** property of your container type configuration to `http://localhost:8080` to be able to work through the quick start below, refer to [the CSP section above for more information](../declarative-agent/spe-da-adv.md#csp-policies).
+> - Set the **CopilotChatEmbeddedHosts** property of your container type configuration to `http://localhost:8080` to be able to work through the following quick start, refer to [the preceding CSP section for more information](../declarative-agent/spe-da-adv.md#csp-policies).
 > - Set the **DiscoverabilityDisabled** property of your container type configuration to `false` so that the agent can find the files in your created container. Refer to the [Discoverability Disabled section above for more information](../declarative-agent/spe-da-adv.md#discoverabilitydisabled).
 > - Ensure that Copilot for Microsoft 365 is available for your organization. You have two ways to get a developer environment for Copilot:
->   - A sandbox Microsoft 365 tenant with M365 Copilot (available in limited preview through [TAP membership](https://developer.microsoft.com/microsoft-365/tap)).
->     - An [eligible Microsoft 365 or Office 365 production environment](/microsoft-365-copilot/extensibility/prerequisites#customers-with-existing-microsoft-365-and-copilot-licenses) with a M365 Copilot license.
+>   - A sandbox Microsoft 365 tenant with Microsoft 365 Copilot (available in limited preview through [TAP membership](https://developer.microsoft.com/microsoft-365/tap)).
+>     - An [eligible Microsoft 365 or Office 365 production environment](/microsoft-365-copilot/extensibility/prerequisites#customers-with-existing-microsoft-365-and-copilot-licenses) with a Microsoft 365 Copilot license.
 
 ## Getting started using the SharePoint Embedded SDK
 
@@ -38,11 +38,11 @@ In MacOS/Linux
 ```console
 version="1.0.9";
 
-url="https://download.microsoft.com/download/970802a5-2a7e-44ed-b17d-ad7dc99be312/microsoft-sharepointembedded-copilotchat-react-1.0.9.tgz"; 
+url="https://download.microsoft.com/download/970802a5-2a7e-44ed-b17d-ad7dc99be312/microsoft-sharepointembedded-copilotchat-react-1.0.9.tgz";
 
-expected_checksum="3bdf19830ffc098b253cc809f969f50fba236ad95fe85123e7b15c7cf58ecf6b"; 
+expected_checksum="3bdf19830ffc098b253cc809f969f50fba236ad95fe85123e7b15c7cf58ecf6b";
 
-package_path="microsoft-sharepointembedded-copilotchat-react-$version.tgz"; 
+package_path="microsoft-sharepointembedded-copilotchat-react-$version.tgz";
 
 curl -o $package_path $url && [ "$(sha256sum $package_path | awk '{ print $1 }')" == "$expected_checksum" ] && npm install $package_path || { echo "Checksum does not match. Aborting installation."; rm $package_path; }
 ```
@@ -209,7 +209,7 @@ function App() {
 
 ### 5. Use the `chatApi` object in your state to open the chat and run it
 
-In the example above, call it this way to open the chat.
+In the preceding example, call it this way to open the chat.
 
 ```typescript
 await chatApi.openChat();
@@ -293,10 +293,10 @@ function App() {
 ### Quick Start
 
 > [!NOTE]
-> When using standard container types with the VS Code extension, [DisableDiscoverability](../declarative-agent/spe-da-adv.md#discoverabilitydisabled) and [Grant admin consent](/entra/identity/enterprise-apps/grant-admin-consent?pivots=portal) features are currently not supported. This will need to be done using the [SPO Admin Powershell](/powershell/sharepoint/sharepoint-online/connect-sharepoint-online).
+> When using standard container types with the VS Code extension, [DisableDiscoverability](../declarative-agent/spe-da-adv.md#discoverabilitydisabled) and [Grant admin consent](/entra/identity/enterprise-apps/grant-admin-consent?pivots=portal) features are currently not supported. This will need to be done using the [SPO Admin PowerShell](/powershell/sharepoint/sharepoint-online/connect-sharepoint-online).
 
 1. Follow this guide up to the [Load Sample App section](../../getting-started/spembedded-for-vscode.md#load-sample-app) with the Visual Studio Code Extension
-1. Within the extension, right click on the owning application, and select `Run sample apps -> Typescript + React + Azure Functions`
+1. Within the extension, right select on the owning application, and select `Run sample apps -> Typescript + React + Azure Functions`
 
     ![Using the SPE VS Code extension to create a TypeScript React Azure Functions project](../../images/speco-runsampleapp.png)
 
@@ -307,10 +307,10 @@ function App() {
 
     ![SPE VS Code notification alerting it will copy app secrets in plain text on local machine](../../images/speco-createappsecret.png)
 
-    If the application does not already have a client secret, the extension will ask to create one for you.
+    If the application doesn't already have a client secret, the extension will ask to create one for you.
 
     ![SPE VS Code notification prompting user to allow it to create a secret for the application if it does not exist.](../../images/speco-createclientsecret.png)
-  
+
 1. Select a folder to host the application, this will clone the following [repository for SharePoint Embedded Samples](https://github.com/microsoft/SharePoint-Embedded-Samples/tree/main/Custom%20Apps/boilerplate-typescript-react) into the folder
 
     ![windows File Explorer folder to save project on local machine](../../images/speco-cloneproject.png)
@@ -338,15 +338,15 @@ function App() {
 
     ![SPE Typescript App running in Edge with sign in buttons](../../images/speco-reacttypescripthomepage.png)
 
-1. Navigate to the `containers` page, create one if you do not have any yet
+1. Navigate to the `containers` page, create one if you don't have any yet
 
     ![SPE Typescript App running in edge in /containers sub page with modal of user c reatign a container called ContosoCompanyContainer](../../images/speco-createcontosocontainer2.png)
 
-    After it has been created, you will see it here:
+    After it has been created, you'll see it here:
 
     ![SPE Typescript App running in edge with a created container from above ContosoCompanyContainer](../../images/speco-createdcontainer.png)
 
-1. Click the container and upload your files. Once a container has been created and you have navigated inside it, your agent chat experience will become enabled.
+1. Select the container and upload your files. Once a container has been created and you have navigated inside it, your agent chat experience will become enabled.
 
     ![SPE Typescript App running in edge inside a created container page of ContosoCompanyContainer](../../images/speco-spechatenabled.png)
 

--- a/docs/embedded/getting-started/spembedded-for-vscode.md
+++ b/docs/embedded/getting-started/spembedded-for-vscode.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint Embedded for Visual Studio Code
 description: Installation and getting started with SharePoint Embedded for Visual Studio Code
-ms.date: 11/26/2025
+ms.date: 01/30/2024
 ms.localizationpriority: high
 ---
 
@@ -18,7 +18,7 @@ The SharePoint Embedded Visual Studio Code extension helps developers get starte
 1. Open a new window in [Visual Studio Code](https://code.visualstudio.com/) and navigate to "**Extensions**" on the activity bar.
 1. Search "SharePoint Embedded" in the Extensions view. You can also view the extension in [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=SharepointEmbedded.ms-sharepoint-embedded-vscode-extension).
 1. Select **"Install"** and the SharePoint Embedded icon will appear on the activity bar.
-1. If already installed, please update to the latest version if one is available.
+1. If already installed, update to the latest version if one is available.
 1. Select the icon to open the SharePoint Embedded view and create a container type with trial configuration.
 
 ![SharePoint Embedded VS Extensions](../images/vsx-images/n1downloadvsx.png)
@@ -31,13 +31,13 @@ To use the extension, you must sign in to a Microsoft 365 tenant with an adminis
 
 - Authentication opens a new tab in an external browser to grant permissions
 
-  ![authorize and authenticate the extension to your M365 Entra tenant](../images/vsx-images/auth-allow-extension-uri.png)
+    ![authorize and authenticate the extension to your M365 Entra tenant](../images/vsx-images/auth-allow-extension-uri.png)
 
 - Review the requested permissions carefully, then select **Accept** on the pop-up window prompting admin consent
 
-  ![review before consenting to the permissions the extension is asking for](../images/vsx-images/n3vsx-grant-admin-consent.png)
+    ![review before consenting to the permissions the extension is asking for](../images/vsx-images/n3vsx-grant-admin-consent.png)
 
-After successful authorization, select open on the dialog to be redirected to VSCode:
+After successful authorization, select open on the dialog to be redirected to VS Code:
 
 ![authorization completed in browser now redirecting to visual studio code](../images/vsx-images/auth-redirect.png)
 
@@ -61,7 +61,7 @@ Every container type is owned by a Microsoft Entra ID application. The first ste
 
 - Follow the prompts to name your new Entra application or select an existing application ID:
 
-![Create App](../images/vsx-images/n6aname-app.png)
+    ![Create App](../images/vsx-images/n6aname-app.png)
 
 > [!NOTE]
 > If you choose an existing application, the extension will update that app's configuration settings for it to work with both SharePoint Embedded and this extension. Doing this is NOT recommended on production applications.
@@ -74,11 +74,11 @@ After creating your container type, you'll need to register that container type 
 
 - Follow the prompts and select **Register on local tenant** on the lower right corner of the VS Code window
 
-  ![local tenant registration popup](../images/vsx-images/local-tenant-registration-popup.png)
-
+    ![local tenant registration popup](../images/vsx-images/local-tenant-registration-popup.png)
+  
 - If you don't see the prompt, you can right-click on your `<container-type-name>` and select **Register** from the menu
 
-  ![register](../images/vsx-images/n7aregister-ct.png)
+    ![register](../images/vsx-images/n7aregister-ct.png)
 
 ### Grant permissions
 
@@ -127,7 +127,7 @@ If no client secret is found on your application, it will ask if you would like 
 
 ## Using Sample App
 
-In your terminal, run the following command, this will start the sample application, which consists of 2 parts:
+In your terminal, run the following command, this will start the sample application, which consists of two parts:
 
 1. **React Client Application** - The frontend user interface running on port 8080
 1. **Azure Function Application Server** - The backend API server that handles SharePoint Embedded operations
@@ -143,7 +143,7 @@ npm run start
 > [!NOTE]
 > The initial startup may take a few minutes as dependencies are installed and both applications are built. Wait for both console outputs to appear before navigating to the application.
 
-This will install the dependencies and run the server and client application, once running, you'll see the following in the terminal, after which you can navigate to http://localhost:8080 to access the application.
+This will install the dependencies and run the server and client application, once running, you'll see the following in the terminal, after which you can navigate to `http://localhost:8080` to access the application.
 
 ![function api console logs](../images/vsx-images/fn-api-logs.png)
 
@@ -151,9 +151,9 @@ This will install the dependencies and run the server and client application, on
 
 Once both applications are running successfully:
 
-1. Open your web browser and navigate to **http://localhost:8080**
+1. Open your web browser and navigate to `http://localhost:8080`
 1. Sign in using your Microsoft 365 administrator account (the same account used in the VS Code extension)
-1. On the home page, select **"Containers"** to begin creating containers and uploading files
+1. On the home page, select **Containers** to begin creating containers and uploading files
 1. Follow the on-screen prompts to interact with your SharePoint Embedded containers
 
 ![home-page-for-spe-sample-app](../images/vsx-images/spe-sample-app-home.png)

--- a/docs/embedded/getting-started/spembedded-for-vscode.md
+++ b/docs/embedded/getting-started/spembedded-for-vscode.md
@@ -134,7 +134,7 @@ In your terminal, run the following command, this will start the sample applicat
 
 ```console
 # Navigate to your sample application directory
-cd [your-path]\SharePoint-Embedded-Samples\Samples\spe-typescript-react-azurefunction
+cd [your-path]\SharePoint-Embedded-Samples\Custom Apps\boilerplate-typescript-react
 
 # Install dependencies and start the application
 npm run start
@@ -171,6 +171,6 @@ If you encounter issues:
 
 ## Export Postman Environment
 
-The [SharePoint Embedded Postman Collection](https://github.com/microsoft/SharePoint-Embedded-Samples/tree/main/Postman) allows you to explore and call the SharePoint Embedded APIs. The Collection requires an environment file with variables used for authentication and various identifiers. This extension automates the generation of this populated environment file so you can import it into Postman and immediately call the SharePoint Embedded APIs.
+The [SharePoint Embedded Postman Collection](https://github.com/microsoft/SharePoint-Embedded-Samples/tree/main/Tools/api-clients) allows you to explore and call the SharePoint Embedded APIs. The Collection requires an environment file with variables used for authentication and various identifiers. This extension automates the generation of this populated environment file so you can import it into Postman and immediately call the SharePoint Embedded APIs.
 
 ![Export Postman Environment](../images/vsx-images/n14postman-c.png)


### PR DESCRIPTION
## Summary

Updates broken links in SPE documentation after [microsoft/SharePoint-Embedded-Samples#209](https://github.com/microsoft/SharePoint-Embedded-Samples/pull/209) reorganized the repository structure.

## Changes

| Old Path | New Path |
|----------|----------|
| `Samples/spe-typescript-react-azurefunction` | `Custom Apps/boilerplate-typescript-react` |
| `Samples/migrate-abs-to-spe` | `Tools/migrate-from-blob-storage` |
| `Postman` | `Tools/api-clients` |

## Affected files (4 files, 7 links)

- `docs/embedded/getting-started/spembedded-for-vscode.md`  sample app path + Postman collection link
- `docs/embedded/development/declarative-agent/spe-da-adv.md`  ChatController.ts example link
- `docs/embedded/development/tutorials/spe-da-vscode.md`  sample repo link (3 occurrences)
- `docs/embedded/development/tutorials/migrate-abs-to-spe.md`  ABS migration sample link