### PR TITLE
docs(spfx): 📝 deprecate online workbench

### DIFF
--- a/docs/spfx/debug-in-vscode.md
+++ b/docs/spfx/debug-in-vscode.md
@@ -1,7 +1,7 @@
 ---
 title: Debug SharePoint Framework solutions in Visual Studio Code
 description: Prerequisites and steps for configuring Visual Studio Code for debugging SharePoint Framework solutions.
-ms.date: 02/24/2026
+ms.date: 04/21/2017
 ms.localizationpriority: high
 ---
 # Debug SharePoint Framework solutions in Visual Studio Code
@@ -52,7 +52,9 @@ The debug mode in Visual Studio Code starts, changing the color of the status ba
 To verify that debugging is working, in the workbench, add your web part to the canvas.
 
 > [!IMPORTANT]
-> The local workbench (`https://localhost:4321/temp/workbench.html`) was **removed in SPFx v1.13** and will not work. Use the hosted workbench (`/_layouts/workbench.aspx`) or debug directly on a modern SharePoint page instead.
+> The local workbench (`https://localhost:4321/temp/workbench.html`) was **removed in SPFx v1.13** and will not work.
+
+[!INCLUDE [spfx-online-workbench-deprecation](../../includes/snippets/spfx-online-workbench-deprecation.md)]
 
 ![Web part toolbox open in SharePoint workbench](../images/vscode-debugging-adding-web-part-to-canvas.png)
 
@@ -154,7 +156,7 @@ Debugging an Extension in a hosted workbench is similar to the steps for a Web P
         }}
     ```
 
-1. Select **Load debug scripts** to continue loading scripts from your local host.
+1. Select **Load debug scripts** to continue loading scripts from your localhost.
 
     ![Allow Debug Manifest question from the page](../images/ext-app-debug-manifest-message.png)
 

--- a/docs/spfx/release-1.23.md
+++ b/docs/spfx/release-1.23.md
@@ -1,12 +1,12 @@
 ---
 title: SharePoint Framework v1.23 preview notes
 description: Release notes for the SharePoint Framework v1.23 preview release.
-ms.date: 04/21/2026
+ms.date: 03/20/2026
 ms.localizationpriority: high
 ---
 # SharePoint Framework v1.23 preview release notes
 
-This is an early baseline version for the upcoming SharePoint 1.23 version with initial updates. We are introducing new capabilities as part of the following updates before the general availability of 1.23.
+This is an early baseline version for the upcoming SharePoint Framework 1.23 version with initial updates. We are introducing new capabilities as part of the following updates before the general availability of v1.23.
 
 [!INCLUDE [spfx-release-beta](../../includes/snippets/spfx-release-beta.md)]
 
@@ -34,7 +34,7 @@ The upgrade steps required to convert a [gulp-based toolchain](toolchain/sharepo
 
 ### Grouping support for list view command sets
 
-Starting with the SPFx 1.23, we will be also supporting grouping of list view command sets in the toolbar and in the context menu. This provides more control on how the list view commands are rendered in lists and libraries.
+Starting with the SPFx v1.23, we will be also supporting grouping of list view command sets in the toolbar and in the context menu. This provides more control on how the list view commands are rendered in lists and libraries.
 
 ![Card personalization visible in the dashboard UI](../images/123-release/list-view-cmdset-grouping.png)
 
@@ -77,11 +77,11 @@ Your feedback is welcome. Let us know your first impressions and provide suggest
 
 When installing the SharePoint Framework Yeoman generator or scaffolding solutions, we have worked on the reported `npm audit` issues. Addressing vulnerabilities is a moving target, which we keep on addressing with all releases.
 
-We have identified issues on the npm audit still for the 1.23 release which will be addressed with the upcoming RC1 release before we are ready for General Availability of 1.23.
+We have identified issues on the npm audit still for the v1.23 release which will be addressed release before we are ready for General Availability of v1.23.
 
 ## Deprecations
 
-No new updates.
+- **Hosted workbench is deprecated** - This is the last release that will include support for the SharePoint Framework online workbench; the hosted workbench will be retired on May 6, 2027. The recommended replacement is to use the [SharePoint Framework Debug Toolbar](../../docs/spfx/debug-toolbar.md)
 
 ## Feedback and issues
 

--- a/docs/spfx/web-parts/get-started/build-a-hello-world-web-part.md
+++ b/docs/spfx/web-parts/get-started/build-a-hello-world-web-part.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first SharePoint client-side web part (Hello World part 1)
 description: Create a new web part project and preview it.
-ms.date: 12/18/2025
+ms.date: 08/26/2016
 ms.localizationpriority: high
 ms.custom: scenarios:getting-started
 ---
@@ -90,7 +90,7 @@ Assuming you've installed & trusted developer certificate, execute the following
 heft start
 ```
 
-This command runs a series of Heft tasks to create and start a local webserver hosting the endpoints **localhost:4321** and **localhost:5432**. It will then open your default browser and load the hosted workbench preview web parts from your local dev environment.
+This command runs a series of Heft tasks to create and start a local webserver hosting the endpoints **localhost:4321** and **localhost:5432**. It will then open your default browser and load the hosted workbench preview web parts from your local dev environment:
 
 ```console
 <i> [webpack-dev-server] Project is running at:
@@ -109,6 +109,8 @@ Cancelling incremental build...
 [build:configure-webpack-serve]
 webpack 5.95.0 compiled successfully in 41820 ms
 ```
+
+[!INCLUDE [spfx-online-workbench-deprecation](../../../../includes/snippets/spfx-online-workbench-deprecation.md)]
 
 SharePoint client-side development tools use [Heft](https://heft.rushstack.io/) as the task runner to handle build process tasks such as:
 
@@ -395,4 +397,3 @@ heft start
 Congratulations on getting your first Hello World web part running!
 
 Now that your web part is running, you can continue building out your Hello World web part in the next topic, [Connect your web part to SharePoint](./connect-to-sharepoint.md). You will use the same Hello World web part project and add the ability to interact with SharePoint List REST APIs. Notice that the **Heft start** command is still running in your console window (or in Visual Studio Code if you're using that as editor). You can continue to let it run while you go to the next article.
-

--- a/includes/snippets/spfx-online-workbench-deprecation.md
+++ b/includes/snippets/spfx-online-workbench-deprecation.md
@@ -1,4 +1,4 @@
 > [!IMPORTANT]
-> The SharePoint Framework Online workbench was deprecated on May 6, 2026 and will be retired on May 6, 2027.
+> The SharePoint Framework Online workbench is deprecated starting on May 13, 2026 and will be retired on December 1, 2026.
 >
 > The recommended replacement is to use the [SharePoint Framework Debug Toolbar](../../docs/spfx/debug-toolbar.md)

--- a/includes/snippets/spfx-online-workbench-deprecation.md
+++ b/includes/snippets/spfx-online-workbench-deprecation.md
@@ -1,0 +1,4 @@
+> [!IMPORTANT]
+> The SharePoint Framework Online workbench was deprecated on May 6, 2026 and will be retired on May 6, 2027.
+>
+> The recommended replacement is to use the [SharePoint Framework Debug Toolbar](../../docs/spfx/debug-toolbar.md)


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- n/a

## What's in this Pull Request?

- note deprecation in v1.23 release notes
- add reusable snippet for online workbench deprecation
- include snippet in debug-in-vscode & hello-world articles
- tighten wording & v1.23 references in release notes
- align `ms.date` with original upstream commit per file