### PR TITLE
Fix broken links, outdated content, and whitespace artifacts in 5 docs

### DIFF
--- a/docs/general-development/exporting-and-importing-search-configuration-settings-in-sharepoint.md
+++ b/docs/general-development/exporting-and-importing-search-configuration-settings-in-sharepoint.md
@@ -8,24 +8,18 @@ ms.localizationpriority: medium
 
 
 # Exporting and importing search configuration settings in SharePoint
-Get code examples that show you how to export and import customized search configuration settings. These settings include all customized query rules, result sources, result types, ranking models, and site search settings. SharePoint exposes this functionality through the  [Microsoft.Office.Server.Search.Portability](https://msdn.microsoft.com/library/Microsoft.Office.Server.Search.Portability.aspx) namespace.You can also export customized search configuration settings from a Search service application (SSA) and import the settings to site collections and sites.
+Get code examples that show you how to export and import customized search configuration settings. These settings include all customized query rules, result sources, result types, ranking models, and site search settings. SharePoint exposes this functionality through the  [Microsoft.Office.Server.Search.Portability](/previous-versions/office/sharepoint-server/jj268113(v=office.15)) namespace.You can also export customized search configuration settings from a Search service application (SSA) and import the settings to site collections and sites.
 
 > [!NOTE]
 > You can't import customized search configuration settings to an SSA, or export the default search configuration settings.
 
 
-
-
-
 ## Export search configuration settings
-<a name="SP15_exporting_search_configuration"> </a>
 
-The following code shows how to use  [SearchConfigurationPortability](https://msdn.microsoft.com/library/Microsoft.Office.Server.Search.Portability.SearchConfigurationPortability.aspx) to export your site's search configuration settings. The code uses an example site `http://yoursite/sites/publishing1`, which you'd replace with your own site.  _fileName_ refers to the file where the search configuration settings are stored; _owner_ specifies the [SPWeb](https://msdn.microsoft.com/library/Microsoft.SharePoint.SPWeb.aspx) level at which the search configuration settings are obtained.
-
+The following code shows how to use  [SearchConfigurationPortability](/previous-versions/office/sharepoint-server/jj267460(v=office.15)) to export your site's search configuration settings. The code uses an example site `http://yoursite/sites/publishing1`, which you'd replace with your own site.  _fileName_ refers to the file where the search configuration settings are stored; _owner_ specifies the [SPWeb](/previous-versions/office/sharepoint-server/ms473942(v=office.15)) level at which the search configuration settings are obtained.
 
 
-
-```
+```csharp
 
 private static void Export(string fileName)
 {
@@ -38,13 +32,9 @@ private static void Export(string fileName)
 }
 ```
 
-
 ## Import search configuration settings
-<a name="SP15_importing_search_configuration"> </a>
 
-The following code shows how to import search configuration settings from a file by using  [SearchConfigurationPortability](https://msdn.microsoft.com/library/Microsoft.Office.Server.Search.Portability.SearchConfigurationPortability.aspx) and replace the existing search settings on a specified site, `http://yoursite/sites/publishing1`.  _fileName_ refers to the file where the search configuration settings are stored; _owner_ specifies the [SPWeb](https://msdn.microsoft.com/library/Microsoft.SharePoint.SPWeb.aspx) level at which the search configuration settings are obtained.
-
-
+The following code shows how to import search configuration settings from a file by using  [SearchConfigurationPortability](/previous-versions/office/sharepoint-server/jj267460(v=office.15)) and replace the existing search settings on a specified site, `http://yoursite/sites/publishing1`.  _fileName_ refers to the file where the search configuration settings are stored; _owner_ specifies the [SPWeb](/previous-versions/office/sharepoint-server/ms473942(v=office.15)) level at which the search configuration settings are obtained.
 
 
 ```csharp
@@ -60,19 +50,7 @@ private static void Import(string fileName)
 
 ```
 
-
 ## See also
-<a name="bk_addresources"> </a>
-
 
 -  [Search in SharePoint](search-in-sharepoint.md)
-
-
--  [Export and import customized search configuration settings in SharePoint](https://technet.microsoft.com/library/jj871675.aspx)
-
-
-
-
-
-
-
+-  [Export and import customized search configuration settings in SharePoint](/SharePoint/search/export-and-import-customized-search-configuration-settings)

--- a/docs/general-development/exporting-and-importing-search-configuration-settings-in-sharepoint.md
+++ b/docs/general-development/exporting-and-importing-search-configuration-settings-in-sharepoint.md
@@ -1,56 +1,50 @@
 ---
 title: Exporting and importing search configuration settings in SharePoint
 description: Get code examples that show you how to export and import customized search configuration settings. These settings include all customized query rules, result sources, result types, ranking models, and site search settings.
-ms.date: 09/25/2017
+ms.date: 04/24/2017
 ms.assetid: d00679a3-ffa2-4281-ad8b-70fc2c4a14e2
 ms.localizationpriority: medium
 ---
 
-
 # Exporting and importing search configuration settings in SharePoint
-Get code examples that show you how to export and import customized search configuration settings. These settings include all customized query rules, result sources, result types, ranking models, and site search settings. SharePoint exposes this functionality through the  [Microsoft.Office.Server.Search.Portability](/previous-versions/office/sharepoint-server/jj268113(v=office.15)) namespace.You can also export customized search configuration settings from a Search service application (SSA) and import the settings to site collections and sites.
+
+Get code examples that show you how to export and import customized search configuration settings. These settings include all customized query rules, result sources, result types, ranking models, and site search settings. SharePoint exposes this functionality through the [Microsoft.Office.Server.Search.Portability](/previous-versions/office/sharepoint-server/jj268113(v=office.15)) namespace. You can also export customized search configuration settings from a Search service application (SSA) and import the settings to site collections and sites.
 
 > [!NOTE]
 > You can't import customized search configuration settings to an SSA, or export the default search configuration settings.
 
-
 ## Export search configuration settings
 
-The following code shows how to use  [SearchConfigurationPortability](/previous-versions/office/sharepoint-server/jj267460(v=office.15)) to export your site's search configuration settings. The code uses an example site `http://yoursite/sites/publishing1`, which you'd replace with your own site.  _fileName_ refers to the file where the search configuration settings are stored; _owner_ specifies the [SPWeb](/previous-versions/office/sharepoint-server/ms473942(v=office.15)) level at which the search configuration settings are obtained.
-
+The following code shows how to use [SearchConfigurationPortability](/previous-versions/office/sharepoint-server/jj267460(v=office.15)) to export your site's search configuration settings. The code uses an example site `http://yoursite/sites/publishing1`, which you'd replace with your own site. _fileName_ refers to the file where the search configuration settings are stored; _owner_ specifies the [SPWeb](/previous-versions/office/sharepoint-server/ms473942(v=office.15)) level at which the search configuration settings are obtained.
 
 ```csharp
-
 private static void Export(string fileName)
 {
-    SPSite site = new SPSite("http://yoursite/sites/publishing1");
-    SearchConfigurationPortability conf = new SearchConfigurationPortability(site);
-    SearchObjectOwner owner = new SearchObjectOwner(SearchObjectLevel.SPWeb, site.OpenWeb());
-    var buff = conf.ExportSearchConfiguration(owner);
-    File.WriteAllText(fileName, buff);
-    site.Close();
+  SPSite site = new SPSite("http://yoursite/sites/publishing1");
+  SearchConfigurationPortability conf = new SearchConfigurationPortability(site);
+  SearchObjectOwner owner = new SearchObjectOwner(SearchObjectLevel.SPWeb, site.OpenWeb());
+  var buff = conf.ExportSearchConfiguration(owner);
+  File.WriteAllText(fileName, buff);
+  site.Close();
 }
 ```
 
 ## Import search configuration settings
 
-The following code shows how to import search configuration settings from a file by using  [SearchConfigurationPortability](/previous-versions/office/sharepoint-server/jj267460(v=office.15)) and replace the existing search settings on a specified site, `http://yoursite/sites/publishing1`.  _fileName_ refers to the file where the search configuration settings are stored; _owner_ specifies the [SPWeb](/previous-versions/office/sharepoint-server/ms473942(v=office.15)) level at which the search configuration settings are obtained.
-
+The following code shows how to import search configuration settings from a file by using [SearchConfigurationPortability](/previous-versions/office/sharepoint-server/jj267460(v=office.15)) and replace the existing search settings on a specified site, `http://yoursite/sites/publishing1`. _fileName_ refers to the file where the search configuration settings are stored; _owner_ specifies the [SPWeb](/previous-versions/office/sharepoint-server/ms473942(v=office.15)) level at which the search configuration settings are obtained.
 
 ```csharp
-
 private static void Import(string fileName)
 {
-    SPSite site = new SPSite("http://yoursite/sites/publishing1");
-    SearchConfigurationPortability conf = new SearchConfigurationPortability(site);
-    SearchObjectOwner owner = new SearchObjectOwner(SearchObjectLevel.SPWeb, site.OpenWeb());
-    conf.ImportSearchConfiguration(owner, File.ReadAllText(fileName));
-    site.Close();
+  SPSite site = new SPSite("http://yoursite/sites/publishing1");
+  SearchConfigurationPortability conf = new SearchConfigurationPortability(site);
+  SearchObjectOwner owner = new SearchObjectOwner(SearchObjectLevel.SPWeb, site.OpenWeb());
+  conf.ImportSearchConfiguration(owner, File.ReadAllText(fileName));
+  site.Close();
 }
-
 ```
 
 ## See also
 
--  [Search in SharePoint](search-in-sharepoint.md)
--  [Export and import customized search configuration settings in SharePoint](/SharePoint/search/export-and-import-customized-search-configuration-settings)
+- [Search in SharePoint](search-in-sharepoint.md)
+- [Export and import customized search configuration settings in SharePoint](/SharePoint/search/export-and-import-customized-search-configuration-settings)

--- a/docs/general-development/how-to-create-tabular-data-source-providers-for-performancepoint-services-in-sha.md
+++ b/docs/general-development/how-to-create-tabular-data-source-providers-for-performancepoint-services-in-sha.md
@@ -1,11 +1,10 @@
 ---
 title: Create tabular data source providers for PerformancePoint Services in SharePoint
 description: Learn how to create the data source provider component in a custom tabular data source extension for PerformancePoint Services.
-ms.date: 09/25/2017
+ms.date: 04/24/2017
 ms.assetid: 8d734ed6-7636-40c5-a99b-bc038362cffe
 ms.localizationpriority: medium
 ---
-
 
 # Create tabular data source providers for PerformancePoint Services in SharePoint
 
@@ -13,34 +12,34 @@ Learn how to create the data source provider component in a custom tabular data 
 
 ## What are custom data source providers for PerformancePoint Services?
 
-Data source providers connect to a data source, access its data, and then return query results. PerformancePoint Services uses tabular data source providers to access data from Excel and Excel Services worksheets, SharePoint lists, and Microsoft SQL Server tables. You can create a custom data source provider to use data from a tabular data source that is not supported by PerformancePoint Services.
+Data source providers connect to a data source, access its data, and then return query results. PerformancePoint Services uses tabular data source providers to access data from Excel and Excel Services worksheets, SharePoint lists, and Microsoft SQL Server tables. You can create a custom data source provider to use data from a tabular data source that isn't supported by PerformancePoint Services.
 
 The main function of a tabular data source provider is to create and populate a data table with data from the data source. It also creates column mappings to define the type of data that each column contains (fact, dimension, or time dimension). This applies a basic multidimensional structure to the tabular data.
 
-The procedures and code examples in this topic are based on the **WSTabularDataSourceProvider** class from the [custom objects sample](/previous-versions/office/developer/sharepoint-2010/ee558401(v=office.14)). The provider retrieves stock quotes from an external web service for specified stock symbols. It stores historical stock quote data in a cache file, which enables the data to be sliced by time. For the complete code for the class, see [Code example: Create a data source provider for custom PerformancePoint Services tabular data sources in SharePoint](#code-example-create-a-data-source-provider-for-custom-performancepoint-services-tabular-data-sources-in-sharepoint).
+The procedures and code examples in this article are based on the **WSTabularDataSourceProvider** class from the [custom objects sample](/previous-versions/office/developer/sharepoint-2010/ee558401(v=office.14)). The provider retrieves stock quotes from an external web service for specified stock symbols. It stores historical stock quote data in a cache file, which enables the data to be sliced by time. For the complete code for the class, see [Code example: Create a data source provider for custom PerformancePoint Services tabular data sources in SharePoint](#code-example-create-a-data-source-provider-for-custom-performancepoint-services-tabular-data-sources-in-sharepoint).
 
 We recommend that you use the sample data source provider as a template. The sample shows how to call objects in the PerformancePoint Services API and demonstrates best practices for PerformancePoint Services development.
 
 ## Create data source providers for custom PerformancePoint Services tabular data sources
 
 1. Install PerformancePoint Services, or copy the DLLs that your extension uses (listed in step 3) to your computer. For instructions, see [DLLs with Class Libraries](/previous-versions/office/developer/sharepoint-2010/bb834722(v=office.14)).
-2. In Visual Studio, create a C# class library. If you have already created a class library for your extension, add a new C# class.
+1. In Visual Studio, create a C# class library. If you have already created a class library for your extension, add a new C# class.
 
     You must sign your DLL with a strong name. In addition, ensure that all assemblies referenced by your DLL have strong names. For information about how to sign an assembly with a strong name and how to create a public/private key pair, see [How to: Create a Public/Private Key Pair](/dotnet/standard/assembly/create-public-private-key-pair).
 
-3. Add the following PerformancePoint Services DLLs as assembly references to the project:
+1. Add the following PerformancePoint Services DLLs as assembly references to the project:
 
-  - Microsoft.PerformancePoint.Scorecards.Client.dll
-  - Microsoft.PerformancePoint.Scorecards.DataSourceProviders.Standard.dll
+    - Microsoft.PerformancePoint.Scorecards.Client.dll
+    - Microsoft.PerformancePoint.Scorecards.DataSourceProviders.Standard.dll
 
     The sample data source provider also contains assembly references to System.Core.dll, System.ServiceModel.dll, System.Web.dll, System.Web.Services.dll, and System.Xml.Linq.dll. Depending on your extension's functionality, other project references may be required.
 
-4. Add a service reference named **StockQuotes** that references the Web service located at the address `http://www.webservicex.net/stockquote.asmx`. This is the Web service that provides stock quotes for the sample data source.
-5. Add the **BasicTabularDataSourceProvider** and **SampleDSCacheHandler** classes from the sample to your project. **BasicTabularDataSourceProvider** inherits from the [TabularDataSourceProvider](/previous-versions/office/sharepoint-server/cc299521(v=office.15)) class, which is the base class for tabular data source providers.
+1. Add a service reference named **StockQuotes** that references the Web service located at the address `http://www.webservicex.net/stockquote.asmx`. This is the Web service that provides stock quotes for the sample data source.
+1. Add the **BasicTabularDataSourceProvider** and **SampleDSCacheHandler** classes from the sample to your project. **BasicTabularDataSourceProvider** inherits from the [TabularDataSourceProvider](/previous-versions/office/sharepoint-server/cc299521(v=office.15)) class, which is the base class for tabular data source providers.
 
-    The sample data source also uses the class as a container for the overridden abstract methods that [TabularDataSourceProvider](/previous-versions/office/sharepoint-server/cc299521(v=office.15)) does not implement ( [GetDatabaseNames()](/previous-versions/office/sharepoint-server/bb833675(v=office.15)) , [GetCubeNames()](/previous-versions/office/sharepoint-server/bb836504(v=office.15)) , [GetCubeNameInfos()](/previous-versions/office/sharepoint-server/bb659072(v=office.15)) , [GetCubeMetaData](/previous-versions/office/developer/sharepoint-2007/bb658733(v=office.12)) , and [Validate()](/previous-versions/office/sharepoint-server/bb659181(v=office.15)) ).
+    The sample data source also uses the class as a container for the overridden abstract methods that [TabularDataSourceProvider](/previous-versions/office/sharepoint-server/cc299521(v=office.15)) doesn't implement ( [GetDatabaseNames()](/previous-versions/office/sharepoint-server/bb833675(v=office.15)) , [GetCubeNames()](/previous-versions/office/sharepoint-server/bb836504(v=office.15)) , [GetCubeNameInfos()](/previous-versions/office/sharepoint-server/bb659072(v=office.15)) , [GetCubeMetaData](/previous-versions/office/developer/sharepoint-2007/bb658733(v=office.12)) , and [Validate()](/previous-versions/office/sharepoint-server/bb659181(v=office.15)) ).
 
-6. In your provider class, add **using** directives for the following PerformancePoint Services namespaces:
+1. In your provider class, add `using` directives for the following PerformancePoint Services namespaces:
 
   - [Microsoft.PerformancePoint.Scorecards](/previous-versions/office/sharepoint-server/bb834037(v=office.15))
   - [Microsoft.PerformancePoint.Scorecards.ServerCommon](/previous-versions/office/sharepoint-server/ee583533(v=office.15))
@@ -48,18 +47,18 @@ We recommend that you use the sample data source provider as a template. The sam
 
     Depending on your extension's functionality, other **using** directives may be required.
 
-7. Inherit from the **BasicTabularDataSourceProvider** class.
-8. Declare variables and define properties that are used for parsing, storing, and retrieving stock symbols, the cache file location, and the URI of the proxy server.
-9. Override the [IsConnectionStringSecure](/previous-versions/office/sharepoint-server/bb835955(v=office.15)) property. This property is not used by PerformancePoint Services, but it is intended for custom applications to optionally use to identify whether a connection string exposes information that might pose a security risk.
+1. Inherit from the **BasicTabularDataSourceProvider** class.
+1. Declare variables and define properties that are used for parsing, storing, and retrieving stock symbols, the cache file location, and the URI of the proxy server.
+1. Override the [IsConnectionStringSecure](/previous-versions/office/sharepoint-server/bb835955(v=office.15)) property. This property isn't used by PerformancePoint Services, but it's intended for custom applications to optionally use to identify whether a connection string exposes information that might pose a security risk.
 
-    Return **true** if your extension stores sensitive information—such as a user name or password—in the connection string for your data source. Return **false** if it does not store sensitive information or if your data source does not use a connection string.
+    Return **true** if your extension stores sensitive information—such as a user name or password—in the connection string for your data source. Return **false** if it doesn't store sensitive information or if your data source doesn't use a connection string.
 
-10. Override the [GetId()](/previous-versions/office/sharepoint-server/bb836773(v=office.15)) method to return the unique identifier for your provider. [GetId()](/previous-versions/office/sharepoint-server/bb836773(v=office.15)) must return the same string as the **key** attribute that is registered in the PerformancePoint Services web.config file for the custom data source provider.
-11. Override the [SetDataSource](/previous-versions/office/sharepoint-server/cc299537(v=office.15)) method to define column mappings. [SetDataSource](/previous-versions/office/sharepoint-server/cc299537(v=office.15)) calls the **CreateDataColumnMappings** method to define data source columns as [Fact](/previous-versions/office/sharepoint-server/bb659274(v=office.15)) , [Dimension](/previous-versions/office/sharepoint-server/bb659274(v=office.15)) , and [TimeDimension](/previous-versions/office/sharepoint-server/bb659274(v=office.15)) types.
+1. Override the [GetId()](/previous-versions/office/sharepoint-server/bb836773(v=office.15)) method to return the unique identifier for your provider. [GetId()](/previous-versions/office/sharepoint-server/bb836773(v=office.15)) must return the same string as the **key** attribute that is registered in the PerformancePoint Services web.config file for the custom data source provider.
+1. Override the [SetDataSource](/previous-versions/office/sharepoint-server/cc299537(v=office.15)) method to define column mappings. [SetDataSource](/previous-versions/office/sharepoint-server/cc299537(v=office.15)) calls the **CreateDataColumnMappings** method to define data source columns as [Fact](/previous-versions/office/sharepoint-server/bb659274(v=office.15)) , [Dimension](/previous-versions/office/sharepoint-server/bb659274(v=office.15)) , and [TimeDimension](/previous-versions/office/sharepoint-server/bb659274(v=office.15)) types.
 
     [SetDataSource](/previous-versions/office/sharepoint-server/cc299537(v=office.15)) also retrieves the stock symbols, cache file location, and proxy server address from the [CustomData](/previous-versions/office/sharepoint-server/bb836036(v=office.15)) property of the custom data source object. These values are defined by dashboard authors in the sample data source editor.
 
-12. Override the [GetDataSet()](/previous-versions/office/sharepoint-server/cc299524(v=office.15)) method to create a [DataSet](/dotnet/api/system.data.dataset) object to store the data from the data source. The sample data source provider uses the **FillResultsTable** and **GetLiveQuote** methods to populate a data table with data from a Web service.
+1. Override the [GetDataSet()](/previous-versions/office/sharepoint-server/cc299524(v=office.15)) method to create a [DataSet](/dotnet/api/system.data.dataset) object to store the data from the data source. The sample data source provider uses the **FillResultsTable** and **GetLiveQuote** methods to populate a data table with data from a Web service.
 
 ## Code example: Create a data source provider for custom PerformancePoint Services tabular data sources in SharePoint
 
@@ -68,7 +67,6 @@ The class in the following code example creates a tabular data source provider t
 Before you can compile this code example, you must configure your development environment as described in [Create data source providers for custom PerformancePoint Services tabular data sources](#create-data-source-providers-for-custom-performancepoint-services-tabular-data-sources).
 
 ```csharp
-
 using System;
 using System.Data;
 using System.IO;
@@ -81,293 +79,285 @@ using System.ServiceModel;
 
 namespace Microsoft.PerformancePoint.SDK.Samples.SampleDataSource
 {
+  // Represents the class that defines the sample data source provider.
+  // It inherits from the BasicTabularDataSourceProvider class, which
+  // contains overridden abstract methods that are not implemented.
+  public class WSTabularDataSourceProvider : BasicTabularDataSourceProvider
+  {
+    #region Constants
+    private const int StockSymbolsIndex = 0;
+    private const int CacheFileLocationIndex = 1;
+    private const int ProxyAddressIndex = 2;
+    #endregion
 
-    // Represents the class that defines the sample data source provider.
-    // It inherits from the BasicTabularDataSourceProvider class, which
-    // contains overridden abstract methods that are not implemented.
-    public class WSTabularDataSourceProvider : BasicTabularDataSourceProvider
+    #region Properties
+
+    // This property stores the stock symbols that are used
+    // to query the Web service.
+    // Its value is obtained by parsing the CustomData property
+    // of the data source object.
+    private string[] StockSymbols
     {
-        #region Constants
-        private const int StockSymbolsIndex = 0;
-        private const int CacheFileLocationIndex = 1;
-        private const int ProxyAddressIndex = 2;
-        #endregion
-
-        #region Properties
-
-        // This property stores the stock symbols that are used
-        // to query the Web service.
-        // Its value is obtained by parsing the CustomData property
-        // of the data source object. 
-        private string[] StockSymbols
-        {
-            get;
-            set;
-        }
-
-        // The address of the proxy server.
-        private Uri ProxyAddress
-        {
-            get;
-            set;
-        }
-
-        // This property is not used by PerformancePoint Services.
-        // Its intended use is for custom applications to indicate
-        // whether a provider stores sensitive information in the
-        // connection string, such as user name and password.
-        // This sample does not, so it returns false. 
-        public override bool IsConnectionStringSecure
-        {
-            get { return false; }
-        }
-        #endregion
-
-        #region Overridden methods
-
-        // The source name for your data source. This value must match the key
-        // attribute that is registered in the web.config file.
-        public override string GetId()
-        {
-            return "WSTabularDataSource";
-        }
-
-        // Add column mappings for the sample columns if they do not exist.
-        // Column mappings may be missing if the custom data source has never
-        // been edited or if the workspace was not refreshed, which saves
-        // changes to the server.
-        public override void SetDataSource(DataSource dataSource)
-        {
-
-            base.SetDataSource(dataSource);
-
-            // Check for symbols stored in the CustomData
-            // property of the data source.
-            if (null == dataSource ||
-                 string.IsNullOrEmpty(dataSource.CustomData))
-            {
-
-                // Create a symbol for testing purposes.
-                StockSymbols = new[] { "MSFT" };
-            }
-            else
-            {
-                string[] splitCustomData = dataSource.CustomData.Split('&amp;');
-                if (splitCustomData.Length > 2)
-                {
-                    StockSymbols = splitCustomData[StockSymbolsIndex].ToUpper().Split(',');
-                    for (int iLoop = 0; iLoop < StockSymbols.Length; iLoop++)
-                    {
-                        StockSymbols[iLoop] = StockSymbols[iLoop].Trim();
-                    }
-
-                    SampleDSCacheHandler.CacheFileLocation = splitCustomData[CacheFileLocationIndex];
-                    ProxyAddress = new Uri(splitCustomData[ProxyAddressIndex]);
-                }
-            }
-
-            // Check whether column mappings exist. Do not overwrite them.
-            if (dataSource.DataTableMapping.ColumnMappings.Count == 0)
-            {
-                dataSource.DataTableMapping = CreateDataColumnMappings();
-            }
-        }
-
-        // Get the data from the data source.
-        // GetDataSet contains the core logic for the provider.
-        public override DataSet GetDataSet()
-        {
-
-            // Create a dataset and a data table to store the data.
-            DataSet resultSet = new DataSet();
-            DataTable resultTable = resultSet.Tables.Add();
-
-            // Define column names and the type of data that they contain. 
-            resultTable.Columns.Add("Symbol", typeof(string));
-            resultTable.Columns.Add("Value", typeof(float));
-            resultTable.Columns.Add("P-E Ratio", typeof(float));
-            resultTable.Columns.Add("Percentage Change", typeof(float));
-            resultTable.Columns.Add("Date", typeof(DateTime));
-
-            FillResultTable(ref resultTable);
-
-            return resultSet;
-        }
-        #endregion
-
-        #region Internal methods
-
-        // Fill the data table with the stock quote values from
-        // the Web service and local cache file.
-        protected void FillResultTable(ref DataTable resultsTable)
-        {
-
-            // Check the sematic validity of symbols (out of scope for this sample).
-            if (null != StockSymbols &amp;&amp;
-                StockSymbols.Length > 0 &amp;&amp;
-                !string.IsNullOrEmpty(SampleDSCacheHandler.CacheFileLocation))
-            {
-                try
-                {
-                    if (!File.Exists(SampleDSCacheHandler.CacheFileLocation))
-                    {
-
-                        // Create the cache file.
-                        XDocument doc = SampleDSCacheHandler.DefaultCacheFileContent;
-                        doc.Save(@SampleDSCacheHandler.CacheFileLocation);
-                    }
-
-                    // Get real-time quotes and update cache file.
-                    string wsResult = GetLiveQuote();
-
-                    SampleDSCacheHandler.UpdateXMLCacheFile(wsResult);
-
-                    // Check if a valid cache file location exists.
-                    if (SampleDSCacheHandler.CacheFileContent != null)
-                    {
-                        var query = from c in SampleDSCacheHandler.CacheFileContent.Elements("StockQuotes").Elements("StockQuote")
-                                    where StockSymbols.Contains(c.Attribute("Symbol").Value)
-                                    select c;
-
-                        foreach (var stockQuote in query)
-                        {
-                            DataRow row = resultsTable.NewRow();
-                            row["Symbol"] = stockQuote.Attribute("Symbol").Value;
-                            row["Value"] = stockQuote.Element("Value").Value;
-                            row["Percentage Change"] = stockQuote.Element("PercentageChange").Value;
-                            row["Date"] = stockQuote.Element("Date").Value;
-
-                            decimal peRatio;
-
-                            // Handle symbols that return 'N/A' for this field.
-                            if (decimal.TryParse(stockQuote.Element("PERatio").Value, out peRatio))
-                            {
-                                row["P-E Ratio"] = peRatio;
-                            }
-
-                            resultsTable.Rows.Add(row);
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    ServerUtils.HandleException(ex);
-                }
-            }
-        }
-
-        // Get real-time quotes from the Web service.
-        protected string GetLiveQuote()
-        {
-            EndpointAddress endpoint = new EndpointAddress("http://www.webservicex.net/stockquote.asmx");
-            BasicHttpBinding binding = new BasicHttpBinding();
-            binding.ReceiveTimeout = new TimeSpan(0, 0, 120);
-            binding.ProxyAddress = ProxyAddress;
-            binding.UseDefaultWebProxy = false;
-
-            StockQuotes.StockQuoteSoapClient wsStockQuoteService = new StockQuoteSoapClient(binding, endpoint);
-
-            // Check the sematic validity of symbols (out of scope for this sample).
-            if (null != StockSymbols &amp;&amp;
-                StockSymbols.Length > 0)
-            {
-                try
-                {
-                    string quoteRequest = StockSymbols[0];
-                    for (int iLoop = 1; iLoop < StockSymbols.Length; iLoop++)
-                    {
-                        quoteRequest = string.Format("{0}, {1}", quoteRequest, StockSymbols[iLoop]);
-                    }
-
-                    string wsResult = wsStockQuoteService.GetQuote(quoteRequest);
-                    return wsResult;
-                }
-                catch (Exception ex)
-                {
-                    ServerUtils.HandleException(ex);
-                }
-            }
-            return string.Empty;
-        }
-
-        // Create the column mappings.
-        internal static DataTableMapping CreateDataColumnMappings()
-        {
-            DataTableMapping dtTableMapping = new DataTableMapping();
-
-            // Define the data in the Symbol column as dimension data.
-            dtTableMapping.ColumnMappings.Add(new DataColumnMapping
-            {
-                SourceColumnName = "Symbol",
-                FriendlyColumnName = "Symbol",
-                UniqueName = "Symbol",
-                ColumnType = MappedColumnTypes.Dimension,
-                FactAggregation = FactAggregations.None,
-                ColumnDataType = MappedColumnDataTypes.String
-            });
-
-            // Define the data in the Value column as fact data.
-            dtTableMapping.ColumnMappings.Add(new DataColumnMapping
-            {
-                SourceColumnName = "Value",
-                FriendlyColumnName = "Value",
-                UniqueName = "Value",
-                ColumnType = MappedColumnTypes.Fact,
-                FactAggregation = FactAggregations.Average,
-                ColumnDataType = MappedColumnDataTypes.Number
-            });
-
-            // Define the data in the P-E Ratio column as fact data.
-            dtTableMapping.ColumnMappings.Add(new DataColumnMapping
-            {
-                SourceColumnName = "P-E Ratio",
-                FriendlyColumnName = "P-E Ratio",
-                UniqueName = "P-E Ratio",
-                ColumnType = MappedColumnTypes.Fact,
-                FactAggregation = FactAggregations.Average,
-                ColumnDataType = MappedColumnDataTypes.Number
-            });
-
-            // Define the data in the Percentage Change column as fact data.
-            dtTableMapping.ColumnMappings.Add(new DataColumnMapping
-            {
-                SourceColumnName = "Percentage Change",
-                FriendlyColumnName = "Percentage Change",
-                UniqueName = "Percentage Change",
-                ColumnType = MappedColumnTypes.Fact,
-                FactAggregation = FactAggregations.Average,
-                ColumnDataType = MappedColumnDataTypes.Number
-            });
-
-            // Define the Date column as a time dimension.
-            dtTableMapping.ColumnMappings.Add(new DataColumnMapping
-            {
-                SourceColumnName = "Date",
-                FriendlyColumnName = "Date",
-                UniqueName = "Date",
-                ColumnType = MappedColumnTypes.TimeDimension,
-                FactAggregation = FactAggregations.None,
-                ColumnDataType = MappedColumnDataTypes.DateTime
-            });
-
-            // Increase the granularity of the time dimension.
-            dtTableMapping.DateAggregationType |= DateAggregationTypes.Quarter;
-            dtTableMapping.DateAggregationType |= DateAggregationTypes.Month;
-            dtTableMapping.DateAggregationType |= DateAggregationTypes.Week;
-            dtTableMapping.DateAggregationType |= DateAggregationTypes.Day;
-
-            return dtTableMapping;
-        }
-        #endregion
+      get;
+      set;
     }
+
+    // The address of the proxy server.
+    private Uri ProxyAddress
+    {
+      get;
+      set;
+    }
+
+    // This property is not used by PerformancePoint Services.
+    // Its intended use is for custom applications to indicate
+    // whether a provider stores sensitive information in the
+    // connection string, such as user name and password.
+    // This sample does not, so it returns false.
+    public override bool IsConnectionStringSecure
+    {
+      get { return false; }
+    }
+    #endregion
+
+    #region Overridden methods
+
+    // The source name for your data source. This value must match the key
+    // attribute that is registered in the web.config file.
+    public override string GetId()
+    {
+      return "WSTabularDataSource";
+    }
+
+    // Add column mappings for the sample columns if they do not exist.
+    // Column mappings may be missing if the custom data source has never
+    // been edited or if the workspace was not refreshed, which saves
+    // changes to the server.
+    public override void SetDataSource(DataSource dataSource)
+    {
+      base.SetDataSource(dataSource);
+
+      // Check for symbols stored in the CustomData
+      // property of the data source.
+      if (null == dataSource || string.IsNullOrEmpty(dataSource.CustomData))
+      {
+        // Create a symbol for testing purposes.
+        StockSymbols = new[] { "MSFT" };
+      }
+      else
+      {
+        string[] splitCustomData = dataSource.CustomData.Split('&amp;');
+        if (splitCustomData.Length > 2)
+        {
+          StockSymbols = splitCustomData[StockSymbolsIndex].ToUpper().Split(',');
+          for (int iLoop = 0; iLoop < StockSymbols.Length; iLoop++)
+          {
+            StockSymbols[iLoop] = StockSymbols[iLoop].Trim();
+          }
+
+          SampleDSCacheHandler.CacheFileLocation = splitCustomData[CacheFileLocationIndex];
+          ProxyAddress = new Uri(splitCustomData[ProxyAddressIndex]);
+        }
+      }
+
+      // Check whether column mappings exist. Do not overwrite them.
+      if (dataSource.DataTableMapping.ColumnMappings.Count == 0)
+      {
+        dataSource.DataTableMapping = CreateDataColumnMappings();
+      }
+    }
+
+    // Get the data from the data source.
+    // GetDataSet contains the core logic for the provider.
+    public override DataSet GetDataSet()
+    {
+      // Create a dataset and a data table to store the data.
+      DataSet resultSet = new DataSet();
+      DataTable resultTable = resultSet.Tables.Add();
+
+      // Define column names and the type of data that they contain.
+      resultTable.Columns.Add("Symbol", typeof(string));
+      resultTable.Columns.Add("Value", typeof(float));
+      resultTable.Columns.Add("P-E Ratio", typeof(float));
+      resultTable.Columns.Add("Percentage Change", typeof(float));
+      resultTable.Columns.Add("Date", typeof(DateTime));
+
+      FillResultTable(ref resultTable);
+
+      return resultSet;
+    }
+    #endregion
+
+    #region Internal methods
+
+    // Fill the data table with the stock quote values from
+    // the Web service and local cache file.
+    protected void FillResultTable(ref DataTable resultsTable)
+    {
+
+      // Check the sematic validity of symbols (out of scope for this sample).
+      if (null != StockSymbols
+          && StockSymbols.Length > 0
+          && !string.IsNullOrEmpty(SampleDSCacheHandler.CacheFileLocation)) {
+        try
+        {
+          if (!File.Exists(SampleDSCacheHandler.CacheFileLocation))
+          {
+            // Create the cache file.
+            XDocument doc = SampleDSCacheHandler.DefaultCacheFileContent;
+            doc.Save(@SampleDSCacheHandler.CacheFileLocation);
+          }
+
+          // Get real-time quotes and update cache file.
+          string wsResult = GetLiveQuote();
+
+          SampleDSCacheHandler.UpdateXMLCacheFile(wsResult);
+
+          // Check if a valid cache file location exists.
+          if (SampleDSCacheHandler.CacheFileContent != null)
+          {
+            var query = from c in SampleDSCacheHandler.CacheFileContent
+                                                      .Elements("StockQuotes")
+                                                      .Elements("StockQuote")
+                        where StockSymbols.Contains(c.Attribute("Symbol").Value)
+                        select c;
+
+            foreach (var stockQuote in query)
+            {
+              DataRow row = resultsTable.NewRow();
+              row["Symbol"] = stockQuote.Attribute("Symbol").Value;
+              row["Value"] = stockQuote.Element("Value").Value;
+              row["Percentage Change"] = stockQuote.Element("PercentageChange").Value;
+              row["Date"] = stockQuote.Element("Date").Value;
+
+              decimal peRatio;
+
+              // Handle symbols that return 'N/A' for this field.
+              if (decimal.TryParse(stockQuote.Element("PERatio").Value, out peRatio))
+              {
+                row["P-E Ratio"] = peRatio;
+              }
+
+              resultsTable.Rows.Add(row);
+            }
+          }
+        }
+        catch (Exception ex)
+        {
+          ServerUtils.HandleException(ex);
+        }
+      }
+    }
+
+    // Get real-time quotes from the Web service.
+    protected string GetLiveQuote()
+    {
+      EndpointAddress endpoint = new EndpointAddress("http://www.webservicex.net/stockquote.asmx");
+      BasicHttpBinding binding = new BasicHttpBinding();
+      binding.ReceiveTimeout = new TimeSpan(0, 0, 120);
+      binding.ProxyAddress = ProxyAddress;
+      binding.UseDefaultWebProxy = false;
+
+      StockQuotes.StockQuoteSoapClient wsStockQuoteService = new StockQuoteSoapClient(binding, endpoint);
+
+      // Check the sematic validity of symbols (out of scope for this sample).
+      if (null != StockSymbols && StockSymbols.Length > 0)
+      {
+        try
+        {
+          string quoteRequest = StockSymbols[0];
+          for (int iLoop = 1; iLoop < StockSymbols.Length; iLoop++)
+          {
+            quoteRequest = string.Format("{0}, {1}", quoteRequest, StockSymbols[iLoop]);
+          }
+
+          string wsResult = wsStockQuoteService.GetQuote(quoteRequest);
+          return wsResult;
+        }
+        catch (Exception ex)
+        {
+          ServerUtils.HandleException(ex);
+        }
+      }
+      return string.Empty;
+    }
+
+    // Create the column mappings.
+    internal static DataTableMapping CreateDataColumnMappings()
+    {
+      DataTableMapping dtTableMapping = new DataTableMapping();
+
+      // Define the data in the Symbol column as dimension data.
+      dtTableMapping.ColumnMappings.Add(new DataColumnMapping
+      {
+        SourceColumnName = "Symbol",
+        FriendlyColumnName = "Symbol",
+        UniqueName = "Symbol",
+        ColumnType = MappedColumnTypes.Dimension,
+        FactAggregation = FactAggregations.None,
+        ColumnDataType = MappedColumnDataTypes.String
+      });
+
+      // Define the data in the Value column as fact data.
+      dtTableMapping.ColumnMappings.Add(new DataColumnMapping
+      {
+        SourceColumnName = "Value",
+        FriendlyColumnName = "Value",
+        UniqueName = "Value",
+        ColumnType = MappedColumnTypes.Fact,
+        FactAggregation = FactAggregations.Average,
+        ColumnDataType = MappedColumnDataTypes.Number
+      });
+
+      // Define the data in the P-E Ratio column as fact data.
+      dtTableMapping.ColumnMappings.Add(new DataColumnMapping
+      {
+        SourceColumnName = "P-E Ratio",
+        FriendlyColumnName = "P-E Ratio",
+        UniqueName = "P-E Ratio",
+        ColumnType = MappedColumnTypes.Fact,
+        FactAggregation = FactAggregations.Average,
+        ColumnDataType = MappedColumnDataTypes.Number
+      });
+
+      // Define the data in the Percentage Change column as fact data.
+      dtTableMapping.ColumnMappings.Add(new DataColumnMapping
+      {
+        SourceColumnName = "Percentage Change",
+        FriendlyColumnName = "Percentage Change",
+        UniqueName = "Percentage Change",
+        ColumnType = MappedColumnTypes.Fact,
+        FactAggregation = FactAggregations.Average,
+        ColumnDataType = MappedColumnDataTypes.Number
+      });
+
+      // Define the Date column as a time dimension.
+      dtTableMapping.ColumnMappings.Add(new DataColumnMapping
+      {
+        SourceColumnName = "Date",
+        FriendlyColumnName = "Date",
+        UniqueName = "Date",
+        ColumnType = MappedColumnTypes.TimeDimension,
+        FactAggregation = FactAggregations.None,
+        ColumnDataType = MappedColumnDataTypes.DateTime
+      });
+
+      // Increase the granularity of the time dimension.
+      dtTableMapping.DateAggregationType |= DateAggregationTypes.Quarter;
+      dtTableMapping.DateAggregationType |= DateAggregationTypes.Month;
+      dtTableMapping.DateAggregationType |= DateAggregationTypes.Week;
+      dtTableMapping.DateAggregationType |= DateAggregationTypes.Day;
+
+      return dtTableMapping;
+    }
+    #endregion
+  }
 }
-
 ```
-
 
 ## Next steps
 
-After you create a data source provider and a data source editor (including its user interface, if required), deploy the extension as described in [How to: Manually Register PerformancePoint Services Extensions](/previous-versions/office/developer/sharepoint-2010/ee556434(v=office.14)).
+After you create a data source provider and a data source editor (including its user interface, if necessary), deploy the extension as described in [How to: Manually Register PerformancePoint Services Extensions](/previous-versions/office/developer/sharepoint-2010/ee556434(v=office.14)).
 
 ## See also
 

--- a/docs/general-development/how-to-create-tabular-data-source-providers-for-performancepoint-services-in-sha.md
+++ b/docs/general-development/how-to-create-tabular-data-source-providers-for-performancepoint-services-in-sha.md
@@ -59,7 +59,7 @@ We recommend that you use the sample data source provider as a template. The sam
 
     [SetDataSource](/previous-versions/office/sharepoint-server/cc299537(v=office.15)) also retrieves the stock symbols, cache file location, and proxy server address from the [CustomData](/previous-versions/office/sharepoint-server/bb836036(v=office.15)) property of the custom data source object. These values are defined by dashboard authors in the sample data source editor.
 
-12. Override the [GetDataSet()](/previous-versions/office/sharepoint-server/cc299524(v=office.15)) method to create a [DataSet](/dotnet/api/system.data.dataset?view=netframework-4.8.1) object to store the data from the data source. The sample data source provider uses the **FillResultsTable** and **GetLiveQuote** methods to populate a data table with data from a Web service.
+12. Override the [GetDataSet()](/previous-versions/office/sharepoint-server/cc299524(v=office.15)) method to create a [DataSet](/dotnet/api/system.data.dataset) object to store the data from the data source. The sample data source provider uses the **FillResultsTable** and **GetLiveQuote** methods to populate a data table with data from a Web service.
 
 ## Code example: Create a data source provider for custom PerformancePoint Services tabular data sources in SharePoint
 

--- a/docs/general-development/how-to-create-tabular-data-source-providers-for-performancepoint-services-in-sha.md
+++ b/docs/general-development/how-to-create-tabular-data-source-providers-for-performancepoint-services-in-sha.md
@@ -12,108 +12,60 @@ ms.localizationpriority: medium
 Learn how to create the data source provider component in a custom tabular data source extension for PerformancePoint Services.
 
 ## What are custom data source providers for PerformancePoint Services?
-<a name="bk_intro"> </a>
 
 Data source providers connect to a data source, access its data, and then return query results. PerformancePoint Services uses tabular data source providers to access data from Excel and Excel Services worksheets, SharePoint lists, and Microsoft SQL Server tables. You can create a custom data source provider to use data from a tabular data source that is not supported by PerformancePoint Services.
-  
-    
-    
+
 The main function of a tabular data source provider is to create and populate a data table with data from the data source. It also creates column mappings to define the type of data that each column contains (fact, dimension, or time dimension). This applies a basic multidimensional structure to the tabular data.
-  
-    
-    
-The procedures and code examples in this topic are based on the **WSTabularDataSourceProvider** class from the [custom objects sample](https://msdn.microsoft.com/library/af021d52-7562-4e7a-9de4-e1fc5784a59d%28Office.15%29.aspx). The provider retrieves stock quotes from an external web service for specified stock symbols. It stores historical stock quote data in a cache file, which enables the data to be sliced by time. For the complete code for the class, see  [Code example: Create a data source provider for custom PerformancePoint Services tabular data sources in SharePoint](#bk_example).
-  
-    
-    
+
+The procedures and code examples in this topic are based on the **WSTabularDataSourceProvider** class from the [custom objects sample](/previous-versions/office/developer/sharepoint-2010/ee558401(v=office.14)). The provider retrieves stock quotes from an external web service for specified stock symbols. It stores historical stock quote data in a cache file, which enables the data to be sliced by time. For the complete code for the class, see [Code example: Create a data source provider for custom PerformancePoint Services tabular data sources in SharePoint](#code-example-create-a-data-source-provider-for-custom-performancepoint-services-tabular-data-sources-in-sharepoint).
+
 We recommend that you use the sample data source provider as a template. The sample shows how to call objects in the PerformancePoint Services API and demonstrates best practices for PerformancePoint Services development.
-  
-    
-    
 
 ## Create data source providers for custom PerformancePoint Services tabular data sources
-<a name="BKMK_CreateClass"> </a>
 
-
-1. Install PerformancePoint Services, or copy the DLLs that your extension uses (listed in step 3) to your computer. For instructions, see  [DLLs with Class Libraries](https://msdn.microsoft.com/library/41e92619-8253-481d-82f9-35b6a6abc477%28Office.15%29.aspx).
-    
-  
+1. Install PerformancePoint Services, or copy the DLLs that your extension uses (listed in step 3) to your computer. For instructions, see [DLLs with Class Libraries](/previous-versions/office/developer/sharepoint-2010/bb834722(v=office.14)).
 2. In Visual Studio, create a C# class library. If you have already created a class library for your extension, add a new C# class.
-    
-    You must sign your DLL with a strong name. In addition, ensure that all assemblies referenced by your DLL have strong names. For information about how to sign an assembly with a strong name and how to create a public/private key pair, see  [How to: Create a Public/Private Key Pair](https://msdn.microsoft.com/library/05026813-f3bd-4d7c-9e0b-fc588eb3d114.aspx).
-    
-  
+
+    You must sign your DLL with a strong name. In addition, ensure that all assemblies referenced by your DLL have strong names. For information about how to sign an assembly with a strong name and how to create a public/private key pair, see [How to: Create a Public/Private Key Pair](/dotnet/standard/assembly/create-public-private-key-pair).
+
 3. Add the following PerformancePoint Services DLLs as assembly references to the project:
-    
+
   - Microsoft.PerformancePoint.Scorecards.Client.dll
-    
-  
   - Microsoft.PerformancePoint.Scorecards.DataSourceProviders.Standard.dll
-    
-  
 
     The sample data source provider also contains assembly references to System.Core.dll, System.ServiceModel.dll, System.Web.dll, System.Web.Services.dll, and System.Xml.Linq.dll. Depending on your extension's functionality, other project references may be required.
-    
-  
+
 4. Add a service reference named **StockQuotes** that references the Web service located at the address `http://www.webservicex.net/stockquote.asmx`. This is the Web service that provides stock quotes for the sample data source.
-    
-  
-5. Add the **BasicTabularDataSourceProvider** and **SampleDSCacheHandler** classes from the sample to your project. **BasicTabularDataSourceProvider** inherits from the [TabularDataSourceProvider](https://msdn.microsoft.com/library/Microsoft.PerformancePoint.Scorecards.DataSourceProviders.TabularDataSourceProvider.aspx) class, which is the base class for tabular data source providers.
-    
-    The sample data source also uses the class as a container for the overridden abstract methods that  [TabularDataSourceProvider](https://msdn.microsoft.com/library/Microsoft.PerformancePoint.Scorecards.DataSourceProviders.TabularDataSourceProvider.aspx) does not implement ( [GetDatabaseNames()](https://msdn.microsoft.com/library/Microsoft.PerformancePoint.Scorecards.Extensions.CustomDataSourceProvider.GetDatabaseNames.aspx) , [GetCubeNames()](https://msdn.microsoft.com/library/Microsoft.PerformancePoint.Scorecards.Extensions.CustomDataSourceProvider.GetCubeNames.aspx) , [GetCubeNameInfos()](https://msdn.microsoft.com/library/Microsoft.PerformancePoint.Scorecards.Extensions.CustomDataSourceProvider.GetCubeNameInfos.aspx) , [GetCubeMetaData](https://msdn.microsoft.com/library/Microsoft.PerformancePoint.Scorecards.Extensions.CustomDataSourceProvider.GetCubeMetaData.aspx) , and [Validate()](https://msdn.microsoft.com/library/Microsoft.PerformancePoint.Scorecards.Extensions.CustomDataSourceProvider.Validate.aspx) ).
-    
-  
+5. Add the **BasicTabularDataSourceProvider** and **SampleDSCacheHandler** classes from the sample to your project. **BasicTabularDataSourceProvider** inherits from the [TabularDataSourceProvider](/previous-versions/office/sharepoint-server/cc299521(v=office.15)) class, which is the base class for tabular data source providers.
+
+    The sample data source also uses the class as a container for the overridden abstract methods that [TabularDataSourceProvider](/previous-versions/office/sharepoint-server/cc299521(v=office.15)) does not implement ( [GetDatabaseNames()](/previous-versions/office/sharepoint-server/bb833675(v=office.15)) , [GetCubeNames()](/previous-versions/office/sharepoint-server/bb836504(v=office.15)) , [GetCubeNameInfos()](/previous-versions/office/sharepoint-server/bb659072(v=office.15)) , [GetCubeMetaData](/previous-versions/office/developer/sharepoint-2007/bb658733(v=office.12)) , and [Validate()](/previous-versions/office/sharepoint-server/bb659181(v=office.15)) ).
+
 6. In your provider class, add **using** directives for the following PerformancePoint Services namespaces:
-    
-  -  [Microsoft.PerformancePoint.Scorecards](https://msdn.microsoft.com/library/Microsoft.PerformancePoint.Scorecards.aspx)
-    
-  
-  -  [Microsoft.PerformancePoint.Scorecards.ServerCommon](https://msdn.microsoft.com/library/Microsoft.PerformancePoint.Scorecards.ServerCommon.aspx)
-    
-  
+
+  - [Microsoft.PerformancePoint.Scorecards](/previous-versions/office/sharepoint-server/bb834037(v=office.15))
+  - [Microsoft.PerformancePoint.Scorecards.ServerCommon](/previous-versions/office/sharepoint-server/ee583533(v=office.15))
   - **Microsoft.PerformancePoint.SDK.Samples.StockQuotes** (represents the StockQuotes service reference created in step 4)
-    
-  
 
     Depending on your extension's functionality, other **using** directives may be required.
-    
-  
+
 7. Inherit from the **BasicTabularDataSourceProvider** class.
-    
-  
 8. Declare variables and define properties that are used for parsing, storing, and retrieving stock symbols, the cache file location, and the URI of the proxy server.
-    
-  
-9. Override the  [IsConnectionStringSecure](https://msdn.microsoft.com/library/Microsoft.PerformancePoint.Scorecards.Extensions.CustomDataSourceProvider.IsConnectionStringSecure.aspx) property. This property is not used by PerformancePoint Services, but it is intended for custom applications to optionally use to identify whether a connection string exposes information that might pose a security risk.
-    
+9. Override the [IsConnectionStringSecure](/previous-versions/office/sharepoint-server/bb835955(v=office.15)) property. This property is not used by PerformancePoint Services, but it is intended for custom applications to optionally use to identify whether a connection string exposes information that might pose a security risk.
+
     Return **true** if your extension stores sensitive information—such as a user name or password—in the connection string for your data source. Return **false** if it does not store sensitive information or if your data source does not use a connection string.
-    
-  
-10. Override the  [GetId()](https://msdn.microsoft.com/library/Microsoft.PerformancePoint.Scorecards.Extensions.CustomDataSourceProvider.GetId.aspx) method to return the unique identifier for your provider. [GetId()](https://msdn.microsoft.com/library/Microsoft.PerformancePoint.Scorecards.Extensions.CustomDataSourceProvider.GetId.aspx) must return the same string as the **key** attribute that is registered in the PerformancePoint Services web.config file for the custom data source provider.
-    
-  
-11. Override the  [SetDataSource](https://msdn.microsoft.com/library/Microsoft.PerformancePoint.Scorecards.DataSourceProviders.TabularDataSourceProvider.SetDataSource.aspx) method to define column mappings. [SetDataSource](https://msdn.microsoft.com/library/Microsoft.PerformancePoint.Scorecards.DataSourceProviders.TabularDataSourceProvider.SetDataSource.aspx) calls the **CreateDataColumnMappings** method to define data source columns as [Fact](https://msdn.microsoft.com/Library/microsoft.performancepoint.scorecards.mappedcolumntypes.aspx) , [Dimension](https://msdn.microsoft.com/Library/microsoft.performancepoint.scorecards.mappedcolumntypes.aspx) , and [TimeDimension](https://msdn.microsoft.com/Library/microsoft.performancepoint.scorecards.mappedcolumntypes.aspx) types.
-    
-     [SetDataSource](https://msdn.microsoft.com/library/Microsoft.PerformancePoint.Scorecards.DataSourceProviders.TabularDataSourceProvider.SetDataSource.aspx) also retrieves the stock symbols, cache file location, and proxy server address from the [CustomData](https://msdn.microsoft.com/library/Microsoft.PerformancePoint.Scorecards.DataSource.CustomData.aspx) property of the custom data source object. These values are defined by dashboard authors in the sample data source editor.
-    
-  
-12. Override the  [GetDataSet()](https://msdn.microsoft.com/library/Microsoft.PerformancePoint.Scorecards.DataSourceProviders.TabularDataSourceProvider.GetDataSet.aspx) method to create a [DataSet](https://msdn.microsoft.com/library/System.Data.DataSet.aspx) object to store the data from the data source. The sample data source provider uses the **FillResultsTable** and **GetLiveQuote** methods to populate a data table with data from a Web service.
-    
-  
+
+10. Override the [GetId()](/previous-versions/office/sharepoint-server/bb836773(v=office.15)) method to return the unique identifier for your provider. [GetId()](/previous-versions/office/sharepoint-server/bb836773(v=office.15)) must return the same string as the **key** attribute that is registered in the PerformancePoint Services web.config file for the custom data source provider.
+11. Override the [SetDataSource](/previous-versions/office/sharepoint-server/cc299537(v=office.15)) method to define column mappings. [SetDataSource](/previous-versions/office/sharepoint-server/cc299537(v=office.15)) calls the **CreateDataColumnMappings** method to define data source columns as [Fact](/previous-versions/office/sharepoint-server/bb659274(v=office.15)) , [Dimension](/previous-versions/office/sharepoint-server/bb659274(v=office.15)) , and [TimeDimension](/previous-versions/office/sharepoint-server/bb659274(v=office.15)) types.
+
+    [SetDataSource](/previous-versions/office/sharepoint-server/cc299537(v=office.15)) also retrieves the stock symbols, cache file location, and proxy server address from the [CustomData](/previous-versions/office/sharepoint-server/bb836036(v=office.15)) property of the custom data source object. These values are defined by dashboard authors in the sample data source editor.
+
+12. Override the [GetDataSet()](/previous-versions/office/sharepoint-server/cc299524(v=office.15)) method to create a [DataSet](/dotnet/api/system.data.dataset?view=netframework-4.8.1) object to store the data from the data source. The sample data source provider uses the **FillResultsTable** and **GetLiveQuote** methods to populate a data table with data from a Web service.
 
 ## Code example: Create a data source provider for custom PerformancePoint Services tabular data sources in SharePoint
-<a name="bk_example"> </a>
 
 The class in the following code example creates a tabular data source provider that retrieves stock quotes from an external Web service and then transforms the data into a tabular format.
-  
-    
-    
-Before you can compile this code example, you must configure your development environment as described in  [Create data source providers for custom PerformancePoint Services tabular data sources](#BKMK_CreateClass).
-  
-    
-    
 
-
+Before you can compile this code example, you must configure your development environment as described in [Create data source providers for custom PerformancePoint Services tabular data sources](#create-data-source-providers-for-custom-performancepoint-services-tabular-data-sources).
 
 ```csharp
 
@@ -414,21 +366,10 @@ namespace Microsoft.PerformancePoint.SDK.Samples.SampleDataSource
 
 
 ## Next steps
-<a name="bk_next"> </a>
 
-After you create a data source provider and a data source editor (including its user interface, if required), deploy the extension as described in  [How to: Manually Register PerformancePoint Services Extensions](https://msdn.microsoft.com/library/3aa6d340-4b05-46b3-9648-2b6e18e04e09%28Office.15%29.aspx). 
-  
-    
-    
+After you create a data source provider and a data source editor (including its user interface, if required), deploy the extension as described in [How to: Manually Register PerformancePoint Services Extensions](/previous-versions/office/developer/sharepoint-2010/ee556434(v=office.14)).
 
 ## See also
-<a name="bk_addResources"> </a>
 
-
--  [How to: Create tabular data source editors for PerformancePoint Services in SharePoint](how-to-create-tabular-data-source-editors-for-performancepoint-services-in-share.md)
-    
-  
--  [PerformancePoint Services in SharePoint](performancepoint-services-in-sharepoint.md)
-    
-  
-
+- [How to: Create tabular data source editors for PerformancePoint Services in SharePoint](how-to-create-tabular-data-source-editors-for-performancepoint-services-in-share.md)
+- [PerformancePoint Services in SharePoint](performancepoint-services-in-sharepoint.md)

--- a/docs/general-development/how-to-detect-the-installed-sku-of-sharepoint.md
+++ b/docs/general-development/how-to-detect-the-installed-sku-of-sharepoint.md
@@ -1,11 +1,10 @@
 ---
 title: Detect the installed SKU of SharePoint
 description: If the behavior of your solutions depends on the locally installed SKU of SharePoint or Project Server 2013, use the code example in this article to find the SKU information you need.
-ms.date: 09/25/2017
+ms.date: 04/24/2017
 ms.assetid: d5d84d6f-6a8e-4ead-9296-7025baf1e154
 ms.localizationpriority: medium
 ---
-
 
 # Detect the installed SKU of SharePoint
 
@@ -19,81 +18,79 @@ If the behavior of your solutions depends on the locally installed SKU of ShareP
 The following code example demonstrates how to retrieve the registry key of the installed SKU of SharePoint, Microsoft Project Server 2013, and other Office server products, and how to match the SKU with a hash table that stores the names and keys for all of the known SKUs of these products. The console output displays the name of the installed SKU.
 
 ```csharp
-
 using System;
 using System.Collections;
 using Microsoft.Win32;
 
-
 namespace GetInstalledSharePointSku
 {
-    class Program
+  class Program
+  {
+    internal static Hashtable _products;
+
+    public static Hashtable SharePointProducts
     {
-        internal static Hashtable _products;
-
-        public static Hashtable SharePointProducts
+      get
+      {
+        if (_products == null)
         {
-            get 
-            {
-                if (_products == null)
-                {
-                    _products = new Hashtable();
+          _products = new Hashtable();
 
-                    _products.Add("35466B1A-B17B-4DFB-A703-F74E2A1F5F5E", "Project Server 2013");
-                    _products.Add("BC7BAF08-4D97-462C-8411-341052402E71", " Project Server 2013 Preview");
+          _products.Add("35466B1A-B17B-4DFB-A703-F74E2A1F5F5E", "Project Server 2013");
+          _products.Add("BC7BAF08-4D97-462C-8411-341052402E71", "Project Server 2013 Preview");
 
-                    _products.Add("C5D855EE-F32B-4A1C-97A8-F0A28CE02F9C", "SharePoint");
-                    _products.Add("CBF97833-C73A-4BAF-9ED3-D47B3CFF51BE", "SharePoint Preview");
-                    _products.Add("B7D84C2B-0754-49E4-B7BE-7EE321DCE0A9", "SharePoint Enterprise");
-                    _products.Add("298A586A-E3C1-42F0-AFE0-4BCFDC2E7CD0", "SharePoint Enterprise Preview");
+          _products.Add("C5D855EE-F32B-4A1C-97A8-F0A28CE02F9C", "SharePoint");
+          _products.Add("CBF97833-C73A-4BAF-9ED3-D47B3CFF51BE", "SharePoint Preview");
+          _products.Add("B7D84C2B-0754-49E4-B7BE-7EE321DCE0A9", "SharePoint Enterprise");
+          _products.Add("298A586A-E3C1-42F0-AFE0-4BCFDC2E7CD0", "SharePoint Enterprise Preview");
 
-                    _products.Add("D6B57A0D-AE69-4A3E-B031-1F993EE52EDC ", "Microsoft Office Online");
-                    _products.Add("9FF54EBC-8C12-47D7-854F-3865D4BE8118", "SharePoint Foundation 2013");
-                }
-                
-                return _products;
-            }
+          _products.Add("D6B57A0D-AE69-4A3E-B031-1F993EE52EDC", "Microsoft Office Online");
+          _products.Add("9FF54EBC-8C12-47D7-854F-3865D4BE8118", "SharePoint Foundation 2013");
         }
 
-        private const String SharePointProductsRegistryPath = @"SOFTWARE\\Microsoft\\Shared Tools\\Web Server Extensions\\15.0\\WSS\\InstalledProducts\\";
+        return _products;
+      }
+    }
 
-        static void Main(string[] args)
+    private const String SharePointProductsRegistryPath = @"SOFTWARE\\Microsoft\\Shared Tools\\Web Server Extensions\\15.0\\WSS\\InstalledProducts\\";
+
+    static void Main(string[] args)
+    {
+      try
+      {
+        //Open the registry key in read-only mode.
+        using (RegistryKey key = Registry.LocalMachine.OpenSubKey(SharePointProductsRegistryPath, false))
         {
+          //Get all of the installed product code/SKUId pairs.
+          foreach (String value in key.GetValueNames())
+          {
             try
             {
-                //Open the registry key in read-only mode.
-                using (RegistryKey key = Registry.LocalMachine.OpenSubKey(SharePointProductsRegistryPath, false))
-                {
-                    //Get all of the installed product code/SKUId pairs.
-                    foreach (String value in key.GetValueNames())
-                    {
-                        try
-                        {
-                            //Get the SKUId and see whether it is a known product.
-                            String SKUId = key.GetValue(value) as String;
+              //Get the SKUId and see whether it is a known product.
+              String SKUId = key.GetValue(value) as String;
 
-                            if (SharePointProducts[SKUId] != null)
-                            {
-                                Console.WriteLine("Product Installed: {0}", SharePointProducts[SKUId]);
-                            }
-                            else
-                            {
-                                Console.WriteLine("Unknown Product: {0}", SKUId);
-                            }
-                        }
-                        catch (Exception e)
-                        {
-                            Console.WriteLine("Could not read key exception was {0}", e.Message);
-                        }
-                    }
-                }
+              if (SharePointProducts[SKUId] != null)
+              {
+                Console.WriteLine("Product Installed: {0}", SharePointProducts[SKUId]);
+              }
+              else
+              {
+                Console.WriteLine("Unknown Product: {0}", SKUId);
+              }
             }
             catch (Exception e)
             {
-                Console.WriteLine("Could not open key exception was {0}", e.Message);
+              Console.WriteLine("Could not read key exception was {0}", e.Message);
             }
-            Console.Read();
+          }
         }
+      }
+      catch (Exception e)
+      {
+        Console.WriteLine("Could not open key exception was {0}", e.Message);
+      }
+      Console.Read();
     }
+  }
 }
 ```

--- a/docs/general-development/how-to-detect-the-installed-sku-of-sharepoint.md
+++ b/docs/general-development/how-to-detect-the-installed-sku-of-sharepoint.md
@@ -9,15 +9,14 @@ ms.localizationpriority: medium
 
 # Detect the installed SKU of SharePoint
 
+> [!NOTE]
+> This article applies only to SharePoint Server 2013 and related Office Server products that use the 15.0 registry hive.
+
 If the behavior of your solutions depends on the locally installed SKU of SharePoint or Project Server 2013, use the code example in this article to find the SKU information you need.
 
 ## Detect the installed SKU of SharePoint or Project Server 2013 by using code
-<a name="SP15DetectSKU_detect"> </a>
 
 The following code example demonstrates how to retrieve the registry key of the installed SKU of SharePoint, Microsoft Project Server 2013, and other Office server products, and how to match the SKU with a hash table that stores the names and keys for all of the known SKUs of these products. The console output displays the name of the installed SKU.
-  
-    
-    
 
 ```csharp
 

--- a/docs/general-development/how-to-enable-udfs.md
+++ b/docs/general-development/how-to-enable-udfs.md
@@ -1,7 +1,7 @@
 ---
 title: Enable UDFs
 description: "Each Excel Services trusted location in the Shared Services Provider (SSP) has an AllowUdfs flag."
-ms.date: 09/25/2017
+ms.date: 04/24/2017
 keywords: how to,howdoi,howto,UDF list
 f1_keywords:
 - how to,howdoi,howto,UDF list
@@ -9,17 +9,16 @@ ms.assetid: 8c1af2eb-bb22-45e1-82de-a2b4b53d7a26
 ms.localizationpriority: medium
 ---
 
-
 # Enable UDFs
 
 Each Excel Services trusted location in the Shared Services Provider (SSP) has an **AllowUdfs** flag.
-  
+
 > [!NOTE]
 > The **AllowUdfs** flag is denoted by the **User-defined functions allowed** option on the Excel Services Trusted File Locations page.
 
-The default **AllowUdfs** value is **false**. If the **AllowUdfs** value is set to **false** in a particular trusted location, the workbooks in that trusted location are not allowed to call UDFs.
+The default **AllowUdfs** value is **false**. If the **AllowUdfs** value is set to **false** in a particular trusted location, the workbooks in that trusted location aren't allowed to call UDFs.
 
-In order to allow UDFs to be called from a specific trusted location, you set the **AllowUdfs** value to **true**.If the **AllowUdfs** value is **false** when a session is started on a workbook that has UDF calls in this trusted location, the UDF calls will fail. If you change the **AllowUdfs** value to **true** after a session has started, the UDF calls will also fail. This is because changes in the **AllowUdfs** flag take effect on the next session, after the configuration database has been updated.You can get around this by restarting the session—for example, by selecting **Reload Workbook** in Excel Web Access.
+In order to allow UDFs to be called from a specific trusted location, you set the **AllowUdfs** value to **true**.If the **AllowUdfs** value is **false** when a session is started on a workbook that has UDF calls in this trusted location, the UDF calls will fail. If you change the **AllowUdfs** value to **true** after a session has started, the UDF calls will also fail. This is because changes in the **AllowUdfs** flag take effect on the next session, after the configuration database has been updated. You can get around this by restarting the session—for example, by selecting **Reload Workbook** in Excel Web Access.
 > [!CAUTION]
 > If you choose to reset Microsoft Internet Information Services (IIS) instead, it will end all current sessions.
 
@@ -29,31 +28,31 @@ To do the following steps, you need a computer that has Microsoft SharePoint Ser
 
 ### To enable UDFs
 
-1. On the **Start** menu, click **All Programs**.
-2. Point to **Microsoft Office Server** and click **SharePoint Central Administration**.
-3. On the Quick Launch, click your Shared Services Provider (SSP) link—for example, "SharedServices1"—to view the Shared Services home page for that particular SSP.
-4. Under **Excel Services Settings**, click **User-defined functions**.
-5. On the Excel Services User-Defined Functions page, click **Add User-Defined Function** to open the Excel Services Add User-Defined Function Assembly page.
-6. In the **Assembly** box, type the path to the UDF assembly. For example, C:\\MyUdfFolder\\MyUdf.dll.
-7. Under **Assembly Location**, click **Local file**.
+1. On the **Start** menu, select **All Programs**.
+1. Point to **Microsoft Office Server** and select **SharePoint Central Administration**.
+1. On the Quick Launch, select your Shared Services Provider (SSP) link—for example, "SharedServices1"—to view the Shared Services home page for that particular SSP.
+1. Under **Excel Services Settings**, select **User-defined functions**.
+1. On the Excel Services User-Defined Functions page, select **Add User-Defined Function** to open the Excel Services Add User-Defined Function Assembly page.
+1. In the **Assembly** box, type the path to the UDF assembly. For example, C:\\MyUdfFolder\\MyUdf.dll.
+1. Under **Assembly Location**, select **Local file**.
 
     > [!NOTE]
     > The **Local file** option will be replaced with **File path** in future releases of Excel Services. If you see **File path**, select that instead.
 
-8. Under **Enable Assembly**, the **Assembly enabled** check box should be selected by default.
-9. Click **OK**.
+1. Under **Enable Assembly**, the **Assembly enabled** check box should be selected by default.
+1. Select **OK**.
 
 ## Allowing UDF Calls
 
 ### To allow UDFs to be called from a workbook
 
-1. Open the Excel Services Add Trusted File Location page (if you are adding a new trusted location) or Excel Services Edit Trusted File Location page (if you are editing an existing trusted location).
+1. Open the Excel Services Add Trusted File Location page (if you're adding a new trusted location) or Excel Services Edit Trusted File Location page (if you're editing an existing trusted location).
 
     > [!NOTE]
     > For more information about trusting a location, see [How to: Trust a Location](how-to-trust-a-location.md).
 
-2. Under **Allow User-Defined Functions**, select **User-defined functions allowed** to allow UDFs to be called from workbooks stored in this trusted location.
-3. Click **OK**.
+1. Under **Allow User-Defined Functions**, select **User-defined functions allowed** to allow UDFs to be called from workbooks stored in this trusted location.
+1. Select **OK**.
 
 ## See also
 

--- a/docs/general-development/how-to-enable-udfs.md
+++ b/docs/general-development/how-to-enable-udfs.md
@@ -16,81 +16,44 @@ Each Excel Services trusted location in the Shared Services Provider (SSP) has a
   
 > [!NOTE]
 > The **AllowUdfs** flag is denoted by the **User-defined functions allowed** option on the Excel Services Trusted File Locations page.
-  
-    
-    
-
 
 The default **AllowUdfs** value is **false**. If the **AllowUdfs** value is set to **false** in a particular trusted location, the workbooks in that trusted location are not allowed to call UDFs.
-  
-    
-    
 
 In order to allow UDFs to be called from a specific trusted location, you set the **AllowUdfs** value to **true**.If the **AllowUdfs** value is **false** when a session is started on a workbook that has UDF calls in this trusted location, the UDF calls will fail. If you change the **AllowUdfs** value to **true** after a session has started, the UDF calls will also fail. This is because changes in the **AllowUdfs** flag take effect on the next session, after the configuration database has been updated.You can get around this by restarting the session—for example, by selecting **Reload Workbook** in Excel Web Access.
-> **Caution:**
-> If you choose to reset Microsoft Internet Information Services (IIS) instead, it will end all current sessions. 
-  
-    
-    
-
+> [!CAUTION]
+> If you choose to reset Microsoft Internet Information Services (IIS) instead, it will end all current sessions.
 
 ## Enabling UDFs
 
 To do the following steps, you need a computer that has Microsoft SharePoint Server 2010 installed.
-  
-    
-    
 
 ### To enable UDFs
 
-
-1. On the **Start** menu, click **All Programs**. 
-    
-  
-2. Point to **Microsoft Office Server** and click **SharePoint Central Administration**. 
-    
-  
+1. On the **Start** menu, click **All Programs**.
+2. Point to **Microsoft Office Server** and click **SharePoint Central Administration**.
 3. On the Quick Launch, click your Shared Services Provider (SSP) link—for example, "SharedServices1"—to view the Shared Services home page for that particular SSP.
-    
-  
-4. Under **Excel Services Settings**, click **User-defined functions**. 
-    
-  
+4. Under **Excel Services Settings**, click **User-defined functions**.
 5. On the Excel Services User-Defined Functions page, click **Add User-Defined Function** to open the Excel Services Add User-Defined Function Assembly page.
-    
-  
-6. In the **Assembly** box, type the path to the UDF assembly. For example,C:\\MyUdfFolder\\MyUdf.dll.
-    
-  
+6. In the **Assembly** box, type the path to the UDF assembly. For example, C:\\MyUdfFolder\\MyUdf.dll.
 7. Under **Assembly Location**, click **Local file**.
-    
+
     > [!NOTE]
-  > The **Local file** option will be replaced with **File path** in future releases of Excel Services. If you see **File path**, select that instead.   
-  
+    > The **Local file** option will be replaced with **File path** in future releases of Excel Services. If you see **File path**, select that instead.
+
 8. Under **Enable Assembly**, the **Assembly enabled** check box should be selected by default.
-    
-  
 9. Click **OK**.
-    
-  
 
 ## Allowing UDF Calls
 
-
 ### To allow UDFs to be called from a workbook
 
+1. Open the Excel Services Add Trusted File Location page (if you are adding a new trusted location) or Excel Services Edit Trusted File Location page (if you are editing an existing trusted location).
 
-1. Open the Excel Services Add Trusted File Location page (if you are adding a new trusted location) or Excel Services Edit Trusted File Location page (if you are editing an existing trusted location). 
-    
     > [!NOTE]
-    > For more information about trusting a location, see  [How to: Trust a Location](how-to-trust-a-location.md). 
+    > For more information about trusting a location, see [How to: Trust a Location](how-to-trust-a-location.md).
 
 2. Under **Allow User-Defined Functions**, select **User-defined functions allowed** to allow UDFs to be called from workbooks stored in this trusted location.
-    
-  
 3. Click **OK**.
-    
-  
 
 ## See also
 

--- a/docs/general-development/how-to-refresh-data.md
+++ b/docs/general-development/how-to-refresh-data.md
@@ -13,24 +13,18 @@ ms.localizationpriority: medium
 # Refresh data
 
 This example shows how to retrieve updated data from external data sources for the open workbook by using the **Refresh** method. The Excel Web Services signature for the **Refresh** method is as follows:
-  
-    
-    
-
 
 ```csharp
 
 public Status[] Refresh (string sessionId, string connectionName)
 ```
 
-
-```VB.net
+```vb
 Public Function Refresh(ByVal sessionId As String, ByVal connectionName As String) As Status()
 End Function
 ```
 
 If you link directly to Microsoft.Office.Excel.Server.WebServices.dll, the signature for the **Refresh** method is:
-
 
 ```csharp
 
@@ -38,22 +32,16 @@ public void Refresh (string sessionId, string connectionName,
     out Status[] status)
 ```
 
-
-
-
-```VB.net
+```vb
 
 Public Sub Refresh(ByVal sessionId As String, ByVal connectionName As String, <System.Runtime.InteropServices.Out()> ByRef status() As Status)
 End Sub
 ```
 
-The  `connectionName` argument refers to the connection name in a Microsoft Office Excel 2007 workbook.You can use the **Refresh** method to refresh a single data connection in the workbook, or to refresh all connections. This is useful particularly when the connections are created without refresh-on-open functionality.When you refresh a connection, the data and all objects using the connection will be refreshed. To refresh all available connections in the workbook, you pass in an empty connection string or **null** for the connection name argument.The refresh operations will be attempted regardless of the type of authentication used, without any further confirmation or prompt.For more information about the **Refresh** method, see the Excel Web Services reference documentation.
+The `connectionName` argument refers to the connection name in a Microsoft Excel workbook.You can use the **Refresh** method to refresh a single data connection in the workbook, or to refresh all connections. This is useful particularly when the connections are created without refresh-on-open functionality.When you refresh a connection, the data and all objects using the connection will be refreshed. To refresh all available connections in the workbook, you pass in an empty connection string or **null** for the connection name argument.The refresh operations will be attempted regardless of the type of authentication used, without any further confirmation or prompt.For more information about the **Refresh** method, see the Excel Web Services reference documentation.
 ## Example
 
 The following code sample shows how to call the **Refresh** method using Excel Web Services. The connection name in this example is "MyInventoryConnection":
-  
-    
-    
 
 ```csharp
 
@@ -68,7 +56,7 @@ string sheetName = "Sheet3";
 // to point to a workbook you have access to.
 // The workbook must be in a trusted location.
 string targetWorkbookPath = 
-    http://myserver02/example/Shared%20Documents/Book1.xlsx";
+    "https://myserver02/example/Shared%20Documents/Book1.xlsx";
             
 // Set credentials for requests.
 xlservice.Credentials = System.Net.CredentialCache.DefaultCredentials;
@@ -90,7 +78,7 @@ xlservice.Refresh(sessionId, "MyInventoryConnection");
 ```
 
 
-```VB.net
+```vb
 
 ' Instantiate the Web service.
 Dim xlservice As New ExcelService()
@@ -102,8 +90,10 @@ Dim sheetName As String = "Sheet3"
 ' TODO: Change the path to the workbook
 ' to point to a workbook you have access to.
 ' The workbook must be in a trusted location.
+Dim targetWorkbookPath As String = "https://myserver02/example/Shared%20Documents/Book1.xlsx"
+
 ' Set credentials for requests.
-Dim targetWorkbookPath As String = http: xlservice.Credentials = System.Net.CredentialCache.DefaultCredentials 'myserver02/example/Shared%20Documents/Book1.xlsx";
+xlservice.Credentials = System.Net.CredentialCache.DefaultCredentials
 
 ' Call open workbook, and point to the trusted   
 ' location of the workbook to open.
@@ -122,13 +112,8 @@ xlservice.Refresh(sessionId, "MyInventoryConnection")
 ```
 
 If you link directly to Microsoft.Office.Excel.Server.WebServices.dll, the equivalent code is:
-  
-    
-    
 
-
-
-```
+```csharp
 
 // Instantiate the ExcelService class.
 ExcelService xlservice = new ExcelService();
@@ -141,7 +126,7 @@ string sheetName = "Sheet3";
 // to point to a workbook you have access to.
 // The workbook must be in a trusted location.
 string targetWorkbookPath = 
-    http://myserver02/example/Shared%20Documents/Book1.xlsx";
+    "https://myserver02/example/Shared%20Documents/Book1.xlsx";
             
 // Call the open workbook, and point to the trusted 
 // location of the workbook to open.
@@ -168,7 +153,7 @@ binaryWriter.Close();
 
 
 
-```VB.net
+```vb
 
 ' Instantiate the ExcelService class.
 Dim xlservice As New ExcelService()
@@ -180,9 +165,11 @@ Dim sheetName As String = "Sheet3"
 ' TODO: Change the path to the workbook
 ' to point to a workbook you have access to.
 ' The workbook must be in a trusted location.
+Dim targetWorkbookPath As String = "https://myserver02/example/Shared%20Documents/Book1.xlsx"
+
 ' Call the open workbook, and point to the trusted 
 ' location of the workbook to open.
-Dim targetWorkbookPath As String = http: String sessionId = xlservice.OpenWorkbook(targetWorkbookPath, "en-US", "en-US", outStatus) 'myserver02/example/Shared%20Documents/Book1.xlsx";
+Dim sessionId As String = xlservice.OpenWorkbook(targetWorkbookPath, "en-US", "en-US", outStatus)
 
 ' Set the cell located in the first row and 
 ' ninth column to 300.
@@ -204,45 +191,11 @@ binaryWriter.Close()
 
 ## See also
 
-
-#### Tasks
-
-
-  
-    
-    
- [How to: Trust a Location](how-to-trust-a-location.md)
-  
-    
-    
- [How to: Save from Excel Client to the Server](how-to-save-from-excel-client-to-the-server.md)
-  
-    
-    
- [How to: Get an Entire Workbook or a Snapshot](how-to-get-an-entire-workbook-or-a-snapshot.md)
-#### Concepts
-
-
-  
-    
-    
- [Accessing the SOAP API](accessing-the-soap-api.md)
-  
-    
-    
- [Excel Services Alerts](excel-services-alerts.md)
-  
-    
-    
- [Excel Services Known Issues and Tips](excel-services-known-issues-and-tips.md)
-  
-    
-    
- [Loop-Back SOAP Calls and Direct Linking](loop-back-soap-calls-and-direct-linking.md)
-#### Other resources
-
-
-  
-    
-    
- [Walkthrough: Developing a Custom Application Using Excel Web Services](walkthrough-developing-a-custom-application-using-excel-web-services.md)
+- [How to: Trust a Location](how-to-trust-a-location.md)
+- [How to: Save from Excel Client to the Server](how-to-save-from-excel-client-to-the-server.md)
+- [How to: Get an Entire Workbook or a Snapshot](how-to-get-an-entire-workbook-or-a-snapshot.md)
+- [Accessing the SOAP API](accessing-the-soap-api.md)
+- [Excel Services Alerts](excel-services-alerts.md)
+- [Excel Services Known Issues and Tips](excel-services-known-issues-and-tips.md)
+- [Loop-Back SOAP Calls and Direct Linking](loop-back-soap-calls-and-direct-linking.md)
+- [Walkthrough: Developing a Custom Application Using Excel Web Services](walkthrough-developing-a-custom-application-using-excel-web-services.md)

--- a/docs/general-development/how-to-refresh-data.md
+++ b/docs/general-development/how-to-refresh-data.md
@@ -1,7 +1,7 @@
 ---
 title: Refresh data
 description: This example shows how to retrieve updated data from external data sources for the open workbook by using the Refresh method.
-ms.date: 09/25/2017
+ms.date: 04/24/2017
 keywords: how to,howdoi,howto
 f1_keywords:
 - how to,howdoi,howto
@@ -9,13 +9,11 @@ ms.assetid: 6cfd89ff-846e-486b-8f73-a109016813ab
 ms.localizationpriority: medium
 ---
 
-
 # Refresh data
 
 This example shows how to retrieve updated data from external data sources for the open workbook by using the **Refresh** method. The Excel Web Services signature for the **Refresh** method is as follows:
 
 ```csharp
-
 public Status[] Refresh (string sessionId, string connectionName)
 ```
 
@@ -27,24 +25,22 @@ End Function
 If you link directly to Microsoft.Office.Excel.Server.WebServices.dll, the signature for the **Refresh** method is:
 
 ```csharp
-
-public void Refresh (string sessionId, string connectionName,
-    out Status[] status)
+public void Refresh (string sessionId,
+                     string connectionName,
+                     out Status[] status)
 ```
 
 ```vb
-
 Public Sub Refresh(ByVal sessionId As String, ByVal connectionName As String, <System.Runtime.InteropServices.Out()> ByRef status() As Status)
 End Sub
 ```
 
-The `connectionName` argument refers to the connection name in a Microsoft Excel workbook.You can use the **Refresh** method to refresh a single data connection in the workbook, or to refresh all connections. This is useful particularly when the connections are created without refresh-on-open functionality.When you refresh a connection, the data and all objects using the connection will be refreshed. To refresh all available connections in the workbook, you pass in an empty connection string or **null** for the connection name argument.The refresh operations will be attempted regardless of the type of authentication used, without any further confirmation or prompt.For more information about the **Refresh** method, see the Excel Web Services reference documentation.
+The `connectionName` argument refers to the connection name in a Microsoft Excel workbook. You can use the **Refresh** method to refresh a single data connection in the workbook, or to refresh all connections. This is useful particularly when the connections are created without refresh-on-open functionality. When you refresh a connection, the data and all objects using the connection will be refreshed. To refresh all available connections in the workbook, you pass in an empty connection string or **null** for the connection name argument. The refresh operations will be attempted regardless of the type of authentication used, without any further confirmation or prompt. For more information about the **Refresh** method, see the Excel Web Services reference documentation.
 ## Example
 
 The following code sample shows how to call the **Refresh** method using Excel Web Services. The connection name in this example is "MyInventoryConnection":
 
 ```csharp
-
 // Instantiate the Web service.
 ExcelService xlservice = new ExcelService();
 Status[] outStatus;
@@ -55,31 +51,28 @@ string sheetName = "Sheet3";
 // TODO: Change the path to the workbook
 // to point to a workbook you have access to.
 // The workbook must be in a trusted location.
-string targetWorkbookPath = 
-    "https://myserver02/example/Shared%20Documents/Book1.xlsx";
-            
+string targetWorkbookPath = "https://myserver02/example/Shared%20Documents/Book1.xlsx";
+
 // Set credentials for requests.
 xlservice.Credentials = System.Net.CredentialCache.DefaultCredentials;
 
-// Call open workbook, and point to the trusted   
+// Call open workbook, and point to the trusted
 // location of the workbook to open.
 string sessionId = xlservice.OpenWorkbook(targetWorkbookPath, "en-US", "en-US", out outStatus);
- 
+
 // Prepare object to define range coordinates.
 rangeCoordinates.Column = 0;
 rangeCoordinates.Row = 0;
 rangeCoordinates.Height = 8;
 rangeCoordinates.Width = 10;
 
-// Set the cell located in the first row and 
+// Set the cell located in the first row and
 // ninth column to 300.
-xlservice.SetCell(sessionId, sheetName, 0, 8, 300); 
+xlservice.SetCell(sessionId, sheetName, 0, 8, 300);
 xlservice.Refresh(sessionId, "MyInventoryConnection");
 ```
 
-
 ```vb
-
 ' Instantiate the Web service.
 Dim xlservice As New ExcelService()
 Dim outStatus() As Status
@@ -95,7 +88,7 @@ Dim targetWorkbookPath As String = "https://myserver02/example/Shared%20Document
 ' Set credentials for requests.
 xlservice.Credentials = System.Net.CredentialCache.DefaultCredentials
 
-' Call open workbook, and point to the trusted   
+' Call open workbook, and point to the trusted
 ' location of the workbook to open.
 Dim sessionId As String = xlservice.OpenWorkbook(targetWorkbookPath, "en-US", "en-US", outStatus)
 
@@ -105,7 +98,7 @@ rangeCoordinates.Row = 0
 rangeCoordinates.Height = 8
 rangeCoordinates.Width = 10
 
-' Set the cell located in the first row and 
+' Set the cell located in the first row and
 ' ninth column to 300.
 xlservice.SetCell(sessionId, sheetName, 0, 8, 300)
 xlservice.Refresh(sessionId, "MyInventoryConnection")
@@ -114,7 +107,6 @@ xlservice.Refresh(sessionId, "MyInventoryConnection")
 If you link directly to Microsoft.Office.Excel.Server.WebServices.dll, the equivalent code is:
 
 ```csharp
-
 // Instantiate the ExcelService class.
 ExcelService xlservice = new ExcelService();
 Status[] outStatus;
@@ -125,36 +117,28 @@ string sheetName = "Sheet3";
 // TODO: Change the path to the workbook
 // to point to a workbook you have access to.
 // The workbook must be in a trusted location.
-string targetWorkbookPath = 
-    "https://myserver02/example/Shared%20Documents/Book1.xlsx";
-            
-// Call the open workbook, and point to the trusted 
+string targetWorkbookPath = "https://myserver02/example/Shared%20Documents/Book1.xlsx";
+
+// Call the open workbook, and point to the trusted
 // location of the workbook to open.
 string sessionId = xlservice.OpenWorkbook(targetWorkbookPath, "en-US", "en-US", out outStatus);
-                
-// Set the cell located in the first row and 
+
+// Set the cell located in the first row and
 // ninth column to 300.
-xlservice.SetCell(sessionId, sheetName, 0, 8, 300, out outStatus); 
+xlservice.SetCell(sessionId, sheetName, 0, 8, 300, out outStatus);
 xlservice.Refresh(sessionId, "MyInventoryConnection", out outStatus);
 
 byte[] workbook = xlService.GetWorkbook(sessionId, WorkbookType.FullWorkbook, out status);
 
-// Write the resulting Excel file to stdout 
+// Write the resulting Excel file to stdout
 // as a binary stream.
-BinaryWriter binaryWriter = 
-    new BinaryWriter(Console.OpenStandardOutput());
+BinaryWriter binaryWriter = new BinaryWriter(Console.OpenStandardOutput());
 binaryWriter.Write(workbook);
 binaryWriter.Close();
 ...
-...
-
 ```
 
-
-
-
 ```vb
-
 ' Instantiate the ExcelService class.
 Dim xlservice As New ExcelService()
 Dim outStatus() As Status
@@ -167,27 +151,24 @@ Dim sheetName As String = "Sheet3"
 ' The workbook must be in a trusted location.
 Dim targetWorkbookPath As String = "https://myserver02/example/Shared%20Documents/Book1.xlsx"
 
-' Call the open workbook, and point to the trusted 
+' Call the open workbook, and point to the trusted
 ' location of the workbook to open.
 Dim sessionId As String = xlservice.OpenWorkbook(targetWorkbookPath, "en-US", "en-US", outStatus)
 
-' Set the cell located in the first row and 
+' Set the cell located in the first row and
 ' ninth column to 300.
 xlservice.SetCell(sessionId, sheetName, 0, 8, 300, outStatus)
 xlservice.Refresh(sessionId, "MyInventoryConnection", outStatus)
 
 Dim workbook() As Byte = xlService.GetWorkbook(sessionId, WorkbookType.FullWorkbook, status)
 
-' Write the resulting Excel file to stdout 
+' Write the resulting Excel file to stdout
 ' as a binary stream.
 Dim binaryWriter As New BinaryWriter(Console.OpenStandardOutput())
 binaryWriter.Write(workbook)
 binaryWriter.Close()
 ...
-...
-
 ```
-
 
 ## See also
 

--- a/docs/general-development/how-to-retrieve-the-url-of-a-pages-library.md
+++ b/docs/general-development/how-to-retrieve-the-url-of-a-pages-library.md
@@ -1,11 +1,10 @@
 ---
 title: Retrieve the URL of a Pages library
 description: Learn how to retrieve the URL for the pages list for a publishing web in a site collection that differs from the current context.
-ms.date: 09/25/2017
+ms.date: 04/24/2017
 ms.assetid: d9922e4b-4948-4c4a-a8ca-1623168143a3
 ms.localizationpriority: medium
 ---
-
 
 # Retrieve the URL of a Pages library
 
@@ -13,39 +12,34 @@ Learn how to retrieve the URL for the pages list for a publishing web in a site 
 
 ## Core concepts to know for retrieving the URL of a Pages list
 
-When developing custom applications for publishing sites, you may notice that the [PublishingWeb](/previous-versions/office/sharepoint-server/ms562424(v=office.15)) object model does not expose a way to retrieve the URL for the Pages list of a publishing web in a site collection that differs from the current context. Although the **PublishingWeb** class wraps the [SPWeb](/previous-versions/office/sharepoint-server/ms473942(v=office.15)) class for instances that have the publishing feature activated, the class is not intended to be used to instantiate **SPWeb** objects outside of the current context.
+When developing custom applications for publishing sites, you may notice that the [PublishingWeb](/previous-versions/office/sharepoint-server/ms562424(v=office.15)) object model doesn't expose a way to retrieve the URL for the Pages list of a publishing web in a site collection that differs from the current context. Although the **PublishingWeb** class wraps the [SPWeb](/previous-versions/office/sharepoint-server/ms473942(v=office.15)) class for instances that have the publishing feature activated, the class isn't intended to be used to instantiate **SPWeb** objects outside of the current context.
 
 If you need to retrieve the URL for the Pages list for a different web application, you can query the [Properties](/previous-versions/office/sharepoint-server/ms416105(v=office.15)) property. Since the [PublishingWeb](/previous-versions/office/sharepoint-server/ms562424(v=office.15)) object is the [SPWeb](/previous-versions/office/sharepoint-server/ms473942(v=office.15)) object of a publishing site, you can query the [Properties](/previous-versions/office/sharepoint-server/ms416105(v=office.15)) property and write its contents to a console application. If the entry `Key = vti_pageslistname, Value = {the URL to the Pages library}` is returned in the console, *{the URL to the Pages library}* is the Pages list URL.
 
 **Table 1. Core concepts for retrieving the URL of a Pages library**
 
-
 |**Article title**|**Description**|
 |:-----|:-----|
-|Pages Library  <br/> |A document library that contains all the content pages for a publishing site.  <br/> |
-| [SPWeb](/previous-versions/office/sharepoint-server/ms473942(v=office.15)) <br/> |Represents a SharePoint Foundation website.  <br/> |
-| [Properties](/previous-versions/office/sharepoint-server/ms416105(v=office.15)) <br/> |Gets a [SPPropertyBag](/previous-versions/office/sharepoint-server/ms413646(v=office.15)) object with metadata for the current website. <br/> |
-| [SPPropertyBag](/previous-versions/office/sharepoint-server/ms413646(v=office.15)) <br/> |Stores arbitrary key and value pairs that contain custom property settings.  <br/> |
-| [PublishingWeb](/previous-versions/office/sharepoint-server/ms562424(v=office.15)) <br/> |Provides publishing behavior for an instance of **SPWeb** that supports publishing. <br/> |
-   
+|Pages Library  |A document library that contains all the content pages for a publishing site.  |
+| [SPWeb](/previous-versions/office/sharepoint-server/ms473942(v=office.15)) |Represents a SharePoint Foundation website.  |
+| [Properties](/previous-versions/office/sharepoint-server/ms416105(v=office.15)) |Gets a [SPPropertyBag](/previous-versions/office/sharepoint-server/ms413646(v=office.15)) object with metadata for the current website. |
+| [SPPropertyBag](/previous-versions/office/sharepoint-server/ms413646(v=office.15)) |Stores arbitrary key and value pairs that contain custom property settings.  |
+| [PublishingWeb](/previous-versions/office/sharepoint-server/ms562424(v=office.15)) |Provides publishing behavior for an instance of **SPWeb** that supports publishing. |
 
 ## Retrieve the URL of a Pages list for a publishing web in a site collection that differs from the current context
-
 
 This example console application accesses the [Properties](/previous-versions/office/sharepoint-server/ms416105(v=office.15)) property, iterates through the collection, and writes each key/value pair to the console.
 
 ### To query the SPWeb.Properties property for the URL to the Pages list
 
-
 1. Write the console application.
-2. View the output in the console.
+1. View the output in the console.
 
 ## Example: Query SPWeb.Properties property for the URL to the Pages list
 
 The application queries the [SPPropertyBag](/previous-versions/office/sharepoint-server/ms413646(v=office.15)) object, iterates through its dictionary entries, and writes those entries to the console.
 
 ```csharp
-
 using System;
 using System.Collections;
 using Microsoft.SharePoint;
@@ -53,32 +47,30 @@ using Microsoft.SharePoint.Utilities;
 
 namespace Test
 {
-    class Program
+  class Program
+  {
+    static void Main(string[] args)
     {
-        static void Main(string[] args)
+      using (SPSite site = new SPSite("http://localhost"))
+      {
+        using (SPWeb web = site.OpenWeb())
         {
-            using (SPSite site = new SPSite("http://localhost"))
-            {
-                using (SPWeb web = site.OpenWeb())
-                {
-                    SPPropertyBag props = web.Properties;
-                    foreach (DictionaryEntry de in props)
-                    {
-                        Console.WriteLine("Key = {0}, Value = {1}", de.Key, de.Value);
-                    }
-                }
-            }
-            Console.ReadLine();
+          SPPropertyBag props = web.Properties;
+          foreach (DictionaryEntry de in props)
+          {
+            Console.WriteLine("Key = {0}, Value = {1}", de.Key, de.Value);
+          }
         }
+      }
+      Console.ReadLine();
     }
+  }
 }
-
 ```
 
 The output that this application prints to the console varies from website to website, but it might look like the following:
 
 ```text
-
 Key = vti_associatemembergroup, Value = 5
 Key = vti_extenderversion, Value = 14.0.0.4016
 Key = vti_associatevisitorgroup, Value = 4
@@ -91,8 +83,6 @@ Key = vti_defaultlanguage, Value = en-us
 Key = vti_pageslistname, Value = {the URL to the Pages list}
 ```
 
-
 ## See also
 
 - [Build sites for SharePoint](build-sites-for-sharepoint.md)
-

--- a/docs/general-development/how-to-retrieve-the-url-of-a-pages-library.md
+++ b/docs/general-development/how-to-retrieve-the-url-of-a-pages-library.md
@@ -12,16 +12,10 @@ ms.localizationpriority: medium
 Learn how to retrieve the URL for the pages list for a publishing web in a site collection that differs from the current context.
 
 ## Core concepts to know for retrieving the URL of a Pages list
-<a name="SP15_Core_Concepts_URL_MP"> </a>
 
-When developing custom applications for publishing sites, you may notice that the  [PublishingWeb](https://msdn.microsoft.com/library/Microsoft.SharePoint.Publishing.PublishingWeb.aspx) object model does not expose a way to retrieve the URL for the Pages list of a publishing web in a site collection that differs from the current context. Although the **PublishingWeb** class wraps the [SPWeb](https://msdn.microsoft.com/library/Microsoft.SharePoint.SPWeb.aspx) class for instances that have the publishing feature activated, the class is not intended to be used to instantiate **SPWeb** objects outside of the current context.
-  
-    
-    
-If you need to retrieve the URL for the Pages list for a different web application, you can query the  [Properties](https://msdn.microsoft.com/library/Microsoft.SharePoint.SPWeb.Properties.aspx) property. Since the [PublishingWeb](https://msdn.microsoft.com/library/Microsoft.SharePoint.Publishing.PublishingWeb.aspx) object is the [SPWeb](https://msdn.microsoft.com/library/Microsoft.SharePoint.SPWeb.aspx) object of a publishing site, you can query the [Properties](https://msdn.microsoft.com/library/Microsoft.SharePoint.SPWeb.Properties.aspx) property and write its contents to a console application. If the entry `Key = vti_pageslistname, Value = {the URL to the Pages library}` is returned in the console, *{the URL to the Pages library}*  is the Pages list URL.
-  
-    
-    
+When developing custom applications for publishing sites, you may notice that the [PublishingWeb](/previous-versions/office/sharepoint-server/ms562424(v=office.15)) object model does not expose a way to retrieve the URL for the Pages list of a publishing web in a site collection that differs from the current context. Although the **PublishingWeb** class wraps the [SPWeb](/previous-versions/office/sharepoint-server/ms473942(v=office.15)) class for instances that have the publishing feature activated, the class is not intended to be used to instantiate **SPWeb** objects outside of the current context.
+
+If you need to retrieve the URL for the Pages list for a different web application, you can query the [Properties](/previous-versions/office/sharepoint-server/ms416105(v=office.15)) property. Since the [PublishingWeb](/previous-versions/office/sharepoint-server/ms562424(v=office.15)) object is the [SPWeb](/previous-versions/office/sharepoint-server/ms473942(v=office.15)) object of a publishing site, you can query the [Properties](/previous-versions/office/sharepoint-server/ms416105(v=office.15)) property and write its contents to a console application. If the entry `Key = vti_pageslistname, Value = {the URL to the Pages library}` is returned in the console, *{the URL to the Pages library}* is the Pages list URL.
 
 **Table 1. Core concepts for retrieving the URL of a Pages library**
 
@@ -29,37 +23,26 @@ If you need to retrieve the URL for the Pages list for a different web applicati
 |**Article title**|**Description**|
 |:-----|:-----|
 |Pages Library  <br/> |A document library that contains all the content pages for a publishing site.  <br/> |
-| [SPWeb](https://msdn.microsoft.com/library/Microsoft.SharePoint.SPWeb.aspx) <br/> |Represents a SharePoint Foundation website.  <br/> |
-| [Properties](https://msdn.microsoft.com/library/Microsoft.SharePoint.SPWeb.Properties.aspx) <br/> |Gets a  [SPPropertyBag](https://msdn.microsoft.com/library/Microsoft.SharePoint.Utilities.SPPropertyBag.aspx) object with metadata for the current website. <br/> |
-| [SPPropertyBag](https://msdn.microsoft.com/library/Microsoft.SharePoint.Utilities.SPPropertyBag.aspx) <br/> |Stores arbitrary key and value pairs that contain custom property settings.  <br/> |
-| [PublishingWeb](https://msdn.microsoft.com/library/Microsoft.SharePoint.Publishing.PublishingWeb.aspx) <br/> |Provides publishing behavior for an instance of **SPWeb** that supports publishing. <br/> |
+| [SPWeb](/previous-versions/office/sharepoint-server/ms473942(v=office.15)) <br/> |Represents a SharePoint Foundation website.  <br/> |
+| [Properties](/previous-versions/office/sharepoint-server/ms416105(v=office.15)) <br/> |Gets a [SPPropertyBag](/previous-versions/office/sharepoint-server/ms413646(v=office.15)) object with metadata for the current website. <br/> |
+| [SPPropertyBag](/previous-versions/office/sharepoint-server/ms413646(v=office.15)) <br/> |Stores arbitrary key and value pairs that contain custom property settings.  <br/> |
+| [PublishingWeb](/previous-versions/office/sharepoint-server/ms562424(v=office.15)) <br/> |Provides publishing behavior for an instance of **SPWeb** that supports publishing. <br/> |
    
 
 ## Retrieve the URL of a Pages list for a publishing web in a site collection that differs from the current context
-<a name="SP15_Code_URL_Pages_List"> </a>
 
-This example console application accesses the  [Properties](https://msdn.microsoft.com/library/Microsoft.SharePoint.SPWeb.Properties.aspx) property, iterates through the collection, and writes each key/value pair to the console.
-  
-    
-    
+
+This example console application accesses the [Properties](/previous-versions/office/sharepoint-server/ms416105(v=office.15)) property, iterates through the collection, and writes each key/value pair to the console.
 
 ### To query the SPWeb.Properties property for the URL to the Pages list
 
 
 1. Write the console application.
-    
-  
 2. View the output in the console.
-    
-  
 
 ## Example: Query SPWeb.Properties property for the URL to the Pages list
-<a name="SP15_Example_SPWeb_Properties"> </a>
 
-The application queries the  [SPPropertyBag](https://msdn.microsoft.com/library/Microsoft.SharePoint.Utilities.SPPropertyBag.aspx) object, iterates through its dictionary entries, and writes those entries to the console.
-  
-    
-    
+The application queries the [SPPropertyBag](/previous-versions/office/sharepoint-server/ms413646(v=office.15)) object, iterates through its dictionary entries, and writes those entries to the console.
 
 ```csharp
 
@@ -93,13 +76,8 @@ namespace Test
 ```
 
 The output that this application prints to the console varies from website to website, but it might look like the following:
-  
-    
-    
 
-
-
-```
+```text
 
 Key = vti_associatemembergroup, Value = 5
 Key = vti_extenderversion, Value = 14.0.0.4016
@@ -115,10 +93,6 @@ Key = vti_pageslistname, Value = {the URL to the Pages list}
 
 
 ## See also
-<a name="bk_addresources"> </a>
 
-
--  [Build sites for SharePoint](build-sites-for-sharepoint.md)
-    
-  
+- [Build sites for SharePoint](build-sites-for-sharepoint.md)
 

--- a/docs/general-development/how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md
+++ b/docs/general-development/how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md
@@ -1,11 +1,10 @@
 ---
 title: Retrieve user profile properties by using the JavaScript object model in SharePoint
 description: Learn how to retrieve user properties and user profile properties programmatically by using the SharePoint JavaScript object model.
-ms.date: 09/25/2017
+ms.date: 04/24/2017
 ms.assetid: c6e1ca38-134f-428a-8d21-b8b2615b161b
 ms.localizationpriority: high
 ---
-
 
 # Retrieve user profile properties by using the JavaScript object model in SharePoint
 
@@ -20,12 +19,10 @@ The [PeopleManager](/previous-versions/office/sharepoint-visio/jj667813(v=office
 - The [getMyProperties](/previous-versions/office/sharepoint-visio/jj679865(v=office.15)) method and the [getPropertiesFor](/previous-versions/office/sharepoint-visio/jj712745(v=office.15)) method return a [PersonProperties](/previous-versions/office/sharepoint-visio/jj712733(v=office.15)) object.
 - The [getUserProfilePropertiesFor](/previous-versions/office/sharepoint-visio/jj679779(v=office.15)) method and the [getUserProfilePropertyFor](/previous-versions/office/sharepoint-visio/jj667887(v=office.15)) method return the values of the user profile properties that you specify.
 
-User profile properties from client APIs are read-only (except the profile picture, which you can change by using the [PeopleManager.setMyProfilePicture](/previous-versions/office/sharepoint-visio/jj667836(v=office.15)) method). If you want to change other user profile properties, you must use the server object model. For more information about working with user profiles, see [Work with user profiles in SharePoint](work-with-user-profiles-in-sharepoint.md).
+User profile properties from client APIs are read only (except the profile picture, which you can change by using the [PeopleManager.setMyProfilePicture](/previous-versions/office/sharepoint-visio/jj667836(v=office.15)) method). If you want to change other user profile properties, you must use the server object model. For more information about working with user profiles, see [Work with user profiles in SharePoint](work-with-user-profiles-in-sharepoint.md).
 
 > [!NOTE]
 > The client-side [UserProfile](/previous-versions/office/sharepoint-visio/jj667833(v=office.15)) object doesn't contain all of the user properties as the server-side version. However, the client-side version does provide the methods for creating a personal site for the current user. To retrieve it, use the [ProfileLoader.getUserProfile](/previous-versions/office/sharepoint-visio/jj679826(v=office.15)) method.
-
-
 
 ## Prerequisites for setting up your development environment to retrieve user properties by using the SharePoint JavaScript object model
 
@@ -38,37 +35,45 @@ To create an application page that uses the JavaScript object model to retrieve 
 
 ## Create the application page in Visual Studio
 
-
 1. On the server running SharePoint, open Visual Studio and choose **File**, **New**, **Project**.
-2. In the **New Project** dialog box, choose **.NET Framework 4.5** from the drop-down list at the top of the dialog box.
-3. In the **Templates** list, expand **Office/SharePoint**, choose the **SharePoint Solutions** category, and then choose the **SharePoint Project** template.
-4. Name the project UserProfilesJSOM, and then choose the **OK** button.
-5. In the **SharePoint Customization Wizard** dialog box, enter the URL to your target SharePoint site, choose **Deploy as a farm solution**, and then choose the **Finish** button.
-6. In **Solution Explorer**, open the shortcut menu for the UserProfilesJSOM project, and then add a SharePoint "Layouts" mapped folder.
-7. In the **Layouts** folder, open the shortcut menu for theUserProfilesJSOM folder, and then add a new SharePoint application page namedUserProfiles.aspx.
+`. In the **New Project** dialog box, choose **.NET Framework 4.5** from the drop-down list at the top of the dialog box.
+`. In the **Templates** list, expand **Office/SharePoint**, choose the **SharePoint Solutions** category, and then choose the **SharePoint Project** template.
+`. Name the project UserProfilesJSOM, and then choose the **OK** button.
+`. In the **SharePoint Customization Wizard** dialog box, enter the URL to your target SharePoint site, choose **Deploy as a farm solution**, and then choose the **Finish** button.
+`. In **Solution Explorer**, open the shortcut menu for the UserProfilesJSOM project, and then add a SharePoint "Layouts" mapped folder.
+`. In the **Layouts** folder, open the shortcut menu for theUserProfilesJSOM folder, and then add a new SharePoint application page namedUserProfiles.aspx.
 
-   > [!NOTE]
-   > The code examples in this article define custom code in the page markup but do not use the code-behind class file that Visual Studio creates for the page.
+    > [!NOTE]
+    > The code examples in this article define custom code in the page markup but don't use the code-behind class file that Visual Studio creates for the page.
 
-8. Open the shortcut menu for the UserProfiles.aspx page, and then choose **Set as Startup Item**.
-9. In the markup for the UserProfiles.aspx page, paste the following code inside the "Main" **asp:Content** tags. This code adds a **span** control that displays the results of the query, **SharePoint:ScriptLink** controls that reference SharePoint JavaScript class library files, and **script** tags to contain your custom logic.
+1. Open the shortcut menu for the UserProfiles.aspx page, and then choose **Set as Startup Item**.
+1. In the markup for the UserProfiles.aspx page, paste the following code inside the "Main" **asp:Content** tags. This code adds a **span** control that displays the results of the query, **SharePoint:ScriptLink** controls that reference SharePoint JavaScript class library files, and **script** tags to contain your custom logic.
 
 ```HTML
 <span id="results"></span><br />
-<SharePoint:ScriptLink ID="ScriptLink1" name="SP.js" runat="server"
-    ondemand="false" localizable="false" loadafterui="true" />
-<SharePoint:ScriptLink ID="ScriptLink2" name="SP.UserProfiles.js" runat="server"
-    ondemand="false" localizable="false" loadafterui="true" />
+<SharePoint:ScriptLink ID="ScriptLink1"
+                       name="SP.js"
+                       runat="server"
+                       ondemand="false"
+                       localizable="false"
+                       loadafterui="true" />
+<SharePoint:ScriptLink ID="ScriptLink2"
+                       name="SP.UserProfiles.js"
+                       runat="server"
+                       ondemand="false"
+                       localizable="false"
+                       loadafterui="true" />
 <script type="text/javascript">
-    // Replace this comment with the code for your scenario.
+  // Replace this comment with the code for your scenario.
 </script>
 ```
 
-10. To add logic to retrieve user profile properties, replace the comment between the **script** tags with the code example from one of the following scenarios:
-   - [Retrieve user profile properties from the PersonProperties object and its userProfileProperties property](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#code-example-retrieving-user-profile-properties-from-the-personproperties-object-and-its-userprofileproperties-property-in-the-sharepoint-javascript-object-model)
-   - [Retrieve a set of user profile properties by using the getUserProfilePropertiesFor method](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#code-example-retrieving-a-set-of-user-profile-properties-by-using-the-getuserprofilepropertiesfor-method-in-the-sharepoint-javascript-object-model)
+1. To add logic to retrieve user profile properties, replace the comment between the **script** tags with the code example from one of the following scenarios:
 
-11. To test the application page, on the menu bar, choose **Debug**, **Start Debugging**. If you're prompted to modify the web.config file, choose the **OK** button.
+    - [Retrieve user profile properties from the PersonProperties object and its userProfileProperties property](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#code-example-retrieving-user-profile-properties-from-the-personproperties-object-and-its-userprofileproperties-property-in-the-sharepoint-javascript-object-model)
+    - [Retrieve a set of user profile properties by using the getUserProfilePropertiesFor method](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#code-example-retrieving-a-set-of-user-profile-properties-by-using-the-getuserprofilepropertiesfor-method-in-the-sharepoint-javascript-object-model)
+
+1. To test the application page, on the menu bar, choose **Debug**, **Start Debugging**. If you're prompted to modify the web.config file, choose the **OK** button.
 
 ## Code example: Retrieving user profile properties from the PersonProperties object and its userProfileProperties property in the SharePoint JavaScript object model
 
@@ -79,10 +84,9 @@ The following code example shows how to get user profile properties for a target
 - Get a property from the [userProfileProperties](/previous-versions/office/sharepoint-visio/jj679700(v=office.15)) property of the [PersonProperties](/previous-versions/office/sharepoint-visio/jj712733(v=office.15)) object. This example gets the **Department** property.
 
 > [!NOTE]
-> Paste the following code between the **script** tags that you added to the UserProfiles.aspx file in the [Create the application page](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#create-the-application-page-in-visual-studio) procedure. Replace the `domainName\\userName` placeholder value before you run the code. (This code example does not use the code-behind class file.)
+> Paste the following code between the **script** tags that you added to the UserProfiles.aspx file in the [Create the application page](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#create-the-application-page-in-visual-studio) procedure. Replace the `domainName\\userName` placeholder value before you run the code. (This code example doesn't use the code-behind class file.)
 
 ```javascript
-
 var personProperties;
 
 // Ensure that the SP.UserProfiles.js file is loaded before the custom code runs.
@@ -90,42 +94,39 @@ SP.SOD.executeOrDelayUntilScriptLoaded(getUserProperties, 'SP.UserProfiles.js');
 
 function getUserProperties() {
 
-    // Replace the placeholder value with the target user's credentials.
-    var targetUser = "domainName\\userName";
+  // Replace the placeholder value with the target user's credentials.
+  var targetUser = "domainName\\userName";
 
-    // Get the current client context and PeopleManager instance.
-    var clientContext = new SP.ClientContext.get_current();
-    var peopleManager = new SP.UserProfiles.PeopleManager(clientContext);
+  // Get the current client context and PeopleManager instance.
+  var clientContext = new SP.ClientContext.get_current();
+  var peopleManager = new SP.UserProfiles.PeopleManager(clientContext);
 
-    // Get user properties for the target user.
-    // To get the PersonProperties object for the current user, use the
-    // getMyProperties method.
-    personProperties = peopleManager.getPropertiesFor(targetUser);
+  // Get user properties for the target user.
+  // To get the PersonProperties object for the current user, use the
+  // getMyProperties method.
+  personProperties = peopleManager.getPropertiesFor(targetUser);
 
-    // Load the PersonProperties object and send the request.
-    clientContext.load(personProperties);
-    clientContext.executeQueryAsync(onRequestSuccess, onRequestFail);
+  // Load the PersonProperties object and send the request.
+  clientContext.load(personProperties);
+  clientContext.executeQueryAsync(onRequestSuccess, onRequestFail);
 }
 
 // This function runs if the executeQueryAsync call succeeds.
 function onRequestSuccess() {
 
-    // Get a property directly from the PersonProperties object.
-    var messageText = " \\"DisplayName\\" property is "
-        + personProperties.get_displayName();
+  // Get a property directly from the PersonProperties object.
+  var messageText = " \\"DisplayName\\" property is " + personProperties.get_displayName();
 
-    // Get a property from the UserProfileProperties property.
-    messageText += "<br />\\"Department\\" property is "
-        + personProperties.get_userProfileProperties()['Department'];
-    $get("results").innerHTML = messageText;
+  // Get a property from the UserProfileProperties property.
+  messageText += "<br />\\"Department\\" property is " + personProperties.get_userProfileProperties()['Department'];
+  $get("results").innerHTML = messageText;
 }
 
 // This function runs if the executeQueryAsync call fails.
 function onRequestFail(sender, args) {
-    $get("results").innerHTML = "Error: " + args.get_message();
+  $get("results").innerHTML = "Error: " + args.get_message();
 }
 ```
-
 
 ## Code example: Retrieving a set of user profile properties by using the getUserProfilePropertiesFor method in the SharePoint JavaScript object model
 
@@ -136,59 +137,53 @@ The following code example retrieves the values for a specified set of user prof
 - Get the values from the returned array of property values.
 
 > [!NOTE]
-> Paste the following code between the **script** tags that you added to the UserProfiles.aspx file in the [Create the application page](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#create-the-application-page-in-visual-studio) procedure. Replace the `domainName\\\\userName` placeholder value before you run the code. (This code example does not use the code-behind class file.)
+> Paste the following code between the **script** tags that you added to the UserProfiles.aspx file in the [Create the application page](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#create-the-application-page-in-visual-studio) procedure. Replace the `domainName\\\\userName` placeholder value before you run the code. (This code example doesn't use the code-behind class file.)
 
 ```javascript
-
 var userProfileProperties;
 
 // Ensure that the SP.UserProfiles.js file is loaded before the custom code runs.
 SP.SOD.executeOrDelayUntilScriptLoaded(getUserProperties, 'SP.UserProfiles.js');
 
 function getUserProperties() {
+  // Replace the placeholder value with the target user's credentials.
+  var targetUser = "domainName\\\\userName";
 
-    // Replace the placeholder value with the target user's credentials.
-    var targetUser = "domainName\\\\userName";
+  // Get the current client context and PeopleManager instance.
+  var clientContext = new SP.ClientContext.get_current();
+  var peopleManager = new SP.UserProfiles.PeopleManager(clientContext);
 
-    // Get the current client context and PeopleManager instance.
-    var clientContext = new SP.ClientContext.get_current();
-    var peopleManager = new SP.UserProfiles.PeopleManager(clientContext);
+  // Specify the properties to retrieve and target user for the
+  // UserProfilePropertiesForUser object.
+  var profilePropertyNames = ["PreferredName", "Department"];
+  var userProfilePropertiesForUser =
+      new SP.UserProfiles.UserProfilePropertiesForUser(
+          clientContext,
+          targetUser,
+          profilePropertyNames);
 
-    // Specify the properties to retrieve and target user for the 
-    // UserProfilePropertiesForUser object.
-    var profilePropertyNames = ["PreferredName", "Department"];
-    var userProfilePropertiesForUser = 
-        new SP.UserProfiles.UserProfilePropertiesForUser(
-            clientContext,
-            targetUser,
-            profilePropertyNames);
+  // Get user profile properties for the target user.
+  // To get the value for only one user profile property, use the
+  // getUserProfilePropertyFor method.
+  userProfileProperties = peopleManager.getUserProfilePropertiesFor(userProfilePropertiesForUser);
 
-    // Get user profile properties for the target user.
-    // To get the value for only one user profile property, use the
-    // getUserProfilePropertyFor method.
-    userProfileProperties = peopleManager.getUserProfilePropertiesFor(
-        userProfilePropertiesForUser);
-
-    // Load the UserProfilePropertiesForUser object and send the request.
-    clientContext.load(userProfilePropertiesForUser);
-    clientContext.executeQueryAsync(onRequestSuccess, onRequestFail);
+  // Load the UserProfilePropertiesForUser object and send the request.
+  clientContext.load(userProfilePropertiesForUser);
+  clientContext.executeQueryAsync(onRequestSuccess, onRequestFail);
 }
 
 // This function runs if the executeQueryAsync call succeeds.
 function onRequestSuccess() {
-    var messageText = "\\"PreferredName\\" property is " 
-        + userProfileProperties[0];
-    messageText += "<br />\\"Department\\" property is " 
-        + userProfileProperties[1];
-    $get("results").innerHTML = messageText;
+  var messageText = "\\"PreferredName\\" property is " + userProfileProperties[0];
+  messageText += "<br />\\"Department\\" property is " + userProfileProperties[1];
+  $get("results").innerHTML = messageText;
 }
 
 // This function runs if the executeQueryAsync call fails.
 function onRequestFail(sender, args) {
-    $get("results").innerHTML = "Error: " + args.get_message();
+  $get("results").innerHTML = "Error: " + args.get_message();
 }
 ```
-
 
 ## See also
 
@@ -196,4 +191,3 @@ function onRequestFail(sender, args) {
 - [How to: Retrieve user profile properties by using the .NET client object model in SharePoint](how-to-retrieve-user-profile-properties-by-using-the-net-client-object-model-in.md)
 - [How to: Work with user profiles and organization profiles by using the server object model in SharePoint](how-to-work-with-user-profiles-and-organization-profiles-by-using-the-server-obj.md)
 - [SP.UserProfiles namespace (sp.userprofiles)](/previous-versions/office/sharepoint-visio/jj642931(v=office.15))
-

--- a/docs/general-development/how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md
+++ b/docs/general-development/how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md
@@ -12,84 +12,47 @@ ms.localizationpriority: high
 Learn how to retrieve user properties and user profile properties programmatically by using the SharePoint JavaScript object model.
 
 ## What are user properties and user profile properties in SharePoint?
-<a name="bkmk_WhatIs"> </a>
 
-User properties and user profile properties provide information about SharePoint users, such as display name, email, title, and other business and personal information. In client-side APIs, you access these properties from the  [PersonProperties](https://msdn.microsoft.com/library/0274d97f-b697-f436-2aaf-f5bcf9b70df8%28Office.15%29.aspx) object and its [userProfileProperties](https://msdn.microsoft.com/library/56516666-7425-4993-222f-f745cf266e89%28Office.15%29.aspx) property. The [userProfileProperties](https://msdn.microsoft.com/library/56516666-7425-4993-222f-f745cf266e89%28Office.15%29.aspx) property contains all user profile properties, but the [PersonProperties](https://msdn.microsoft.com/library/0274d97f-b697-f436-2aaf-f5bcf9b70df8%28Office.15%29.aspx) object contains commonly used properties (such as [accountName](https://msdn.microsoft.com/library/ad1551bf-dad8-d54e-880a-8a4388fad44e%28Office.15%29.aspx),  [displayName](https://msdn.microsoft.com/library/ffc35ed6-5f3e-c86d-6931-97ff9d825a8b%28Office.15%29.aspx), and  [email](https://msdn.microsoft.com/library/74302f73-aaf6-920b-0605-812b0dbf4568%28Office.15%29.aspx)) that are easier to access.
-  
-    
-    
-The  [PeopleManager](https://msdn.microsoft.com/library/985fd2df-0e31-6ece-b846-ba2ccb156d00%28Office.15%29.aspx) object includes the following methods that you can use to retrieve user properties and user profile properties by using the JavaScript object model:
-  
-    
-    
+User properties and user profile properties provide information about SharePoint users, such as display name, email, title, and other business and personal information. In client-side APIs, you access these properties from the [PersonProperties](/previous-versions/office/sharepoint-visio/jj712733(v=office.15)) object and its [userProfileProperties](/previous-versions/office/sharepoint-visio/jj679700(v=office.15)) property. The [userProfileProperties](/previous-versions/office/sharepoint-visio/jj679700(v=office.15)) property contains all user profile properties, but the [PersonProperties](/previous-versions/office/sharepoint-visio/jj712733(v=office.15)) object contains commonly used properties (such as [accountName](/previous-versions/office/sharepoint-visio/jj667852(v=office.15)), [displayName](/previous-versions/office/sharepoint-visio/jj667922(v=office.15)), and [email](/previous-versions/office/sharepoint-visio/jj679810(v=office.15))) that are easier to access.
 
-- The  [getMyProperties](https://msdn.microsoft.com/library/be001abc-a431-8d48-8e6f-161251aa19ac%28Office.15%29.aspx) method and the [getPropertiesFor](https://msdn.microsoft.com/library/097464db-2630-4c7a-fd0c-0f333680b5a4%28Office.15%29.aspx) method return a [PersonProperties](https://msdn.microsoft.com/library/0274d97f-b697-f436-2aaf-f5bcf9b70df8%28Office.15%29.aspx) object.
-    
-  
-- The  [getUserProfilePropertiesFor](https://msdn.microsoft.com/library/8674e96f-d320-4a50-1580-9a4568842ee5%28Office.15%29.aspx) method and the [getUserProfilePropertyFor](https://msdn.microsoft.com/library/da048bfa-54c6-8216-e8ef-09bd84f68d8d%28Office.15%29.aspx) method return the values of the user profile properties that you specify.
-    
-  
-User profile properties from client APIs are read-only (except the profile picture, which you can change by using the  [PeopleManager.setMyProfilePicture](https://msdn.microsoft.com/library/a4f8d745-f211-e750-4fd0-047091804683%28Office.15%29.aspx) method). If you want to change other user profile properties, you must use the server object model. For more information about working with user profiles, see [Work with user profiles in SharePoint](work-with-user-profiles-in-sharepoint.md).
-  
+The [PeopleManager](/previous-versions/office/sharepoint-visio/jj667813(v=office.15)) object includes the following methods that you can use to retrieve user properties and user profile properties by using the JavaScript object model:
+
+- The [getMyProperties](/previous-versions/office/sharepoint-visio/jj679865(v=office.15)) method and the [getPropertiesFor](/previous-versions/office/sharepoint-visio/jj712745(v=office.15)) method return a [PersonProperties](/previous-versions/office/sharepoint-visio/jj712733(v=office.15)) object.
+- The [getUserProfilePropertiesFor](/previous-versions/office/sharepoint-visio/jj679779(v=office.15)) method and the [getUserProfilePropertyFor](/previous-versions/office/sharepoint-visio/jj667887(v=office.15)) method return the values of the user profile properties that you specify.
+
+User profile properties from client APIs are read-only (except the profile picture, which you can change by using the [PeopleManager.setMyProfilePicture](/previous-versions/office/sharepoint-visio/jj667836(v=office.15)) method). If you want to change other user profile properties, you must use the server object model. For more information about working with user profiles, see [Work with user profiles in SharePoint](work-with-user-profiles-in-sharepoint.md).
+
 > [!NOTE]
-> The client-side  [UserProfile](https://msdn.microsoft.com/library/f8c4a219-fbaa-2e50-1bd5-fdc80051b33d%28Office.15%29.aspx) object doesn't contain all of the user properties as the server-side version. However, the client-side version does provide the methods for creating a personal site for the current user. To retrieve it, use the [ProfileLoader.getUserProfile](https://msdn.microsoft.com/library/8e30e811-5da1-b6d0-a8b5-befea9b22496%28Office.15%29.aspx) method.
-  
-    
-    
+> The client-side [UserProfile](/previous-versions/office/sharepoint-visio/jj667833(v=office.15)) object doesn't contain all of the user properties as the server-side version. However, the client-side version does provide the methods for creating a personal site for the current user. To retrieve it, use the [ProfileLoader.getUserProfile](/previous-versions/office/sharepoint-visio/jj679826(v=office.15)) method.
+
 
 
 ## Prerequisites for setting up your development environment to retrieve user properties by using the SharePoint JavaScript object model
-<a name="bk_Prereqs"> </a>
 
 To create an application page that uses the JavaScript object model to retrieve user properties, you'll need:
-  
-    
-    
 
 - SharePoint with profiles created for the current user and a target user
-    
-  
-- Visual Studio 2012
-    
-  
-- Office Developer Tools for Visual Studio 2013
-    
-  
+- Visual Studio 2022
+- Office Developer Tools for Visual Studio 2022
 - **Full Control** connection permissions to access the User Profile service application for the current user
-    
-  
 
-## Create the application page in Visual Studio 2012
-<a name="bk_CreateAppPage"> </a>
+## Create the application page in Visual Studio
 
 
 1. On the server running SharePoint, open Visual Studio and choose **File**, **New**, **Project**.
-    
-  
 2. In the **New Project** dialog box, choose **.NET Framework 4.5** from the drop-down list at the top of the dialog box.
-    
-  
 3. In the **Templates** list, expand **Office/SharePoint**, choose the **SharePoint Solutions** category, and then choose the **SharePoint Project** template.
-    
-  
 4. Name the project UserProfilesJSOM, and then choose the **OK** button.
-    
-  
 5. In the **SharePoint Customization Wizard** dialog box, enter the URL to your target SharePoint site, choose **Deploy as a farm solution**, and then choose the **Finish** button.
-    
-  
 6. In **Solution Explorer**, open the shortcut menu for the UserProfilesJSOM project, and then add a SharePoint "Layouts" mapped folder.
-    
-  
 7. In the **Layouts** folder, open the shortcut menu for theUserProfilesJSOM folder, and then add a new SharePoint application page namedUserProfiles.aspx.
-    
-   > Note: The code examples in this article define custom code in the page markup but do not use the code-behind class file that Visual Studio creates for the page. 
+
+   > [!NOTE]
+   > The code examples in this article define custom code in the page markup but do not use the code-behind class file that Visual Studio creates for the page.
 
 8. Open the shortcut menu for the UserProfiles.aspx page, and then choose **Set as Startup Item**.
-    
-  
 9. In the markup for the UserProfiles.aspx page, paste the following code inside the "Main" **asp:Content** tags. This code adds a **span** control that displays the results of the query, **SharePoint:ScriptLink** controls that reference SharePoint JavaScript class library files, and **script** tags to contain your custom logic.
-    
+
 ```HTML
 <span id="results"></span><br />
 <SharePoint:ScriptLink ID="ScriptLink1" name="SP.js" runat="server"
@@ -102,39 +65,23 @@ To create an application page that uses the JavaScript object model to retrieve 
 ```
 
 10. To add logic to retrieve user profile properties, replace the comment between the **script** tags with the code example from one of the following scenarios:
-    
-  -  [Retrieve user profile properties from the PersonProperties object and its userProfileProperties property](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#bk_examplePersonPropsObj)  
-  -  [Retrieve a set of user profile properties by using the getUserProfilePropertiesFor method](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#bk_exampleGetUPMethod)
-    
-  
+   - [Retrieve user profile properties from the PersonProperties object and its userProfileProperties property](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#bk_examplePersonPropsObj)
+   - [Retrieve a set of user profile properties by using the getUserProfilePropertiesFor method](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#bk_exampleGetUPMethod)
+
 11. To test the application page, on the menu bar, choose **Debug**, **Start Debugging**. If you're prompted to modify the web.config file, choose the **OK** button.
-    
-  
 
 ## Code example: Retrieving user profile properties from the PersonProperties object and its userProfileProperties property in the SharePoint JavaScript object model
-<a name="bk_examplePersonPropsObj"> </a>
 
-The following code example shows how to get user profile properties for a target user by querying the  [PersonProperties](https://msdn.microsoft.com/library/0274d97f-b697-f436-2aaf-f5bcf9b70df8%28Office.15%29.aspx) object and its [userProfileProperties](https://msdn.microsoft.com/library/56516666-7425-4993-222f-f745cf266e89%28Office.15%29.aspx) property. It shows how to:
-  
-    
-    
+The following code example shows how to get user profile properties for a target user by querying the [PersonProperties](/previous-versions/office/sharepoint-visio/jj712733(v=office.15)) object and its [userProfileProperties](/previous-versions/office/sharepoint-visio/jj679700(v=office.15)) property. It shows how to:
 
-- Get the  [PersonProperties](https://msdn.microsoft.com/library/0274d97f-b697-f436-2aaf-f5bcf9b70df8%28Office.15%29.aspx) object that represents the target user by using the [getPropertiesFor](https://msdn.microsoft.com/library/097464db-2630-4c7a-fd0c-0f333680b5a4%28Office.15%29.aspx) method. (To get the [PersonProperties](https://msdn.microsoft.com/library/0274d97f-b697-f436-2aaf-f5bcf9b70df8%28Office.15%29.aspx) object for the current user, use the [getMyProperties](https://msdn.microsoft.com/library/be001abc-a431-8d48-8e6f-161251aa19ac%28Office.15%29.aspx) method.)
-    
-  
-- Get a property directly from the  [PersonProperties](https://msdn.microsoft.com/library/0274d97f-b697-f436-2aaf-f5bcf9b70df8%28Office.15%29.aspx) object. This example gets the [displayName](https://msdn.microsoft.com/library/ffc35ed6-5f3e-c86d-6931-97ff9d825a8b%28Office.15%29.aspx) property.
-    
-  
-- Get a property from the  [userProfileProperties](https://msdn.microsoft.com/library/56516666-7425-4993-222f-f745cf266e89%28Office.15%29.aspx) property of the [PersonProperties](https://msdn.microsoft.com/library/0274d97f-b697-f436-2aaf-f5bcf9b70df8%28Office.15%29.aspx) object. This example gets the **Department** property.
-    
+- Get the [PersonProperties](/previous-versions/office/sharepoint-visio/jj712733(v=office.15)) object that represents the target user by using the [getPropertiesFor](/previous-versions/office/sharepoint-visio/jj712745(v=office.15)) method. (To get the [PersonProperties](/previous-versions/office/sharepoint-visio/jj712733(v=office.15)) object for the current user, use the [getMyProperties](/previous-versions/office/sharepoint-visio/jj679865(v=office.15)) method.)
+- Get a property directly from the [PersonProperties](/previous-versions/office/sharepoint-visio/jj712733(v=office.15)) object. This example gets the [displayName](/previous-versions/office/sharepoint-visio/jj667922(v=office.15)) property.
+- Get a property from the [userProfileProperties](/previous-versions/office/sharepoint-visio/jj679700(v=office.15)) property of the [PersonProperties](/previous-versions/office/sharepoint-visio/jj712733(v=office.15)) object. This example gets the **Department** property.
+
 > [!NOTE]
 > Paste the following code between the **script** tags that you added to the UserProfiles.aspx file in the [Create the application page](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#bk_CreateAppPage) procedure. Replace the `domainName\\userName` placeholder value before you run the code. (This code example does not use the code-behind class file.)
-  
-    
-    
 
-
-```
+```javascript
 
 var personProperties;
 
@@ -181,29 +128,17 @@ function onRequestFail(sender, args) {
 
 
 ## Code example: Retrieving a set of user profile properties by using the getUserProfilePropertiesFor method in the SharePoint JavaScript object model
-<a name="bk_exampleGetUPMethod"> </a>
 
-The following code example retrieves the values for a specified set of user profile properties for a target user by using the  [getUserProfilePropertiesFor](https://msdn.microsoft.com/library/8674e96f-d320-4a50-1580-9a4568842ee5%28Office.15%29.aspx) method. It shows how to:
-  
-    
-    
+The following code example retrieves the values for a specified set of user profile properties for a target user by using the [getUserProfilePropertiesFor](/previous-versions/office/sharepoint-visio/jj679779(v=office.15)) method. It shows how to:
 
-- Create a  [UserProfilePropertiesForUser](https://msdn.microsoft.com/library/97bc94ec-62c8-dc38-d204-c5ad9ee8faee%28Office.15%29.aspx) object that specifies the target user and the user profile properties to retrieve. This example gets the **PreferredName** property and the **Department** property.
-    
-  
-- Get the values of the specified properties by using the  [getUserProfilePropertiesFor](https://msdn.microsoft.com/library/8674e96f-d320-4a50-1580-9a4568842ee5%28Office.15%29.aspx) method and passing in the [UserProfilePropertiesForUser](https://msdn.microsoft.com/library/97bc94ec-62c8-dc38-d204-c5ad9ee8faee%28Office.15%29.aspx) object. (To retrieve the value for only one user profile property, use the [getUserProfilePropertyFor](https://msdn.microsoft.com/library/da048bfa-54c6-8216-e8ef-09bd84f68d8d%28Office.15%29.aspx) method.)
-    
-  
+- Create a [UserProfilePropertiesForUser](/previous-versions/office/sharepoint-visio/jj679838(v=office.15)) object that specifies the target user and the user profile properties to retrieve. This example gets the **PreferredName** property and the **Department** property.
+- Get the values of the specified properties by using the [getUserProfilePropertiesFor](/previous-versions/office/sharepoint-visio/jj679779(v=office.15)) method and passing in the [UserProfilePropertiesForUser](/previous-versions/office/sharepoint-visio/jj679838(v=office.15)) object. (To retrieve the value for only one user profile property, use the [getUserProfilePropertyFor](/previous-versions/office/sharepoint-visio/jj667887(v=office.15)) method.)
 - Get the values from the returned array of property values.
-    
+
 > [!NOTE]
 > Paste the following code between the **script** tags that you added to the UserProfiles.aspx file in the [Create the application page](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#bk_CreateAppPage) procedure. Replace the `domainName\\\\userName` placeholder value before you run the code. (This code example does not use the code-behind class file.)
-  
-    
-    
 
-
-```
+```javascript
 
 var userProfileProperties;
 
@@ -256,19 +191,9 @@ function onRequestFail(sender, args) {
 
 
 ## See also
-<a name="bk_addresources"> </a>
 
-
--  [Work with user profiles in SharePoint](work-with-user-profiles-in-sharepoint.md)
-    
-  
--  [How to: Retrieve user profile properties by using the .NET client object model in SharePoint](how-to-retrieve-user-profile-properties-by-using-the-net-client-object-model-in.md)
-    
-  
--  [How to: Work with user profiles and organization profiles by using the server object model in SharePoint](how-to-work-with-user-profiles-and-organization-profiles-by-using-the-server-obj.md)
-    
-  
--  [SP.UserProfiles namespace (sp.userprofiles)](https://msdn.microsoft.com/library/8c1fcceb-cd9a-b25c-32f4-1cfb0578278c%28Office.15%29.aspx)
-    
-  
+- [Work with user profiles in SharePoint](work-with-user-profiles-in-sharepoint.md)
+- [How to: Retrieve user profile properties by using the .NET client object model in SharePoint](how-to-retrieve-user-profile-properties-by-using-the-net-client-object-model-in.md)
+- [How to: Work with user profiles and organization profiles by using the server object model in SharePoint](how-to-work-with-user-profiles-and-organization-profiles-by-using-the-server-obj.md)
+- [SP.UserProfiles namespace (sp.userprofiles)](/previous-versions/office/sharepoint-visio/jj642931(v=office.15))
 

--- a/docs/general-development/how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md
+++ b/docs/general-development/how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md
@@ -65,8 +65,8 @@ To create an application page that uses the JavaScript object model to retrieve 
 ```
 
 10. To add logic to retrieve user profile properties, replace the comment between the **script** tags with the code example from one of the following scenarios:
-   - [Retrieve user profile properties from the PersonProperties object and its userProfileProperties property](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#bk_examplePersonPropsObj)
-   - [Retrieve a set of user profile properties by using the getUserProfilePropertiesFor method](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#bk_exampleGetUPMethod)
+   - [Retrieve user profile properties from the PersonProperties object and its userProfileProperties property](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#code-example-retrieving-user-profile-properties-from-the-personproperties-object-and-its-userprofileproperties-property-in-the-sharepoint-javascript-object-model)
+   - [Retrieve a set of user profile properties by using the getUserProfilePropertiesFor method](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#code-example-retrieving-a-set-of-user-profile-properties-by-using-the-getuserprofilepropertiesfor-method-in-the-sharepoint-javascript-object-model)
 
 11. To test the application page, on the menu bar, choose **Debug**, **Start Debugging**. If you're prompted to modify the web.config file, choose the **OK** button.
 
@@ -79,7 +79,7 @@ The following code example shows how to get user profile properties for a target
 - Get a property from the [userProfileProperties](/previous-versions/office/sharepoint-visio/jj679700(v=office.15)) property of the [PersonProperties](/previous-versions/office/sharepoint-visio/jj712733(v=office.15)) object. This example gets the **Department** property.
 
 > [!NOTE]
-> Paste the following code between the **script** tags that you added to the UserProfiles.aspx file in the [Create the application page](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#bk_CreateAppPage) procedure. Replace the `domainName\\userName` placeholder value before you run the code. (This code example does not use the code-behind class file.)
+> Paste the following code between the **script** tags that you added to the UserProfiles.aspx file in the [Create the application page](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#create-the-application-page-in-visual-studio) procedure. Replace the `domainName\\userName` placeholder value before you run the code. (This code example does not use the code-behind class file.)
 
 ```javascript
 
@@ -136,7 +136,7 @@ The following code example retrieves the values for a specified set of user prof
 - Get the values from the returned array of property values.
 
 > [!NOTE]
-> Paste the following code between the **script** tags that you added to the UserProfiles.aspx file in the [Create the application page](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#bk_CreateAppPage) procedure. Replace the `domainName\\\\userName` placeholder value before you run the code. (This code example does not use the code-behind class file.)
+> Paste the following code between the **script** tags that you added to the UserProfiles.aspx file in the [Create the application page](how-to-retrieve-user-profile-properties-by-using-the-javascript-object-model-in.md#create-the-application-page-in-visual-studio) procedure. Replace the `domainName\\\\userName` placeholder value before you run the code. (This code example does not use the code-behind class file.)
 
 ```javascript
 

--- a/docs/general-development/how-to-specify-a-range-address-and-sheet-name.md
+++ b/docs/general-development/how-to-specify-a-range-address-and-sheet-name.md
@@ -76,7 +76,7 @@ If you specify a sheet name, the ranges you reference must exist on the sheet yo
 ## Example
 
 > [!NOTE]
-> It is assumed that you have already created a SharePoint document library and made it a trusted location. For more information about this, see  [How to: Trust a Location](how-to-trust-a-location.md) and [How to: Trust Workbook Locations Using Script](https://msdn.microsoft.com/library/79ab6ced-7a0c-4275-b852-bb246fc6be57%28Office.15%29.aspx). 
+> It is assumed that you have already created a SharePoint document library and made it a trusted location. For more information about this, see  [How to: Trust a Location](how-to-trust-a-location.md) and [How to: Trust Workbook Locations Using Script](/previous-versions/office/ms562080(v=office.14)). 
   
     
     
@@ -110,7 +110,7 @@ namespace ExcelWebService
             // Using the workbook path this way will allow 
             // you to call the workbook remotely.
             string targetWorkbookPath = 
-       "http://myserver02/example/Shared%20Documents/MyWorkbook1.xlsx";
+       "https://myserver02/example/Shared%20Documents/MyWorkbook1.xlsx";
 
             // Set Credentials for requests
             xlservice.Credentials = 
@@ -195,7 +195,7 @@ Namespace ExcelWebService
             ' The workbook must be in a trusted location.
             ' Using the workbook path this way will allow 
             ' you to call the workbook remotely.
-            Dim targetWorkbookPath As String = "http://myserver02/example/Shared%20Documents/MyWorkbook1.xlsx"
+            Dim targetWorkbookPath As String = "https://myserver02/example/Shared%20Documents/MyWorkbook1.xlsx"
 
             ' Set Credentials for requests
             xlservice.Credentials = System.Net.CredentialCache.DefaultCredentials
@@ -245,42 +245,13 @@ End Namespace
 ## Robust programming
 
 Make sure you add a Web reference to an Excel Web Services site to which you have access. Change the following:
-  
-    
-    
 
-- Change the  `using ExcelWebService.myserver02;` statement to point to the Web service site you are referencing.
-    
-  
-- Change  `string targetWorkbookPath = "http://myserver02/example/Shared%20Documents/Book1.xlsx";` to point to a workbook to which you have access. The workbook must be in a trusted location.
-    
-  
+- Change the `using ExcelWebService.myserver02;` statement to point to the Web service site you are referencing.
+- Change `string targetWorkbookPath = "https://myserver02/example/Shared%20Documents/Book1.xlsx";` to point to a workbook to which you have access. The workbook must be in a trusted location.
 
 ## See also
 
-
-#### Tasks
-
-
-  
-    
-    
- [How to: Get Values from Ranges](how-to-get-values-from-ranges.md)
-  
-    
-    
- [How to: Set Values of Ranges](how-to-set-values-of-ranges.md)
-#### Concepts
-
-
-  
-    
-    
- [Accessing the SOAP API](accessing-the-soap-api.md)
-#### Other resources
-
-
-  
-    
-    
- [Walkthrough: Developing a Custom Application Using Excel Web Services](walkthrough-developing-a-custom-application-using-excel-web-services.md)
+- [How to: Get Values from Ranges](how-to-get-values-from-ranges.md)
+- [How to: Set Values of Ranges](how-to-set-values-of-ranges.md)
+- [Accessing the SOAP API](accessing-the-soap-api.md)
+- [Walkthrough: Developing a Custom Application Using Excel Web Services](walkthrough-developing-a-custom-application-using-excel-web-services.md)

--- a/docs/general-development/how-to-specify-a-range-address-and-sheet-name.md
+++ b/docs/general-development/how-to-specify-a-range-address-and-sheet-name.md
@@ -1,7 +1,7 @@
 ---
 title: Specify a range address and sheet name
 description: This example shows how to specify range addresses by using range coordinates, named ranges, rows, and columns. It also shows how to specify a sheet name and the relationship between a sheet name and a range address.
-ms.date: 09/25/2017
+ms.date: 04/24/2017
 keywords: how to,howdoi,howto,set range
 f1_keywords:
 - how to,howdoi,howto,set range
@@ -9,78 +9,60 @@ ms.assetid: 8bfefc48-1fbc-4b65-8156-1b7d0a8453ee
 ms.localizationpriority: medium
 ---
 
-
 # Specify a range address and sheet name
 
 This example shows how to specify range addresses by using range coordinates, named ranges, rows, and columns. It also shows how to specify a sheet name and the relationship between a sheet name and a range address.
-  
-    
-    
 
-Range coordinates are the four integer coordinates used to select a contiguous range. Range coordinates enable you to specify Excel ranges by using direct integer indexing as an alternative to "A1" expressions. The coordinates you can specify are the top row, left column, height, and width. It is easier to use range coordinates when you have code that iterates through a set of cells in a loop, or when the range coordinates are calculated dynamically as part of the algorithm.
-A range specification must contain a sheet name; Excel Web Services does not recognize the "current sheet." There are a few ways to specify the sheet name: 
-  
-    
-    
+Range coordinates are the four integer coordinates used to select a contiguous range. Range coordinates enable you to specify Excel ranges by using direct integer indexing as an alternative to "A1" expressions. The coordinates you can specify are the top row, left column, height, and width. It's easier to use range coordinates when you have code that iterates through a set of cells in a loop, or when the range coordinates are calculated dynamically as part of the algorithm.
 
+A range specification must contain a sheet name; Excel Web Services doesn't recognize the "current sheet." There are a few ways to specify the sheet name:
 
 - As part of the range address—for example, "Sheet3!B12:D18"—in which case the sheet name argument can be empty:
-    
-```csharp
-  
-object[] rangeResult1 = xlservice.GetRangeA1(sessionId, String.Empty, "Sheet2!A12:G18", true, out outStatus);
-```
 
+    ```csharp
+    object[] rangeResult1 = xlservice.GetRangeA1(sessionId, String.Empty, "Sheet2!A12:G18", true, out outStatus);
+    ```
 
-```VB.net
-  Dim rangeResult1() As Object = xlservice.GetRangeA1(sessionId, String.Empty, "Sheet2!A12:G18", True, outStatus)
-```
+    ```VB.net
+    Dim rangeResult1() As Object = xlservice.GetRangeA1(sessionId, String.Empty, "Sheet2!A12:G18", True, outStatus)
+    ```
 
-- In a separate sheet name argument, in which case the range address argument does not have to include the sheet name:
-    
-```csharp
-  xlservice.SetCell(sessionId, "Sheet3", 0, 11, 1000);
-```
+- In a separate sheet name argument, in which case the range address argument doesn't have to include the sheet name:
 
+    ```csharp
+    xlservice.SetCell(sessionId, "Sheet3", 0, 11, 1000);
+    ```
 
-```VB.net
-  xlservice.SetCell(sessionId, "Sheet3", 0, 11, 1000)
-```
+    ```VB.net
+    xlservice.SetCell(sessionId, "Sheet3", 0, 11, 1000)
+    ```
 
 - In both the sheet name and range address, in which case the name of the sheet must match:
-    
-```csharp
-  object[] rangeResult = xlservice.GetCellA1(sessionId, "Sheet3", "Sheet3!G18", true, out outStatus);
-```
 
+    ```csharp
+    object[] rangeResult = xlservice.GetCellA1(sessionId, "Sheet3", "Sheet3!G18", true, out outStatus);
+    ```
 
-```VB.net
-  Dim rangeResult() As Object = xlservice.GetCellA1(sessionId, "Sheet3", "Sheet3!G18", True, outStatus)
-```
+    ```VB.net
+    Dim rangeResult() As Object = xlservice.GetCellA1(sessionId, "Sheet3", "Sheet3!G18", True, outStatus)
+    ```
 
-The only case that does not require a sheet name is a named range, because some named ranges have a workbook scope. For example, you can refer to named ranges without specifying the sheet name argument:
-
+The only case that doesn't require a sheet name is a named range, because some named ranges have a workbook scope. For example, you can refer to named ranges without specifying the sheet name argument:
 
 ```csharp
 xlServices.SetCellA1(sessionId, String.Empty, "MyNamedRange", 8);
 ```
 
-
-
-
 ```VB.net
 xlServices.SetCellA1(sessionId, String.Empty, "MyNamedRange", 8)
 ```
 
-If you specify a sheet name, the ranges you reference must exist on the sheet you specify. If you specify a sheet that does not exist, the call will fail and you will get a Simple Object Access Protocol (SOAP) exception, saying that the sheet does not exist.
+If you specify a sheet name, the ranges you reference must exist on the sheet you specify. If you specify a sheet that doesn't exist, the call will fail and you'll get a Simple Object Access Protocol (SOAP) exception, saying that the sheet doesn't exist.
+
 ## Example
 
 > [!NOTE]
-> It is assumed that you have already created a SharePoint document library and made it a trusted location. For more information about this, see  [How to: Trust a Location](how-to-trust-a-location.md) and [How to: Trust Workbook Locations Using Script](/previous-versions/office/ms562080(v=office.14)). 
-  
-    
-    
-
+> It's assumed that you have already created a SharePoint document library and made it a trusted location. For more information about this, see [How to: Trust a Location](how-to-trust-a-location.md) and [How to: Trust Workbook Locations Using Script](/previous-versions/office/ms562080(v=office.14)).
 
 ```csharp
 using System;
@@ -92,86 +74,83 @@ namespace ExcelWebService
 /// <summary>
 /// Summary description for Class1.
 /// </summary>
-    class MyExcelWebService
+  class MyExcelWebService
+  {
+    [STAThread]
+    static void Main(string[] args)
     {
-        [STAThread]
-        static void Main(string[] args)
-        {
-            // Instantiate the Web service 
-            // and range coordinate array object.
-            ExcelService xlservice = new ExcelService();
-            Status[] outStatus;
-            RangeCoordinates rangeCoordinates = new RangeCoordinates();
-            string sheetName = "MySheet1";
+      // Instantiate the Web service
+      // and range coordinate array object.
+      ExcelService xlservice = new ExcelService();
+      Status[] outStatus;
+      RangeCoordinates rangeCoordinates = new RangeCoordinates();
+      string sheetName = "MySheet1";
 
-            // TODO: Change the path to the workbook
-            // to point to a workbook you have access to.
-            // The workbook must be in a trusted location.
-            // Using the workbook path this way will allow 
-            // you to call the workbook remotely.
-            string targetWorkbookPath = 
-       "https://myserver02/example/Shared%20Documents/MyWorkbook1.xlsx";
+      // TODO: Change the path to the workbook
+      // to point to a workbook you have access to.
+      // The workbook must be in a trusted location.
+      // Using the workbook path this way will allow
+      // you to call the workbook remotely.
+      string targetWorkbookPath = "https://myserver02/example/Shared%20Documents/MyWorkbook1.xlsx";
 
-            // Set Credentials for requests
-            xlservice.Credentials = 
-                System.Net.CredentialCache.DefaultCredentials;
+      // Set Credentials for requests
+      xlservice.Credentials = System.Net.CredentialCache.DefaultCredentials;
 
-            try
-            {
-                // Call the open workbook, and point to    
-                // the workbook to open.
-                string sessionId = 
-                    xlservice.OpenWorkbook(targetWorkbookPath, 
-                        String.Empty, String.Empty, out outStatus);
-                // Prepare object to define range coordinates
-                // and call the GetRange method.
-                // startCol, startRow, startHeight, and startWidth
-                // get their values from user input.
-                rangeCoordinates.Column = (int)startCol.Value;
-                rangeCoordinates.Row = (int)startRow.Value;
-                rangeCoordinates.Height = (int)startHeight.Value;
-                rangeCoordinates.Width = (int)startWidth.Value;
+      try
+      {
+        // Call the open workbook, and point to
+        // the workbook to open.
+        string sessionId = xlservice.OpenWorkbook(targetWorkbookPath,
+                                                  String.Empty,
+                                                  String.Empty,
+                                                  out outStatus);
 
-                object[] rangeResult1 = xlservice.GetRange(sessionId, 
-                    sheetName, rangeCoordinates, false, out outStatus);
-                Console.WriteLine("Total rows in range: " + 
-                    rangeResult1.Length);
-                Console.WriteLine("Sum in last column is: " + 
-                    ((object[])rangeResult1[18])[11]);
+        // Prepare object to define range coordinates
+        // and call the GetRange method.
+        // startCol, startRow, startHeight, and startWidth
+        // get their values from user input.
+        rangeCoordinates.Column = (int)startCol.Value;
+        rangeCoordinates.Row = (int)startRow.Value;
+        rangeCoordinates.Height = (int)startHeight.Value;
+        rangeCoordinates.Width = (int)startWidth.Value;
 
-                // Call the SetCell method, which invokes 
-                // the Calculate method.
-                // Set first row in last column cell to 1000.
-                xlservice.SetCell(sessionId, sheetName, 0, 11, 1000);
+        object[] rangeResult1 = xlservice.GetRange(sessionId, sheetName, rangeCoordinates, false, out outStatus);
+        Console.WriteLine("Total rows in range: " + rangeResult1.Length);
+        Console.WriteLine("Sum in last column is: " + ((object[])rangeResult1[18])[11]);
 
-                // Call the GetRange method again to see if 
-                // the Sum total in the last column changed.
-                object[] rangeResult2 = xlservice.GetRange(sessionId, 
-                    sheetName, rangeCoordinates, false, out outStatus);    
-                Console.WriteLine("Sum in the last column after SetCell 
-                    is: " + ((object[])rangeResult2[18])[11]); 
+        // Call the SetCell method, which invokes
+        // the Calculate method.
+        // Set first row in last column cell to 1000.
+        xlservice.SetCell(sessionId, sheetName, 0, 11, 1000);
 
-                // Close workbook. This also closes the session.
-                xlservice.CloseWorkbook(sessionId);
-            }
+        // Call the GetRange method again to see if
+        // the Sum total in the last column changed.
+        object[] rangeResult2 = xlservice.GetRange(sessionId,
+                                                   sheetName,
+                                                   rangeCoordinates,
+                                                   false,
+                                                   out outStatus);
+        Console.WriteLine("Sum in the last column after SetCell is: " + ((object[])rangeResult2[18])[11]);
 
-            catch (SoapException e)
-            {
-                Console.WriteLine("Exception Message: {0}", e.Message);
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine("Exception Message: {0}", e.Message);
-            }
-            Console.ReadLine();
-        }
+        // Close workbook. This also closes the session.
+        xlservice.CloseWorkbook(sessionId);
+      }
+
+      catch (SoapException e)
+      {
+        Console.WriteLine("Exception Message: {0}", e.Message);
+      }
+      catch (Exception e)
+      {
+        Console.WriteLine("Exception Message: {0}", e.Message);
+      }
+      Console.ReadLine();
     }
+  }
 }
 ```
 
-
 ```VB.net
-
 Imports System
 Imports System.Text
 Imports System.Web.Services.Protocols
@@ -180,73 +159,72 @@ Namespace ExcelWebService
 ''' <summary>
 ''' Summary description for Class1.
 ''' </summary>
-    Friend Class MyExcelWebService
-        <STAThread> _
-        Shared Sub Main(ByVal args() As String)
-            ' Instantiate the Web service 
-            ' and range coordinate array object.
-            Dim xlservice As New ExcelService()
-            Dim outStatus() As Status
-            Dim rangeCoordinates As New RangeCoordinates()
-            Dim sheetName As String = "MySheet1"
+  Friend Class MyExcelWebService
+    <STAThread> _
+    Shared Sub Main(ByVal args() As String)
+      ' Instantiate the Web service
+      ' and range coordinate array object.
+      Dim xlservice As New ExcelService()
+      Dim outStatus() As Status
+      Dim rangeCoordinates As New RangeCoordinates()
+      Dim sheetName As String = "MySheet1"
 
-            ' TODO: Change the path to the workbook
-            ' to point to a workbook you have access to.
-            ' The workbook must be in a trusted location.
-            ' Using the workbook path this way will allow 
-            ' you to call the workbook remotely.
-            Dim targetWorkbookPath As String = "https://myserver02/example/Shared%20Documents/MyWorkbook1.xlsx"
+      ' TODO: Change the path to the workbook
+      ' to point to a workbook you have access to.
+      ' The workbook must be in a trusted location.
+      ' Using the workbook path this way will allow
+      ' you to call the workbook remotely.
+      Dim targetWorkbookPath As String = "https://myserver02/example/Shared%20Documents/MyWorkbook1.xlsx"
 
-            ' Set Credentials for requests
-            xlservice.Credentials = System.Net.CredentialCache.DefaultCredentials
+      ' Set Credentials for requests
+      xlservice.Credentials = System.Net.CredentialCache.DefaultCredentials
 
-            Try
-                ' Call the open workbook, and point to    
-                ' the workbook to open.
-                Dim sessionId As String = xlservice.OpenWorkbook(targetWorkbookPath, String.Empty, String.Empty, outStatus)
-                ' Prepare object to define range coordinates
-                ' and call the GetRange method.
-                ' startCol, startRow, startHeight, and startWidth
-                ' get their values from user input.
-                rangeCoordinates.Column = CInt(Fix(startCol.Value))
-                rangeCoordinates.Row = CInt(Fix(startRow.Value))
-                rangeCoordinates.Height = CInt(Fix(startHeight.Value))
-                rangeCoordinates.Width = CInt(Fix(startWidth.Value))
+      Try
+        ' Call the open workbook, and point to
+        ' the workbook to open.
+        Dim sessionId As String = xlservice.OpenWorkbook(targetWorkbookPath, String.Empty, String.Empty, outStatus)
+        ' Prepare object to define range coordinates
+        ' and call the GetRange method.
+        ' startCol, startRow, startHeight, and startWidth
+        ' get their values from user input.
+        rangeCoordinates.Column = CInt(Fix(startCol.Value))
+        rangeCoordinates.Row = CInt(Fix(startRow.Value))
+        rangeCoordinates.Height = CInt(Fix(startHeight.Value))
+        rangeCoordinates.Width = CInt(Fix(startWidth.Value))
 
-                Dim rangeResult1() As Object = xlservice.GetRange(sessionId, sheetName, rangeCoordinates, False, outStatus)
-                Console.WriteLine("Total rows in range: " &amp; rangeResult1.Length)
-                Console.WriteLine("Sum in last column is: " &amp; (CType(rangeResult1(18), Object()))(11))
+        Dim rangeResult1() As Object = xlservice.GetRange(sessionId, sheetName, rangeCoordinates, False, outStatus)
+        Console.WriteLine("Total rows in range: " &amp; rangeResult1.Length)
+        Console.WriteLine("Sum in last column is: " &amp; (CType(rangeResult1(18), Object()))(11))
 
-                ' Call the SetCell method, which invokes 
-                ' the Calculate method.
-                ' Set first row in last column cell to 1000.
-                xlservice.SetCell(sessionId, sheetName, 0, 11, 1000)
+        ' Call the SetCell method, which invokes
+        ' the Calculate method.
+        ' Set first row in last column cell to 1000.
+        xlservice.SetCell(sessionId, sheetName, 0, 11, 1000)
 
-                ' Call the GetRange method again to see if 
-                ' the Sum total in the last column changed.
-                Dim rangeResult2() As Object = xlservice.GetRange(sessionId, sheetName, rangeCoordinates, False, outStatus)
-                Console.WriteLine("Sum in the last column after SetCell is: " &amp; (CType(rangeResult2(18), Object()))(11))
+        ' Call the GetRange method again to see if
+        ' the Sum total in the last column changed.
+        Dim rangeResult2() As Object = xlservice.GetRange(sessionId, sheetName, rangeCoordinates, False, outStatus)
+        Console.WriteLine("Sum in the last column after SetCell is: " &amp; (CType(rangeResult2(18), Object()))(11))
 
-                ' Close workbook. This also closes the session.
-                xlservice.CloseWorkbook(sessionId)
+        ' Close workbook. This also closes the session.
+        xlservice.CloseWorkbook(sessionId)
 
-            Catch e As SoapException
-                Console.WriteLine("Exception Message: {0}", e.Message)
-            Catch e As Exception
-                Console.WriteLine("Exception Message: {0}", e.Message)
-            End Try
-            Console.ReadLine()
-        End Sub
-    End Class
+      Catch e As SoapException
+        Console.WriteLine("Exception Message: {0}", e.Message)
+      Catch e As Exception
+        Console.WriteLine("Exception Message: {0}", e.Message)
+      End Try
+      Console.ReadLine()
+    End Sub
+  End Class
 End Namespace
 ```
-
 
 ## Robust programming
 
 Make sure you add a Web reference to an Excel Web Services site to which you have access. Change the following:
 
-- Change the `using ExcelWebService.myserver02;` statement to point to the Web service site you are referencing.
+- Change the `using ExcelWebService.myserver02;` statement to point to the Web service site you're referencing.
 - Change `string targetWorkbookPath = "https://myserver02/example/Shared%20Documents/Book1.xlsx";` to point to a workbook to which you have access. The workbook must be in a trusted location.
 
 ## See also

--- a/docs/general-development/search-add-ins-in-sharepoint.md
+++ b/docs/general-development/search-add-ins-in-sharepoint.md
@@ -1,21 +1,15 @@
 ---
 title: Search add-ins in SharePoint
-description: Learn about search SharePoint Add-ins and how you can create your own search add-ins. The add-ins you create can be added to the SharePoint add-ins catalog so that they can be used in both on-premises deployment and Office 365. Search add-ins only work with data that is stored in the search index and not with the original source documents.
+description: Learn about search SharePoint Add-ins and how you can create your own search add-ins. The add-ins you create can be added to the SharePoint add-ins catalog so that they can be used in both on-premises deployment and Microsoft 365. Search add-ins only work with data that is stored in the search index and not with the original source documents.
 ms.date: 04/24/2017
 ms.assetid: 21682e45-dd78-4f3c-8f1e-cdd48de3bde2
 ms.localizationpriority: medium
 ---
 # Search add-ins in SharePoint
 
-> [!IMPORTANT]
-> The SharePoint Add-in model is deprecated for SharePoint Online and is no longer recommended for new development.
-> Microsoft recommends using SharePoint Framework (SPFx) and Microsoft Graph APIs for modern SharePoint extensibility solutions.
->
-> Existing SharePoint Add-ins continue to be supported in SharePoint Server environments.
+Learn about search SharePoint Add-ins and how you can create your own search add-ins. The add-ins you create can be added to the SharePoint add-ins catalog so that they can be used in both on-premises deployment and Microsoft 365. Search add-ins only work with data that is stored in the search index and not with the original source documents.
 
-Learn about search SharePoint Add-ins and how you can create your own search add-ins. The add-ins you create can be added to the SharePoint add-ins catalog so that they can be used in both on-premises deployment and Office 365. Search add-ins only work with data that is stored in the search index and not with the original source documents.
-
-SharePoint Add-ins are self-contained pieces of functionality that extend the capabilities of a SharePoint website. These add-ins solve specific business and end-user needs by integrating the best of the web and SharePoint. An add-in can contain various SharePoint elements like Lists, Remote Event Receivers, Content Types, Workflows, Workflow Custom Activities, Site Columns, Modules, Menu Item Custom Actions, Client web parts, and Search Configurations. For more information, see [SharePoint Add-ins](../sp-add-ins/sharepoint-add-ins.md).
+SharePoint Add-ins are self-contained pieces of functionality that extend the capabilities of a SharePoint website. These add-ins solve specific business and end-user needs by integrating the best of the web and SharePoint. An add-in can contain various SharePoint elements like Lists, Remote Event Receivers, Content Types, Workflows, Workflow Custom Activities, Site Columns, Modules, Menu Item Custom Actions, Client web parts, and Search Configurations. For more information, see [SharePoint Add-ins](../sp-add-ins/sharepoint-add-ins.md)
 
 A search add-in is a SharePoint Add-in that uses search functionality. In a search add-in, you can use the SharePoint Search API to locate content. Depending on the type of permissions set up in your [add-in manifest](../sp-add-ins/explore-the-app-manifest-structure-and-the-package-of-a-sharepoint-add-in.md), you can search either inside or outside the contents of the add-in. In addition, you can also use a search add-in to distribute search configurations from one SharePoint installation to another.
 The core design of a search add-in depends on the deployment method that you choose. The following section summarizes the available options and their benefits. For more information, see [Choose patterns for developing and hosting your SharePoint Add-in](../sp-add-ins/choose-patterns-for-developing-and-hosting-your-sharepoint-add-in.md)
@@ -29,14 +23,9 @@ There are two ways to deploy your search add-in:
 
 ## Search add-in development environment
 
-> [!NOTE]
-> SharePoint Add-ins are a legacy development model. For new development, use SharePoint Framework (SPFx).
+To create a search add-in, use following environment: **Visual Studio 2022**
 
-To create a search add-in, use following environment:
-
-- Microsoft Visual Studio Code
-
-With Visual Studio Code and later, you can publish your search add-ins to both on-premises or in Office 365. For more information about the development environments and how to use them to create search add-ins, see [Set up a general development environment for SharePoint](set-up-a-general-development-environment-for-sharepoint.md).
+With Visual Studio 2022 and later, you can publish your search add-ins to both on-premises or in Microsoft 365. For more information about the development environments and how to use them to create search add-ins, see [Set up a general development environment for SharePoint](set-up-a-general-development-environment-for-sharepoint.md).
 
 ## APIs for search add-ins
 
@@ -44,15 +33,11 @@ You can use the wide range of search-related APIs that SharePoint offers for sea
 
 **SharePoint APIs for Search add-ins**
 
-> [!NOTE]
-> Silverlight-based APIs are deprecated and no longer supported.
-
 |**API name**|**Class library**|
 |:-----|:-----|
-|.NET client object model (CSOM) |Microsoft.SharePoint.Client.Search.dll |
-|Silverlight CSOM |Microsoft.SharePoint.Client.Search.Silverlight.dll |
-|ECMAScript (JavaScript, JScript) object model (JSOM) |SP.search.js |
-|Search REST API |http://server/_api/search/query |
+|.NET client object model (CSOM)  |Microsoft.SharePoint.Client.Search.dll  |
+|ECMAScript (JavaScript, JScript) object model (JSOM)  |SP.search.js  |
+|Search REST API  |`https://server/_api/search/query`  |
 
 ### Code examples
 
@@ -66,8 +51,7 @@ using (ClientContext clientContext = new ClientContext("http://localhost"))
   KeywordQuery keywordQuery = new KeywordQuery(clientContext);
   keywordQuery.QueryText = "*";
   SearchExecutor searchExecutor = new SearchExecutor(clientContext);
-  ClientResult<ResultTableCollection> results =
-    searchExecutor.ExecuteQuery(keywordQuery);
+  ClientResult<ResultTableCollection> results = searchExecutor.ExecuteQuery(keywordQuery);
   clientContext.ExecuteQuery();
 }
 ```
@@ -75,8 +59,7 @@ using (ClientContext clientContext = new ClientContext("http://localhost"))
 **JavaScript Object Model (JSOM)**
 
 ```javascript
-var keywordQuery = new
-Microsoft.SharePoint.Client.Search.Query.KeywordQuery(context);
+var keywordQuery = new Microsoft.SharePoint.Client.Search.Query.KeywordQuery(context);
 keywordQuery.set_queryText('SharePoint');
 var searchExecutor = new Microsoft.SharePoint.Client.Search.Query.SearchExecutor(context);
 results = searchExecutor.executeQuery(keywordQuery);
@@ -87,13 +70,13 @@ context.executeQueryAsync(onQuerySuccess, onQueryFail);
 
 HTTP GET request
 
-```html
-http://mylocalhost/_api/search/query?querytext='SharePoint'
+```http
+https://mylocalhost/_api/search/query?querytext='SharePoint'
 ```
 
 HTTP POST request
 
-```html
+```json
 {
   '__metadata' : {'type' : 'Microsoft.Office.Server.Search.REST.SearchRequest'},
   'Querytext' : 'SharePoint'
@@ -108,7 +91,7 @@ Search add-ins send query requests to the Search service application (SSA), and 
 
 ![Search app permission configuration with VS](../images/SP15_search_apps_permission_Visual_Studio.PNG)
 
-An SharePoint Add-in has its own identity and is associated with a security principal, called an add-in principal. Like users and groups, an add-in principal has certain permissions and rights. The add-in principal has full control rights to the add-in web, so it only needs to request permissions to SharePoint resources in the host web or other locations outside the add-in web, such as site collections. Unlike other SharePoint Add-ins, a search add-in requires only user-level permissions, known as **QueryAsUserIgnoreAppPrincipal**. This permission lets you query the search add-in based on the user's permissions. This means that search results will be returned based on the user's ACLs.
+A SharePoint Add-in has its own identity and is associated with a security principal, called an add-in principal. Like users and groups, an add-in principal has certain permissions and rights. The add-in principal has full control rights to the add-in web, so it only needs to request permissions to SharePoint resources in the host web or other locations outside the add-in web, such as site collections. Unlike other SharePoint Add-ins, a search add-in requires only user-level permissions, known as **QueryAsUserIgnoreAppPrincipal**. This permission lets you query the search add-in based on the user's permissions. This means that search results will be returned based on the user's ACLs.
 
 ### Request permissions in the add-in manifest file
 
@@ -119,6 +102,7 @@ The add-in manifest file is in XML format and can be edited directly. To get per
   <AppPermissionRequest Scope="http://sharepoint/search" Right="QueryAsUserIgnoreAppPrincipal" />
 </AppPermissionRequests>
 ```
+
 ## See also
 
 - [SharePoint Add-ins](../sp-add-ins/sharepoint-add-ins.md)
@@ -128,4 +112,4 @@ The add-in manifest file is in XML format and can be edited directly. To get per
 - [Important aspects of the SharePoint Add-in architecture and development landscape](../sp-add-ins/important-aspects-of-the-sharepoint-add-in-architecture-and-development-landscap.md)
 - [Explore the app manifest structure and the package of a SharePoint Add-in](../sp-add-ins/explore-the-app-manifest-structure-and-the-package-of-a-sharepoint-add-in.md)
 - [Exporting and importing search configuration settings in SharePoint](exporting-and-importing-search-configuration-settings-in-sharepoint.md)
-- [Export and import customized search configuration settings in SharePoint](/sharepoint/search/export-and-import-customized-search-configuration-settings)
+- [Export and import customized search configuration settings in SharePoint](/SharePoint/search/export-and-import-customized-search-configuration-settings)

--- a/docs/general-development/search-add-ins-in-sharepoint.md
+++ b/docs/general-development/search-add-ins-in-sharepoint.md
@@ -87,32 +87,28 @@ context.executeQueryAsync(onQuerySuccess, onQueryFail);
 
 HTTP GET request
 
-```HTML
+```html
 http://mylocalhost/_api/search/query?querytext='SharePoint'
 ```
 
 HTTP POST request
 
-```HTML
+```html
 {
-'__metadata' : {'type' : 'Microsoft.Office.Server.Search.REST.SearchRequest'},
-'Querytext' : 'SharePoint'
+  '__metadata' : {'type' : 'Microsoft.Office.Server.Search.REST.SearchRequest'},
+  'Querytext' : 'SharePoint'
 }
 ```
 
 ## Search add-in permissions
 
-Search add-ins send query requests to the Search service application (SSA), and the add-ins require different types of permissions to function correctly. You can configure these permissions via the add-in manifest file, which is a part of each SharePoint add-in. You can modify the add-in manifest file directly with a text editor, or you can modify it with Visual Studio or Napa, as shown in the following figures.
+Search add-ins send query requests to the Search service application (SSA), and the add-ins require different types of permissions to function correctly. You can configure these permissions via the add-in manifest file, which is a part of each SharePoint add-in. You can modify the add-in manifest file directly with a text editor, or you can modify it with Visual Studio, as shown in the following figure.
 
-**Figure 1: Setting up permissions for search add-ins in Visual Studio 2015**
+**Figure 1: Setting up permissions for search add-ins in Visual Studio 2022**
 
-![Search app permission configuration with VS](../images/SP15_search_apps_permission_Visual_Studio.png)
+![Search app permission configuration with VS](../images/SP15_search_apps_permission_Visual_Studio.PNG)
 
-**Figure 2: Setting up permissions for search add-ins in "Napa" Office 365 Development Tools**
-
-![Search app permission configuration through Napa](../images/SP15_search_app_permission_Napa.gif)
-
-A SharePoint Add-in has its own identity and is associated with a security principal, called an add-in principal. Like users and groups, an add-in principal has certain permissions and rights. The add-in principal has full control rights to the add-in web, so it only needs to request permissions to SharePoint resources in the host web or other locations outside the add-in web, such as site collections. Unlike other SharePoint Add-ins, a search add-in requires only user-level permissions, known as **QueryAsUserIgnoreAppPrincipal**. This permission lets you query the search add-in based on the user's permissions. This means that search results will be returned based on the user's ACLs.
+An SharePoint Add-in has its own identity and is associated with a security principal, called an add-in principal. Like users and groups, an add-in principal has certain permissions and rights. The add-in principal has full control rights to the add-in web, so it only needs to request permissions to SharePoint resources in the host web or other locations outside the add-in web, such as site collections. Unlike other SharePoint Add-ins, a search add-in requires only user-level permissions, known as **QueryAsUserIgnoreAppPrincipal**. This permission lets you query the search add-in based on the user's permissions. This means that search results will be returned based on the user's ACLs.
 
 ### Request permissions in the add-in manifest file
 

--- a/docs/solution-guidance/master-pages-sharepoint-add-in.md
+++ b/docs/solution-guidance/master-pages-sharepoint-add-in.md
@@ -1,17 +1,17 @@
 ---
 title: Master pages in the SharePoint Add-in model
 description: The approach you take to implement custom master pages in SharePoint sites is different in the new SharePoint Add-in model than it was with Full Trust Code / Farm Solutions. In a typical Full Trust Code (FTC) / Farm Solution branding scenario, custom master pages are created to implement a custom brand. The master pages are typically packaged in a feature that uses declarative code and a FTC / Farm Solution to deploy the master pages and register them with the SharePoint site.
-ms.date: 11/03/2017
+ms.date: 11/06/2017
 ms.localizationpriority: medium
 ---
 # Master pages in the SharePoint Add-in model
 
 > [!IMPORTANT]
-> This guidance applies to classic SharePoint experiences and the SharePoint Add-in model. Custom master pages are not supported in modern SharePoint Online experiences and are considered a legacy customization approach.
+> This guidance applies to classic SharePoint experiences and the SharePoint Add-in model. Custom master pages aren't supported in modern SharePoint Online experiences and are considered a legacy customization approach.
 
 The approach you take to implement custom master pages in SharePoint sites is different in the new SharePoint Add-in model than it was with Full Trust Code / Farm Solutions. In a typical Full Trust Code (FTC) / Farm Solution branding scenario, custom master pages are created to implement a custom brand. The master pages are typically packaged in a feature that uses declarative code and a FTC / Farm Solution to deploy the master pages and register them with the SharePoint site.
 
-In a SharePoint Add-in model branding scenario, custom master pages may be also be used. You can deploy and register your custom master pages on SharePoint sites via the remote-provisioning pattern.
+In a SharePoint Add-in model branding scenario, custom master pages may be used. You can deploy and register your custom master pages on SharePoint sites via the remote-provisioning pattern.
 
 ## High-level guidelines for custom master pages
 
@@ -20,48 +20,47 @@ As a rule of a thumb, we would like to provide the following high-level guidelin
 - You can customize SharePoint sites using custom master pages, but keep in mind this will cause you additional long-term costs and challenges with future updates.
   - In most cases, you can achieve all common branding scenarios with themes, composed looks and alternate CSS.
 
-    See the [Branding SharePoint Sites (SharePoint Add-in Recipe)](branding-sharepoint-sites-sharepoint-add-in.md) to learn all about the different branding options you have for SharePoint sites with the SharePoint Add-in model.  The recipe will help you consider the short and long-term impact of customization from an operational and a maintenance perspective. You may discover that a custom master page is not required to implement your specific branding requirements.
+    See the [Branding SharePoint Sites (SharePoint Add-in Recipe)](branding-sharepoint-sites-sharepoint-add-in.md) to learn all about the different branding options you have for SharePoint sites with the SharePoint Add-in model. The recipe will help you consider the short and long-term impact of customization from an operational and a maintenance perspective. You may discover that a custom master page isn't required to implement your specific branding requirements.
 
   - If you chose to use custom master pages, be prepared to apply changes to the custom master pages when major functional updates are applied to Microsoft 365.
 - Use remote provisioning to deploy and register custom master pages with SharePoint sites.
-- Do not use declarative code or sandbox code to deploy and register master pages with SharePoint sites.
+- Don't use declarative code or sandbox code to deploy and register master pages with SharePoint sites.
 
 ## Team sites vs. publishing sites
 
 ### When is a custom master page needed?
 
-When applying custom branding to SharePoint sites, you will encounter the need to brand both team sites and publishing sites. Generally speaking, intranets built on SharePoint in both on-premises and Microsoft 365 scenarios use a combination of team sites and publishing sites.
+When applying custom branding to SharePoint sites, you'll encounter the need to brand both team sites and publishing sites. Generally speaking, intranets built on SharePoint in both on-premises and Microsoft 365 scenarios use a combination of team sites and publishing sites.
 
-Custom branding requirements often times require specific layout changes that themes and JavaScript embedding techniques cannot accomplish.
+Custom branding requirements often require specific layout changes that themes and JavaScript embedding techniques can't accomplish.
 
-In such a scenario, team sites usually do not require the amount of custom branding that publishing sites do and the out-of-the-box SharePoint Contemporary View for mobile devices is usually sufficient to support mobile devices for team sites. Since this is the case, it is best to only use custom master pages for publishing sites and to use AlternativeCSS and custom SharePoint themes (**\*.spcolor** files), font schemes (**\*.spfont** files) and background images defined as composed looks to brand team sites.
+In such a scenario, team sites usually don't require the amount of custom branding that publishing sites do and the out-of-the-box SharePoint Contemporary View for mobile devices is sufficient to support mobile devices for team sites. Since this is the case, it's best to only use custom master pages for publishing sites and to use AlternativeCSS and custom SharePoint themes (**\*.spcolor** files), font schemes (**\*.spfont** files) and background images defined as composed looks to brand team sites.
 
 ### Deployment considerations
 
-- When deploying custom master pages to *publishing sites* you only need to deploy the custom master pages to the root site.
-  - The [Provisioning.PublishingFeatures (O365 PnP Sample)](https://github.com/pnp/PnP/tree/master/Samples/Provisioning.PublishingFeatures) demonstrates how to deploy custom master pages to publishing sites.
+- When deploying custom master pages to *publishing sites*, you only need to deploy the custom master pages to the root site.
+  - The [Provisioning.PublishingFeatures (PnP Sample)](https://github.com/pnp/PnP/tree/master/Samples/Provisioning.PublishingFeatures) demonstrates how to deploy custom master pages to publishing sites.
+- When deploying custom master pages to *non-publishing sites*, you need to deploy the custom master pages to each site.
 
-- When deploying custom master pages to *non-publishing sites* you need to deploy the custom master pages to each site.
-
-Custom master pages are typically applied when a site is provisioned. The remote provisioning process fits very well with this approach. Usually the only time you will use the web browser to manually apply SharePoint branding customization is when you are prototyping or modifying a single SharePoint site that is not planned to grow to include other site collections or sub sites.
+Custom master pages are typically applied when a site is provisioned. The remote provisioning process fits well with this approach. Usually the only time you'll use the web browser to manually apply SharePoint branding customization is when you're prototyping or modifying a single SharePoint site that isn't planned to grow to include other site collections or sub sites.
 
 - See the [Modules (SharePoint Add-in Recipe)](modules-sharepoint-add-in.md) and [Site Provisioning (SharePoint Add-in Recipe)](site-provisioning-sharepoint-add-in.md) for more deployment details and additional samples.
 
 ## More details about custom master pages and page layouts for SharePoint sites
 
-In scenarios where a custom master page is the only way to implement your custom branding requirements you can create a custom master page and page layouts. Keep in mind the points made at the beginning of this article with regard to the long-term maintenance costs associated with this approach.
+In scenarios where a custom master page is the only way to implement your custom branding requirements you can create a custom master page and page layouts. Keep in mind the points made at the beginning of this article regarding the long-term maintenance costs associated with this approach.
 
 - Using custom master pages for SharePoint sites provides the ultimate level of customization (unlimited).
 - Using custom master pages for SharePoint sites requires the largest amount of time to implement and maintain in the short and long term.
-- Any changes to out-of-the-box master pages that come with service updates will not be reflected in custom master pages.
+- Any changes to out-of-the-box master pages that come with service updates won't be reflected in custom master pages.
 - You can apply custom master pages at a per-site level.
-- When using a custom master page it is recommended to start with one of the out-of-the-box master pages and modify it to meet your needs.
+- When using a custom master page, it's recommended to start with one of the out-of-the-box master pages and modify it to meet your needs.
   - Try to minimize the amount of customization you make with custom master pages; this will make it easier to update them when Microsoft 365 service changes to out-of-the-box master pages must be replicated to custom master pages.
-- There are many required content placeholders in SharePoint master pages that must not be removed or they will cause the pages to error. You will know when you have removed a required content placeholder because the minute you deploy it and assign the master page to your site, errors will appear.
+- There are many required content placeholders in SharePoint master pages that must not be removed or they'll cause the pages to error. You'll know when you have removed a required content placeholder because the minute you deploy it and assign the master page to your site, errors will appear.
 
 ### When are custom master pages and page layouts for a SharePoint site a good fit?
 
-This option works well when your branding needs are very specific or you are using publishing sites.
+This option works well when your branding needs are specific or you're using publishing sites.
 
 ### Recommended deployment approaches
 
@@ -79,15 +78,15 @@ This option works well when your branding needs are very specific or you are usi
 ## PnP samples
 
 - [Theme management using CSOM (Microsoft 365 PnP Sample)](https://github.com/pnp/PnP/tree/master/Samples/Branding.DeployCustomThemeWeb)
-- [AlternateCSSUrl and SiteLogoUrl Properties in the web object (O365 PnP Sample)](https://github.com/pnp/PnP/tree/master/Samples/Branding.AlternateCSSAndSiteLogo)
-- [Set theme to site (O365 PnP Sample)](https://github.com/pnp/PnP/tree/master/Samples/Branding.SetThemeToSite)
-- [Setting a SharePoint Theme in an App for SharePoint (O365 PnP Sample)](https://github.com/pnp/PnP/tree/master/Samples/Branding.Themes)
-- [Making out-of-the-box Seattle master responsive (O365 PnP Sample)](https://github.com/pnp/PnP/tree/master/Samples/Branding.InjectResponsiveCSS)
+- [AlternateCSSUrl and SiteLogoUrl Properties in the web object (PnP Sample)](https://github.com/pnp/PnP/tree/master/Samples/Branding.AlternateCSSAndSiteLogo)
+- [Set theme to site (PnP Sample)](https://github.com/pnp/PnP/tree/master/Samples/Branding.SetThemeToSite)
+- [Setting a SharePoint Theme in an App for SharePoint (PnP Sample)](https://github.com/pnp/PnP/tree/master/Samples/Branding.Themes)
+- [Making out-of-the-box Seattle master responsive (PnP Sample)](https://github.com/pnp/PnP/tree/master/Samples/Branding.InjectResponsiveCSS)
 - Samples and content at [https://github.com/pnp/PnP](https://github.com/pnp/PnP)
 
 ## Applies to
 
-- Microsoft 365 Multi Tenant (MT)
+- Microsoft 365 multitenant (MT)
 - Microsoft 365 Dedicated (D) *partly*
 - SharePoint 2013 on-premises – *partly*
 

--- a/docs/solution-guidance/master-pages-sharepoint-add-in.md
+++ b/docs/solution-guidance/master-pages-sharepoint-add-in.md
@@ -6,6 +6,9 @@ ms.localizationpriority: medium
 ---
 # Master pages in the SharePoint Add-in model
 
+> [!IMPORTANT]
+> This guidance applies to classic SharePoint experiences and the SharePoint Add-in model. Custom master pages are not supported in modern SharePoint Online experiences and are considered a legacy customization approach.
+
 The approach you take to implement custom master pages in SharePoint sites is different in the new SharePoint Add-in model than it was with Full Trust Code / Farm Solutions. In a typical Full Trust Code (FTC) / Farm Solution branding scenario, custom master pages are created to implement a custom brand. The master pages are typically packaged in a feature that uses declarative code and a FTC / Farm Solution to deploy the master pages and register them with the SharePoint site.
 
 In a SharePoint Add-in model branding scenario, custom master pages may be also be used. You can deploy and register your custom master pages on SharePoint sites via the remote-provisioning pattern.
@@ -19,7 +22,7 @@ As a rule of a thumb, we would like to provide the following high-level guidelin
 
     See the [Branding SharePoint Sites (SharePoint Add-in Recipe)](branding-sharepoint-sites-sharepoint-add-in.md) to learn all about the different branding options you have for SharePoint sites with the SharePoint Add-in model.  The recipe will help you consider the short and long-term impact of customization from an operational and a maintenance perspective. You may discover that a custom master page is not required to implement your specific branding requirements.
 
-  - If you chose to use custom master pages, be prepared to apply changes to the custom master pages when major functional updates are applied to Office 365.
+  - If you chose to use custom master pages, be prepared to apply changes to the custom master pages when major functional updates are applied to Microsoft 365.
 - Use remote provisioning to deploy and register custom master pages with SharePoint sites.
 - Do not use declarative code or sandbox code to deploy and register master pages with SharePoint sites.
 
@@ -27,7 +30,7 @@ As a rule of a thumb, we would like to provide the following high-level guidelin
 
 ### When is a custom master page needed?
 
-When applying custom branding to SharePoint sites, you will encounter the need to brand both team sites and publishing sites. Generally speaking, intranets built on SharePoint in both on-premises and Office 365 scenarios use a combination of team sites and publishing sites.
+When applying custom branding to SharePoint sites, you will encounter the need to brand both team sites and publishing sites. Generally speaking, intranets built on SharePoint in both on-premises and Microsoft 365 scenarios use a combination of team sites and publishing sites.
 
 Custom branding requirements often times require specific layout changes that themes and JavaScript embedding techniques cannot accomplish.
 
@@ -36,8 +39,8 @@ In such a scenario, team sites usually do not require the amount of custom brand
 ### Deployment considerations
 
 - When deploying custom master pages to *publishing sites* you only need to deploy the custom master pages to the root site.
-  - The [Provisioning.PublishingFeatures (O365 PnP Sample)](https://github.com/SharePoint/PnP/tree/master/Samples/Provisioning.PublishingFeatures) demonstrates how to deploy custom master pages to publishing sites.
-  - The [Provisioning SharePoint Publishing Features (O365 PnP Video)](https://channel9.msdn.com/Blogs/Office-365-Dev/Provisioning-SharePoint-Publishing-Features-Office-365-Developer-Patterns-and-Practices) walks you through the sample.
+  - The [Provisioning.PublishingFeatures (O365 PnP Sample)](https://github.com/pnp/PnP/tree/master/Samples/Provisioning.PublishingFeatures) demonstrates how to deploy custom master pages to publishing sites.
+
 - When deploying custom master pages to *non-publishing sites* you need to deploy the custom master pages to each site.
 
 Custom master pages are typically applied when a site is provisioned. The remote provisioning process fits very well with this approach. Usually the only time you will use the web browser to manually apply SharePoint branding customization is when you are prototyping or modifying a single SharePoint site that is not planned to grow to include other site collections or sub sites.
@@ -53,7 +56,7 @@ In scenarios where a custom master page is the only way to implement your custom
 - Any changes to out-of-the-box master pages that come with service updates will not be reflected in custom master pages.
 - You can apply custom master pages at a per-site level.
 - When using a custom master page it is recommended to start with one of the out-of-the-box master pages and modify it to meet your needs.
-  - Try to minimize the amount of customization you make with custom master pages; this will make it easier to update them when Office 365 service changes to out-of-the-box master pages must be replicated to custom master pages.
+  - Try to minimize the amount of customization you make with custom master pages; this will make it easier to update them when Microsoft 365 service changes to out-of-the-box master pages must be replicated to custom master pages.
 - There are many required content placeholders in SharePoint master pages that must not be removed or they will cause the pages to error. You will know when you have removed a required content placeholder because the minute you deploy it and assign the master page to your site, errors will appear.
 
 ### When are custom master pages and page layouts for a SharePoint site a good fit?
@@ -71,24 +74,21 @@ This option works well when your branding needs are very specific or you are usi
 - [Modules (SharePoint Add-in Recipe)](modules-sharepoint-add-in.md)
 - [Site Provisioning (SharePoint Add-in Recipe)](site-provisioning-sharepoint-add-in.md)
 - [Branding SharePoint Sites (SharePoint Add-in Recipe)](branding-sharepoint-sites-sharepoint-add-in.md)
-- Ignite 2015 - [Deep Dive into Safe SharePoint Branding in Office 365 Using Repeatable Patterns and Practices](https://channel9.msdn.com/Events/Ignite/2015/BRK3164)
-- Guidance articles at [https://aka.ms/OfficeDevPnPGuidance](https://aka.ms/OfficeDevPnPGuidance "Guidance Articles")
-- References in MSDN at [https://aka.ms/OfficeDevPnPMSDN](https://aka.ms/OfficeDevPnPMSDN "References in MSDN")
-- Videos at [https://aka.ms/OfficeDevPnPVideos](https://aka.ms/OfficeDevPnPVideos "Videos")
+- Guidance articles at [Office 365 development and SharePoint PnP solution guidance](/sharepoint/dev/solution-guidance/office-365-development-patterns-and-practices-solution-guidance)
 
 ## PnP samples
 
-- [Theme management using CSOM (O365 PnP Sample)](https://github.com/SharePoint/PnP/tree/master/Samples/Branding.DeployCustomThemeWeb)
-- [AlternateCSSUrl and SiteLogoUrl Properties in the web object (O365 PnP Sample)](https://github.com/SharePoint/PnP/tree/master/Samples/Branding.AlternateCSSAndSiteLogo)
-- [Set theme to site (O365 PnP Sample)](https://github.com/SharePoint/PnP/tree/master/Samples/Branding.SetThemeToSite)
-- [Setting a SharePoint Theme in an App for SharePoint (O365 PnP Sample)](https://github.com/SharePoint/PnP/tree/master/Samples/Branding.Themes)
-- [Making out-of-the-box Seattle master responsive (O365 PnP Sample)](https://github.com/SharePoint/PnP/tree/master/Samples/Branding.InjectResponsiveCSS)
-- Samples and content at [https://github.com/SharePoint/PnP](https://github.com/SharePoint/PnP)
+- [Theme management using CSOM (Microsoft 365 PnP Sample)](https://github.com/pnp/PnP/tree/master/Samples/Branding.DeployCustomThemeWeb)
+- [AlternateCSSUrl and SiteLogoUrl Properties in the web object (O365 PnP Sample)](https://github.com/pnp/PnP/tree/master/Samples/Branding.AlternateCSSAndSiteLogo)
+- [Set theme to site (O365 PnP Sample)](https://github.com/pnp/PnP/tree/master/Samples/Branding.SetThemeToSite)
+- [Setting a SharePoint Theme in an App for SharePoint (O365 PnP Sample)](https://github.com/pnp/PnP/tree/master/Samples/Branding.Themes)
+- [Making out-of-the-box Seattle master responsive (O365 PnP Sample)](https://github.com/pnp/PnP/tree/master/Samples/Branding.InjectResponsiveCSS)
+- Samples and content at [https://github.com/pnp/PnP](https://github.com/pnp/PnP)
 
 ## Applies to
 
-- Office 365 Multi Tenant (MT)
-- Office 365 Dedicated (D) *partly*
+- Microsoft 365 Multi Tenant (MT)
+- Microsoft 365 Dedicated (D) *partly*
 - SharePoint 2013 on-premises – *partly*
 
 *Patterns for dedicated and on-premises are identical with SharePoint Add-in model techniques, but there are differences on the possible technologies that can be used.*


### PR DESCRIPTION
## Category

- [x] Content fix


## Related issues

- fixes #10839
- fixes #10838 
- fixes #10837 
- fixes #10836
- fixes #10835
-fixes #10846
-fixes #10845 
-fixes #10844 
-fixes #10843 
-fixes #10842

## What's in this Pull Request?
Fix broken links, outdated content, and whitespace artifacts in 5 docs

- Replace retired msdn.microsoft.com and technet.microsoft.com links
- Update Office 365 references to Microsoft 365
- Remove legacy HTML anchor tags and MSDN-style whitespace artifacts
- Fix outdated Visual Studio version references
- Remove discontinued Silverlight CSOM and Napa tool references
- Add javascript/csharp language tags to code blocks
- Clean up See also sections and list formatting