### PR TITLE
docs: Remove admin role requirement for SPE container type creation

### DIFF
--- a/docs/embedded/administration/developer-admin/dev-admin.md
+++ b/docs/embedded/administration/developer-admin/dev-admin.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint Embedded developer administrator
 description: This article describes the role and responsibilities of developer tenant admin in SharePoint Embedded.
-ms.date: 01/20/2026
+ms.date: 06/05/2026
 ms.localizationpriority: high
 ---
 # SharePoint Embedded Developer Administrator
@@ -18,6 +18,9 @@ Organizations that use SharePoint Embedded for file management are included in t
 > Global Administrators can continue to execute SharePoint Embedded container cmdlets.
 
 A Microsoft 365 SharePoint Embedded Administrator serves as the developer admin. Global Administrators in Microsoft 365 can assign users the SharePoint Embedded Administrator role. The Global Administrator role already has all the permissions of the SharePoint Embedded Administrator role. The SharePoint Embedded Role is available in Microsoft Entra ID and Microsoft 365 Admin Center. For information on the [SharePoint Embedded Administrator](../adminrole.md) role.
+
+> [!NOTE]
+> The PowerShell cmdlets in this article require the [SharePoint Embedded Administrator](../adminrole.md) or [Global Administrator](/entra/identity/role-based-access-control/permissions-reference#global-administrator) role. The equivalent Microsoft Graph endpoints don't require an administrator role. Any non-guest user in the owning tenant can [create a container type using Microsoft Graph](../../getting-started/containertypes.md#creating-container-types) and is automatically assigned as an [owner](../../development/auth.md#container-type-owner-capabilities).
 
 The following are some of the SharePoint Embedded actions currently supported on PowerShell:
 

--- a/docs/embedded/administration/developer-admin/dev-admin.md
+++ b/docs/embedded/administration/developer-admin/dev-admin.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint Embedded developer administrator
 description: This article describes the role and responsibilities of developer tenant admin in SharePoint Embedded.
-ms.date: 06/08/2026
+ms.date: 11/21/2023
 ms.localizationpriority: high
 ---
 # SharePoint Embedded Developer Administrator

--- a/docs/embedded/administration/developer-admin/dev-admin.md
+++ b/docs/embedded/administration/developer-admin/dev-admin.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint Embedded developer administrator
 description: This article describes the role and responsibilities of developer tenant admin in SharePoint Embedded.
-ms.date: 06/05/2026
+ms.date: 06/08/2026
 ms.localizationpriority: high
 ---
 # SharePoint Embedded Developer Administrator
@@ -20,7 +20,7 @@ Organizations that use SharePoint Embedded for file management are included in t
 A Microsoft 365 SharePoint Embedded Administrator serves as the developer admin. Global Administrators in Microsoft 365 can assign users the SharePoint Embedded Administrator role. The Global Administrator role already has all the permissions of the SharePoint Embedded Administrator role. The SharePoint Embedded Role is available in Microsoft Entra ID and Microsoft 365 Admin Center. For information on the [SharePoint Embedded Administrator](../adminrole.md) role.
 
 > [!NOTE]
-> The PowerShell cmdlets in this article require the [SharePoint Embedded Administrator](../adminrole.md) or [Global Administrator](/entra/identity/role-based-access-control/permissions-reference#global-administrator) role. The equivalent Microsoft Graph endpoints don't require an administrator role. Any non-guest user in the owning tenant can [create a container type using Microsoft Graph](../../getting-started/containertypes.md#creating-container-types) and is automatically assigned as an [owner](../../development/auth.md#container-type-owner-capabilities).
+> The PowerShell cmdlets in this article require the [SharePoint Embedded Administrator](../adminrole.md) or [Global Administrator](/entra/identity/role-based-access-control/permissions-reference#global-administrator) role. The equivalent Microsoft Graph container type endpoints (create, get, update, delete) don't require an administrator role. Any non-guest user in the owning tenant can [create a container type using Microsoft Graph](../../getting-started/containertypes.md#creating-container-types) and is automatically assigned as an [owner](../../development/auth.md#container-type-owner-capabilities). Other SharePoint Embedded Graph operations (for example, container management with `FileStorageContainer.Manage.All`) continue to require an administrator role.
 
 The following are some of the SharePoint Embedded actions currently supported on PowerShell:
 

--- a/docs/embedded/development/auth.md
+++ b/docs/embedded/development/auth.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint Embedded Authentication and Authorization
 description: This article describes the authentication and authorization model for SharePoint Embedded applications.
-ms.date: 06/05/2026
+ms.date: 06/08/2026
 ms.localizationpriority: high
 ---
 
@@ -147,7 +147,7 @@ Container type owners are managed through the [permissions](/graph/api/filestora
 
 Container type owners can do the following operations on the **owning tenant** when using an application with **[FileStorageContainerType.Manage.All](/graph/permissions-reference#filestoragecontainertypemanageall)** in delegated mode:
 
-- **Create, read, update, and delete** the container type they own. Non-admin owners can manage only container types they have a permission on, and the calling app must match the owning application.
+- **Create, read, update, and delete** the container type they own. Non-admin owners can manage only container types on which they have a permission, and the calling app must match the owning application.
 - **Add and remove** other owners on the container type they own (via the permissions endpoint).
 - **Create containers** of the container type they own, as long as the call is delegated (not app-only).
 
@@ -208,16 +208,19 @@ Here are some actions you can take next:
 
     - Add the Microsoft Graph permission **[FileStorageContainerType.Manage.All](/graph/permissions-reference#filestoragecontainertypemanageall)** to create container types on the _owning_ tenant:
         - **resourceAppId**: `00000003-0000-0000-c000-000000000000`
-        - **type**: `Role`
+        - **type**: `Scope`
         - **ID**: `8e6ec84c-5fcd-4cc7-ac8a-2296efc0ed9b`
 
-1. [Grant admin consent](/entra/identity-platform/v2-admin-consent) to your application on your _owning_ tenant
+      > [!NOTE]
+      > **[FileStorageContainerType.Manage.All](/graph/permissions-reference#filestoragecontainertypemanageall)** is a delegated permission and doesn't require admin consent. Any non-guest user in the owning tenant can consent to it and use it to create a container type; that user is then automatically added as an [owner of the container type](#container-type-owner-capabilities).
+
+1. [Grant admin consent](/entra/identity-platform/v2-admin-consent) to your application on your _owning_ tenant for the application permissions you added (admin consent isn't required for the delegated **[FileStorageContainerType.Manage.All](/graph/permissions-reference#filestoragecontainertypemanageall)** scope).
 1. [Create a new container type](../getting-started/containertypes.md) on the _owning_ tenant.
 1. Reconfigure your SharePoint Embedded [application manifest](/entra/identity-platform/reference-app-manifest#requiredresourceaccess-attribute) to request only the required permissions on consuming tenants:
 
     - Remove the Microsoft Graph permission **[FileStorageContainerType.Manage.All](/graph/permissions-reference#filestoragecontainertypemanageall)** as this is only needed to create the container type on the _owning_ tenant:
         - **resourceAppId**: `00000003-0000-0000-c000-000000000000`
-        - **type**: `Role`
+        - **type**: `Scope`
         - **ID**: `8e6ec84c-5fcd-4cc7-ac8a-2296efc0ed9b`
 
           > [!NOTE]

--- a/docs/embedded/development/auth.md
+++ b/docs/embedded/development/auth.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint Embedded Authentication and Authorization
 description: This article describes the authentication and authorization model for SharePoint Embedded applications.
-ms.date: 11/21/2023
+ms.date: 06/05/2026
 ms.localizationpriority: high
 ---
 
@@ -147,7 +147,7 @@ Container type owners are managed through the [permissions](/graph/api/filestora
 
 Container type owners can do the following operations on the **owning tenant** when using an application with **[FileStorageContainerType.Manage.All](/graph/permissions-reference#filestoragecontainertypemanageall)** in delegated mode:
 
-- **Create, read, update, and delete** the container type they own. Non-admin owners can only manage container types where they appear in the permissions collection and the calling app matches the owning application.
+- **Create, read, update, and delete** the container type they own. Non-admin owners can manage only container types they have a permission on, and the calling app must match the owning application.
 - **Add and remove** other owners on the container type they own (via the permissions endpoint).
 - **Create containers** of the container type they own, as long as the call is delegated (not app-only).
 

--- a/docs/embedded/development/auth.md
+++ b/docs/embedded/development/auth.md
@@ -214,7 +214,6 @@ Here are some actions you can take next:
       > [!NOTE]
       > **[FileStorageContainerType.Manage.All](/graph/permissions-reference#filestoragecontainertypemanageall)** is a delegated permission and doesn't require admin consent. Any non-guest user in the owning tenant can consent to it and use it to create a container type; that user is then automatically added as an [owner of the container type](#container-type-owner-capabilities).
 
-1. [Grant admin consent](/entra/identity-platform/v2-admin-consent) to your application on your _owning_ tenant for the application permissions you added (admin consent isn't required for the delegated **[FileStorageContainerType.Manage.All](/graph/permissions-reference#filestoragecontainertypemanageall)** scope).
 1. [Create a new container type](../getting-started/containertypes.md) on the _owning_ tenant.
 1. Reconfigure your SharePoint Embedded [application manifest](/entra/identity-platform/reference-app-manifest#requiredresourceaccess-attribute) to request only the required permissions on consuming tenants:
 

--- a/docs/embedded/development/auth.md
+++ b/docs/embedded/development/auth.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint Embedded Authentication and Authorization
 description: This article describes the authentication and authorization model for SharePoint Embedded applications.
-ms.date: 06/08/2026
+ms.date: 11/21/2023
 ms.localizationpriority: high
 ---
 

--- a/docs/embedded/getting-started/containertypes.md
+++ b/docs/embedded/getting-started/containertypes.md
@@ -190,6 +190,6 @@ To create and interact with containers, you must [register](../getting-started/r
 
 ## Deleting container types
 
-You can only delete trial container types. Deletion of standard container types isn't yet supported. Before you delete a container type, you need to remove every container of that type, including from the deleted container collection. To remove containers, see [Consuming Tenant Admin](../administration/consuming-tenant-admin/cta.md).
+You can only delete trial container types. Deletion of standard container types isn't yet supported. Before you delete a container type, you need to remove every container of that type, including from the deleted container collection. To remove containers, see [Delete fileStorageContainer](/graph/api/filestorage-delete-containers).
 
 Once every container is deleted, call the [Delete fileStorageContainerType](/graph/api/filestorage-delete-containertypes) endpoint. Non-administrator users can delete only container types they have a permission on. [SharePoint Embedded Administrators](/entra/identity/role-based-access-control/permissions-reference#sharepoint-embedded-administrator) and [Global Administrators](/entra/identity/role-based-access-control/permissions-reference#global-administrator) can delete any trial container type.

--- a/docs/embedded/getting-started/containertypes.md
+++ b/docs/embedded/getting-started/containertypes.md
@@ -1,7 +1,7 @@
 ---
 title: Create new SharePoint Embedded container types
 description: This article explains how container types work and the steps to create new container types.
-ms.date: 06/11/2026
+ms.date: 11/27/2023
 ms.localizationpriority: high
 ---
 
@@ -120,7 +120,6 @@ The billing profile for your container type is created using **SharePoint Online
 1. Download and install the [latest version of SharePoint Online Management Shell](https://www.microsoft.com/download/details.aspx?id=35588)
 1. Open SharePoint Online Management Shell from **Start** screen, type **sharepoint**, and then select **SharePoint Online Management Shell**.
 1. Connect to SPO service using `Connect-SPOService` cmdlet by providing admin credentials associated with tenancy. For information, see [how to use Connect-SPOService](/powershell/module/sharepoint-online/connect-sposervice).
-.
 To create the standard billing profile for your container type, use the following cmdlet:
 
 ```powershell
@@ -136,7 +135,7 @@ Add-SPOContainerTypeBilling –ContainerTypeId <ContainerTypeId> -AzureSubscript
 >
 > An Azure subscription can be attached to any number of container types.
 >
-> If the cmdlet above fails with a SubscriptionNotRegistered error, it is because **Microsoft.Syntex** isn't registered as a resource provider in the subscription. The cmdlet sends a resource provider registration request on your behalf but it takes a few minutes to be completed. Wait 5-10 minutes and try again until the cmdlet succeeds.
+> If the preceding cmdlet fails with a SubscriptionNotRegistered error, it is because **Microsoft.Syntex** isn't registered as a resource provider in the subscription. The cmdlet sends a resource provider registration request on your behalf but it takes a few minutes to be completed. Wait 5-10 minutes and try again until the cmdlet succeeds.
 
 To update the billing profile for a standard container type, use the following cmdlet:
 

--- a/docs/embedded/getting-started/containertypes.md
+++ b/docs/embedded/getting-started/containertypes.md
@@ -1,7 +1,7 @@
 ---
 title: Create new SharePoint Embedded container types
 description: This article explains how container types work and the steps to create new container types.
-ms.date: 01/20/2026
+ms.date: 06/05/2026
 ms.localizationpriority: high
 ---
 
@@ -39,7 +39,9 @@ SharePoint Embedded has two different container types you can create.
 1. [Trial container type](#trial-container-type). Uses the `trial` billing classification.
 1. [Standard container type](#standard-container-types-nontrial). Uses the `standard` or `directToCustomer` billing classification.
 
-To create a container type, your Microsoft Entra ID application needs to have the `FileStorageContainerType.Manage.All` application permission on the owning tenant. Your Microsoft Entra ID application needs to call the [Create fileStorageContainerType](/graph/api/filestorage-post-containertypes) endpoint on behalf of a [SharePoint Embedded Administrator](/entra/identity/role-based-access-control/permissions-reference#sharepoint-embedded-administrator):
+To create a container type, your Microsoft Entra ID application needs the [`FileStorageContainerType.Manage.All`](/graph/permissions-reference#filestoragecontainertypemanageall) **delegated** Microsoft Graph permission. Application-only access isn't supported for this endpoint. The calling user must be a non-guest member of the owning tenant. Administrator roles aren't required. The calling user is automatically assigned as an owner of the new container type. For details on owner capabilities and how to manage owners, see [Container type owner capabilities](../development/auth.md#container-type-owner-capabilities).
+
+Call the [Create fileStorageContainerType](/graph/api/filestorage-post-containertypes) endpoint:
 
 ```http
 POST https://graph.microsoft.com/beta/storage/fileStorage/containerTypes
@@ -47,7 +49,7 @@ Content-Type: application/json
 
 {
   "name": "{ContainerTypeName}",
-  "owningAppId": "{ApplicationId}",
+  "owningApplicationId": "{ApplicationId}",
   "billingClassification": "{BillingClassification}",
   "settings": {
     ...
@@ -56,13 +58,13 @@ Content-Type: application/json
 ```
 
 > [!NOTE]
-> You need to replace:
+> Replace:
 >
 > - `{ContainerTypeName}` with a user-friendly name for your SharePoint Embedded application.
-> - `{ApplicationId}` with the ID of your properly configured application ID.
-> - `{BillingClassification}` with either `trial`, `standard`, or `directToCustomer`. Keep reading to understand what each means.
+> - `{ApplicationId}` with the ID of your properly configured application.
+> - `{BillingClassification}` with `trial`, `standard`, or `directToCustomer`. Keep reading to understand what each means.
 >
-> Additionally, you may [configure your container type](#configuring-container-types) during creation by using the `settings` field.
+> You can also [configure your container type](#configuring-container-types) during creation by setting the `settings` field.
 
 ## Trial container type
 
@@ -180,7 +182,7 @@ For information on all the settings supported by container types, see [fileStora
 
 ## Viewing container types
 
-The Developer Admin can view all the SharePoint Embedded container types they created on their tenant using the [List fileStorageContainerType](/graph/api/filestorage-list-containertypes) endpoint.
+You can list container types in your tenant by calling the [List fileStorageContainerType](/graph/api/filestorage-list-containertypes) endpoint. Results are filtered by ownership: non-administrator users see only the container types they have a permission on. [SharePoint Embedded Administrators](/entra/identity/role-based-access-control/permissions-reference#sharepoint-embedded-administrator) and [Global Administrators](/entra/identity/role-based-access-control/permissions-reference#global-administrator) see every container type in the tenant.
 
 ## Registering container types
 
@@ -188,5 +190,6 @@ To create and interact with containers, you must [register](../getting-started/r
 
 ## Deleting container types
 
-The Developer Admin can only delete trial container types in their tenant. Deletion of standard container types is not yet supported. To delete a container type, you must first remove all containers of that container type, including from the deleted container collection. To remove containers, refer to [Consuming Tenant Admin](../administration/consuming-tenant-admin/cta.md).
-Once all the containers are deleted, Developer admins can delete the container type using the [Delete fileStorageContainerType](/graph/api/filestorage-delete-containertypes) endpoint.
+You can only delete trial container types. Deletion of standard container types isn't yet supported. Before you delete a container type, you need to remove every container of that type, including from the deleted container collection. To remove containers, see [Consuming Tenant Admin](../administration/consuming-tenant-admin/cta.md).
+
+Once every container is deleted, call the [Delete fileStorageContainerType](/graph/api/filestorage-delete-containertypes) endpoint. Non-administrator users can delete only container types they have a permission on. [SharePoint Embedded Administrators](/entra/identity/role-based-access-control/permissions-reference#sharepoint-embedded-administrator) and [Global Administrators](/entra/identity/role-based-access-control/permissions-reference#global-administrator) can delete any trial container type.

--- a/docs/embedded/getting-started/containertypes.md
+++ b/docs/embedded/getting-started/containertypes.md
@@ -1,7 +1,7 @@
 ---
 title: Create new SharePoint Embedded container types
 description: This article explains how container types work and the steps to create new container types.
-ms.date: 06/05/2026
+ms.date: 06/11/2026
 ms.localizationpriority: high
 ---
 
@@ -49,7 +49,7 @@ Content-Type: application/json
 
 {
   "name": "{ContainerTypeName}",
-  "owningApplicationId": "{ApplicationId}",
+  "owningAppId": "{ApplicationId}",
   "billingClassification": "{BillingClassification}",
   "settings": {
     ...

--- a/docs/embedded/whats-new.md
+++ b/docs/embedded/whats-new.md
@@ -1,7 +1,7 @@
 ---
 title: What's new in SharePoint Embedded?
 description: Updates about Microsoft SharePoint Embedded.
-ms.date: 06/05/2026
+ms.date: 06/04/2025
 ms.localizationpriority: medium
 ---
 

--- a/docs/embedded/whats-new.md
+++ b/docs/embedded/whats-new.md
@@ -1,11 +1,15 @@
 ---
 title: What's new in SharePoint Embedded?
 description: Updates about Microsoft SharePoint Embedded.
-ms.date: 06/04/2025
+ms.date: 06/05/2026
 ms.localizationpriority: medium
 ---
 
 # What's new in SharePoint Embedded
+
+## June 2026
+
+- The [`FileStorageContainerType.Manage.All`](/graph/permissions-reference#filestoragecontainertypemanageall) Microsoft Graph permission no longer requires the [SharePoint Embedded Administrator](./administration/adminrole.md) or [Global Administrator](/entra/identity/role-based-access-control/permissions-reference#global-administrator) role. Any non-guest user in the owning tenant can [create a container type](./getting-started/containertypes.md#creating-container-types) and is automatically assigned as an [owner of that container type](./development/auth.md#container-type-owner-capabilities).
 
 ## March 2026
 


### PR DESCRIPTION
## Category

- Content fix

## Related issues

- n/a

## What's in this Pull Request?

Updates SharePoint Embedded container type docs to reflect that `FileStorageContainerType.Manage.All` no longer requires the SharePoint Embedded Administrator or Global Administrator role. Any non-guest user in the owning tenant can now create a container type and is automatically assigned as an owner.

- `docs/embedded/getting-started/containertypes.md`  rewrote *Creating*, *Viewing*, and *Deleting* sections to reflect the new ownership-based authorization model; fixed `owningAppId`  `owningApplicationId` typo in the request body example
- `docs/embedded/administration/developer-admin/dev-admin.md`  added a note distinguishing the PowerShell path (admin required) from the Microsoft Graph path (no admin required)
- `docs/embedded/development/auth.md`  minor phrasing fix in *Container type owner capabilities* per reviewer feedback
- `docs/embedded/whats-new.md`  added June 2026 entry

### Related documentation PRs

- AD-Aggregator [PR 13698352](https://msazure.visualstudio.com/One/_git/AD-AggregatorService-Workloads/pullrequest/13698352)  Graph API spec describing the authorization model change
- The [`FileStorageContainerType.Manage.All` description in the Microsoft Graph permissions reference](https://learn.microsoft.com/graph/permissions-reference#filestoragecontainertypemanageall) still mentions the admin requirement and will need a follow-up update in the Graph docs repo.