### PR TITLE
Optimize SPFx release pages for agentic upgrade workflows

### DIFF
--- a/docs/spfx/release-0.0.0.md.template
+++ b/docs/spfx/release-0.0.0.md.template
@@ -29,7 +29,18 @@ In the project's **package.json** file, identify all SPFx vTODO: {version-previo
     npm install @microsoft/{spfx-package-name}@TODO: {version-release}.0 --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion TODO: {version-release} --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.0.0.md
+++ b/docs/spfx/release-1.0.0.md
@@ -28,7 +28,18 @@ In the project's **package.json** file, identify all SPFx pre-v1 packages. For e
     npm install @microsoft/{spfx-package-name}@1.0.0.0 --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.0.0 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.1.0.md
+++ b/docs/spfx/release-1.1.0.md
@@ -28,7 +28,18 @@ In the project's **package.json** file, identify all SPFx v1.0 packages. For eac
     npm install @microsoft/{spfx-package-name}@1.1.0 --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.1 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.10.0.md
+++ b/docs/spfx/release-1.10.0.md
@@ -28,7 +28,18 @@ In the project's **package.json** file, identify all SPFx v1.9.1 packages. For e
     npm install @microsoft/{spfx-package-name}@1.10.0 --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.10.0 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.11.0.md
+++ b/docs/spfx/release-1.11.0.md
@@ -33,7 +33,18 @@ In the project's **package.json** file, identify all SPFx v1.10 packages. For ea
 > [!IMPORTANT]
 > Be sure you update the **package-solution.json** with the new developers information as described in the article [Docs: SharePoint Framework toolchain - Update developer information](toolchain/sharepoint-framework-toolchain.md). Not providing such information will generate an error during gulp package-solution process.
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.11.0 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.12.1.md
+++ b/docs/spfx/release-1.12.1.md
@@ -28,7 +28,18 @@ In the project's **package.json** file, identify all SPFx v1.11.0 packages. For 
     npm install @microsoft/{spfx-package-name}@1.12.1 --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.12.1 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.13.0.md
+++ b/docs/spfx/release-1.13.0.md
@@ -28,7 +28,18 @@ In the project's **package.json** file, identify all SPFx v1.12.1 packages. For 
     npm install @microsoft/{spfx-package-name}@1.13.0 --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.13 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.13.1.md
+++ b/docs/spfx/release-1.13.1.md
@@ -28,7 +28,18 @@ In the project's **package.json** file, identify all SPFx v1.13 packages. For ea
     npm install @microsoft/{spfx-package-name}@1.13.1 --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.13.1 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## Changes in this release
 

--- a/docs/spfx/release-1.14.0.md
+++ b/docs/spfx/release-1.14.0.md
@@ -28,7 +28,18 @@ In the project's **package.json** file, identify all SPFx v1.13.1 packages. For 
     npm install @microsoft/{spfx-package-name}@1.14.0 --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.14 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.15.0.md
+++ b/docs/spfx/release-1.15.0.md
@@ -36,7 +36,18 @@ In the project's **package.json** file, identify all SPFx v1.14 packages. For ea
     npm install @microsoft/{spfx-package-name}@latest --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.15 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.15.2.md
+++ b/docs/spfx/release-1.15.2.md
@@ -36,7 +36,18 @@ In the project's **package.json** file, identify all SPFx v1.15.0 packages. For 
     npm install @microsoft/{spfx-package-name}@latest --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.15.2 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.16.0.md
+++ b/docs/spfx/release-1.16.0.md
@@ -36,7 +36,18 @@ In the project's **package.json** file, identify all SPFx v1.15.2 packages. For 
     npm install @microsoft/{spfx-package-name}@latest --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.16 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.16.1.md
+++ b/docs/spfx/release-1.16.1.md
@@ -36,7 +36,18 @@ In the project's **package.json** file, identify all SPFx v1.16 packages. For ea
     npm install @microsoft/{spfx-package-name}@latest --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.16.1 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.17.0.md
+++ b/docs/spfx/release-1.17.0.md
@@ -36,7 +36,18 @@ In the project's **package.json** file, identify all SPFx v1.16.1 packages. For 
     npm install @microsoft/{spfx-package-name}@latest --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.17 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.17.1.md
+++ b/docs/spfx/release-1.17.1.md
@@ -39,7 +39,18 @@ In the project's **package.json** file, identify all SPFx v1.17 packages. For ea
     npm install @microsoft/{spfx-package-name}@latest --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.17.1 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## Fixed Issues
 

--- a/docs/spfx/release-1.17.2.md
+++ b/docs/spfx/release-1.17.2.md
@@ -40,7 +40,18 @@ npm install @microsoft/generator-sharepoint@latest --global
         npm install @microsoft/{spfx-package-name}@latest --save --save-exact
         ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.17.2 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## Fixed Issues
 

--- a/docs/spfx/release-1.17.3.md
+++ b/docs/spfx/release-1.17.3.md
@@ -40,7 +40,18 @@ npm install @microsoft/generator-sharepoint@latest --global
         npm install @microsoft/{spfx-package-name}@latest --save --save-exact
         ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.17.3 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## Fixed Issues
 

--- a/docs/spfx/release-1.17.4.md
+++ b/docs/spfx/release-1.17.4.md
@@ -40,7 +40,18 @@ npm install @microsoft/generator-sharepoint@latest --global
         npm install @microsoft/{spfx-package-name}@latest --save --save-exact
         ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.17.4 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.18.0.md
+++ b/docs/spfx/release-1.18.0.md
@@ -36,7 +36,18 @@ In the project's **package.json** file, identify all SPFx v1.17.x packages. For 
     npm install @microsoft/{spfx-package-name}@latest --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.18 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.18.1.md
+++ b/docs/spfx/release-1.18.1.md
@@ -36,7 +36,18 @@ In the project's **package.json** file, identify all SPFx packages. For each SPF
     npm install @microsoft/{spfx-package-name}@1.18.1 --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.18.1 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.18.2.md
+++ b/docs/spfx/release-1.18.2.md
@@ -36,7 +36,18 @@ In the project's **package.json** file, identify all SPFx packages. For each SPF
     npm install @microsoft/{spfx-package-name}@latest --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.18.2 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.19.0.md
+++ b/docs/spfx/release-1.19.0.md
@@ -36,7 +36,18 @@ In the project's **package.json** file, identify all SPFx v1.18.x packages. For 
     npm install @microsoft/{spfx-package-name}@latest --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.19 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.20.0.md
+++ b/docs/spfx/release-1.20.0.md
@@ -36,7 +36,18 @@ In the project's **package.json** file, identify all SPFx v1.19 packages. For ea
     npm install @microsoft/{spfx-package-name}@latest --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.20 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.21.0.md
+++ b/docs/spfx/release-1.21.0.md
@@ -39,7 +39,18 @@ In the project's **package.json** file, identify all SPFx v1.20 packages. For ea
     npm install @microsoft/{spfx-package-name}@latest --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.21 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.21.1.md
+++ b/docs/spfx/release-1.21.1.md
@@ -39,7 +39,18 @@ In the project's **package.json** file, identify all SPFx v1.21 packages. For ea
     npm install @microsoft/{spfx-package-name}@latest --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.21.1 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## Fixed Issues
 

--- a/docs/spfx/release-1.22.0.md
+++ b/docs/spfx/release-1.22.0.md
@@ -25,17 +25,26 @@ npm install @microsoft/generator-sharepoint@latest --global
 
 ## Upgrading projects from the SPFx v1.21.1 to v1.22.0 version
 
-The upgrade steps required to convert a [gulp-based toolchain](toolchain/sharepoint-framework-toolchain.md) SPFx project to the [Heft-based toolchain](toolchain/sharepoint-framework-toolchain-rushstack-heft.md) are detailed in the following article: [Migrate from the Gulp Toolchain to Heft Toolchain](toolchain/migrate-gulptoolchain-hefttoolchain.md).
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.22.0 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
+
+For an overview of what changes during this migration from the [Gulp-based toolchain](toolchain/sharepoint-framework-toolchain.md) to the [Heft-based toolchain](toolchain/sharepoint-framework-toolchain-rushstack-heft.md), see: [Migrate from the Gulp Toolchain to Heft Toolchain](toolchain/migrate-gulptoolchain-hefttoolchain.md).
 
 ## New features and capabilities
 
 ### Transitioning from Gulp-based toolchain to the Heft-based toolchain
 
-Starting with SPFx v1.22.0, new projects use Heft as the build task orchestrator instead of a [gulp-based toolchain](./toolchain/sharepoint-framework-toolchain.md) used in SPFx v1.0 - v1.21.1 releases. This change represents a fundamental shift in how SPFx projects are built, configured, and customized, though the underlying bundling technology (webpack) remains the same.
-
-See more details on this upcoming change from the following documentation:
-
-- [Heft-based toolchain (SPFx v1.22.0+)](./toolchain/sharepoint-framework-toolchain-rushstack-heft.md)
+Starting with SPFx v1.22.0, new projects use Heft as the build task orchestrator instead of the gulp-based toolchain used in SPFx v1.0 - v1.21.1 releases. This change represents a fundamental shift in how SPFx projects are built, configured, and customized, though the underlying bundling technology (webpack) remains the same.
 
 ### Addressing npm audit issues
 

--- a/docs/spfx/release-1.22.1.md
+++ b/docs/spfx/release-1.22.1.md
@@ -39,7 +39,18 @@ In the project's **package.json** file, identify all SPFx v1.22 packages. For ea
     npm install @microsoft/{spfx-package-name}@latest --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.22.1 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## Fixed Issues
 

--- a/docs/spfx/release-1.22.2.md
+++ b/docs/spfx/release-1.22.2.md
@@ -39,7 +39,18 @@ In the project's **package.json** file, identify all SPFx v1.22 packages. For ea
     npm install @microsoft/{spfx-package-name}@latest --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.22.2 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## Fixed Issues
 

--- a/docs/spfx/release-1.23.0.md
+++ b/docs/spfx/release-1.23.0.md
@@ -24,6 +24,19 @@ npm install @microsoft/generator-sharepoint@latest --global
 
 If you are upgrading from older than 1.22 version, please follow the upgrade steps required to convert a [gulp-based toolchain](toolchain/sharepoint-framework-toolchain.md) SPFx project to the [Heft-based toolchain](toolchain/sharepoint-framework-toolchain-rushstack-heft.md) are detailed in the following article: [Migrate from the Gulp Toolchain to Heft Toolchain](toolchain/migrate-gulptoolchain-hefttoolchain.md).
 
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.23.0 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
+
 ## New features and capabilities
 
 ### Grouping support for list view command sets

--- a/docs/spfx/release-1.23.2.md
+++ b/docs/spfx/release-1.23.2.md
@@ -39,7 +39,18 @@ In the project's **package.json** file, identify all SPFx v1.23.0 packages. For 
     npm install @microsoft/{spfx-package-name}@latest --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.23.2 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 
 ## Readiness for list panel override

--- a/docs/spfx/release-1.3.0.md
+++ b/docs/spfx/release-1.3.0.md
@@ -28,7 +28,18 @@ In the project's **package.json** file, identify all SPFx v1.1 packages. For eac
     npm install @microsoft/{spfx-package-name}@1.3.0 --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.3 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.4.0.md
+++ b/docs/spfx/release-1.4.0.md
@@ -26,7 +26,18 @@ In the project's **package.json** file, identify all SPFx v1.3 packages. For eac
     npm install @microsoft/{spfx-package-name}@1.4.0 --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.4 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.4.1.md
+++ b/docs/spfx/release-1.4.1.md
@@ -26,7 +26,18 @@ In the project's **package.json** file, identify all SPFx v1.4 packages. For eac
     npm install @microsoft/{spfx-package-name}@1.4.1.0 --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.4.1 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.5.0.md
+++ b/docs/spfx/release-1.5.0.md
@@ -49,7 +49,18 @@ Key changes are around the introduction of the new *plusbeta* model and many oth
     }
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.5 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.5.1.md
+++ b/docs/spfx/release-1.5.1.md
@@ -28,7 +28,18 @@ In the project's **package.json** file, identify all SPFx v1.5 packages. For eac
     npm install @microsoft/{spfx-package-name}@1.5.1 --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.5.1 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## Changes in this release
 

--- a/docs/spfx/release-1.6.0.md
+++ b/docs/spfx/release-1.6.0.md
@@ -31,7 +31,18 @@ In the project's **package.json** file, identify all SPFx v1.5.1 packages. For e
     npm install @microsoft/{spfx-package-name}@1.6.0 --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.6 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.7.0.md
+++ b/docs/spfx/release-1.7.0.md
@@ -28,7 +28,18 @@ In the project's **package.json** file, identify all SPFx v1.6 packages. For eac
     npm install @microsoft/{spfx-package-name}@1.7.0 --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.7 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.7.1.md
+++ b/docs/spfx/release-1.7.1.md
@@ -28,7 +28,18 @@ In the project's **package.json** file, identify all SPFx v1.7 packages. For eac
     npm install @microsoft/{spfx-package-name}@1.7.1.0 --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.7.1 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## Changes in this release
 

--- a/docs/spfx/release-1.8.0.md
+++ b/docs/spfx/release-1.8.0.md
@@ -51,7 +51,18 @@ We'll release more updated documentation and guidance videos during upcoming day
 
 1. Fix all the new and interesting tslint errors that are now getting raised with a newer compiler. For large projects, this might take a while. The default behavior of the TypeScript compilers is getting stricter, but your code will be the better for it.
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.8.0 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/release-1.8.1.md
+++ b/docs/spfx/release-1.8.1.md
@@ -28,7 +28,18 @@ In the project's **package.json** file, identify all SPFx v1.8.0 packages. For e
     npm install @microsoft/{spfx-package-name}@1.8.1.0 --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.8.1 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## Changes in this release
 

--- a/docs/spfx/release-1.8.2.md
+++ b/docs/spfx/release-1.8.2.md
@@ -28,7 +28,18 @@ In the project's **package.json** file, identify all SPFx v1.8.1 packages. For e
     npm install @microsoft/{spfx-package-name}@1.8.2.0 --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.8.2 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## Changes in this release
 

--- a/docs/spfx/release-1.9.1.md
+++ b/docs/spfx/release-1.9.1.md
@@ -28,7 +28,18 @@ In the project's **package.json** file, identify all SPFx v1.8.2 packages. For e
     npm install @microsoft/{spfx-package-name}@1.9.1.0 --save --save-exact
     ```
 
-[!INCLUDE [spfx-release-upgrade-tip](../../includes/snippets/spfx-release-upgrade-tip.md)]
+[!INCLUDE [spfx-release-upgrade-warning](../../includes/snippets/spfx-release-upgrade-warning.md)]
+
+> [!TIP]
+> To upgrade this project, run:
+>
+> ```console
+> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.9.1 --output md
+> ```
+>
+> This analyzes your project and outputs all required changes, including a single script to apply them in one go.
+
+[!INCLUDE [pnp-o365cli](../../includes/snippets/open-source/pnp-o365cli.md)]
 
 ## New features and capabilities
 

--- a/docs/spfx/toolchain/migrate-gulptoolchain-hefttoolchain-manual.md
+++ b/docs/spfx/toolchain/migrate-gulptoolchain-hefttoolchain-manual.md
@@ -1,0 +1,227 @@
+---
+title: Migrate from the Gulp-based to the Heft-based Toolchain Manually
+description: In this article, you'll learn how to manually migrate an existing SharePoint Framework v1.21.1 project based on the legacy Gulp-based build toolchain to the Heft-based build toolchain introduced in SPFx v1.22.\*.
+ms.date: 07/14/2026
+ms.localizationpriority: high
+---
+# Migrate from the Gulp-based to the Heft-based Toolchain
+
+The migration steps in moving from a Gulp-based toolchain SharePoint Framework (SPFx) project to a Heft-based toolchain are more involved than a typical SPFx project upgrade from one version to another version.
+
+> [!NOTE]
+> This article covers the manual steps to migrate an existing SharePoint Framework v1.21.1 project based on the legacy Gulp-based build toolchain to the Heft-based build toolchain introduced in SPFx v1.22.\*. You can also perform the same task using the CLI for Microsoft 365 that is covered in this article: [Migrate from the Gulp-based to the Heft-based Toolchain](migrate-gulptoolchain-hefttoolchain.md).
+
+In this article, you'll walk through in detail the manual steps required for removing the Gulp toolchain from a SPFx version v1.21.1 project and adding the Heft-based toolchain as part of the upgrade to an SPFx v1.22.\* project.
+
+> [!IMPORTANT]
+> **This article assumes that you are upgrading an existing SPFx v1.21.1 React web part project.**
+>
+> The steps for upgrading other types of projects, such as those not using React, using SPFx extensions, or SPFx Adaptive Card Extensions instead of web parts are similar to the steps in this article.
+
+> [!TIP]
+> The steps in this page involve making numerous and significant changes to to your project. Before proceeding, strongly consider making a copy of your project or, if it's in source control, to start with a clean state (ie: no unstaged files).
+
+## Uninstall Gulp toolchain dependencies
+
+Start by first uninstalling the gulp-based toolchain packages from your project.
+
+```console
+npm uninstall @microsoft/sp-build-web ajv gulp
+```
+
+Next, uninstall the **@microsoft/rush-stack-compiler-\*** which maps to the current version of TypeScript that your project currently uses.
+
+For instance, the default SPFx v1.21.1 project uses TypeScript v5.3, so you would uninstall the **@microsoft/rush-stack-compiler-5.3** package:
+
+```console
+npm uninstall @microsoft/rush-stack-compiler-5.3
+```
+
+If you're using a different version of TypeScript, make sure that you uninstall the **@microsoft/rush-stack-compiler-\*** package with the TypeScript version in the name of the **@microsoft/rush-stack-compiler-\*** package.
+
+## Install Heft toolchain dependencies
+
+The next step is to install all of the dependencies the Heft-based toolchain requires:
+
+```console
+npm install @microsoft/spfx-web-build-rig@1.22.1 \
+            @microsoft/spfx-heft-plugins@1.22.1 \
+            @microsoft/eslint-config-spfx@1.22.1 \
+            @microsoft/eslint-plugin-spfx@1.22.1 \
+            @microsoft/sp-module-interfaces@1.22.1 \
+            @rushstack/eslint-config@4.5.2 \
+            @rushstack/heft@1.1.2 \
+            @types/heft-jest@1.0.2 \
+            @typescript-eslint/parser@8.46.2 \
+            --save-dev --save-exact --force
+```
+
+## Optionally upgrade TypeScript
+
+The Heft-based SPFx toolchain supports any version of TypeScript supported by the [Heft TypeScript Plugin](https://heft.rushstack.io/pages/plugins/typescript/) that toolchain is using.
+
+> [!TIP]
+> The **[loadTypeScriptTool.ts](https://github.com/microsoft/rushstack/blob/main/heft-plugins/heft-typescript-plugin/src/loadTypeScriptTool.ts)** file defines the TypeScript supported versions by the plugin. Ensure you are looking at the correct version of the plugin when considering the version of TypeScript to install.
+
+```console
+npm install typescript@~5.8.0 --save-dev
+```
+
+## Update the ESLint configuration
+
+Next, modify the default ESLint configuration for your project.
+
+Open the **./eslintrc.js** file and locate the following line:
+
+```javascript
+'@rushstack/hoist-jest-mock': 1,
+```
+
+Add the following immediately after that line:
+
+```javascript
+// Require chunk names for dynamic imports in SPFx projects. https://www.npmjs.com/package/@rushstack/eslint-plugin
+'@rushstack/import-requires-chunk-name': 1,
+// Ensure that React components rendered with ReactDOM.render() are unmounted with ReactDOM.unmountComponentAtNode(). https://www.npmjs.com/package/@rushstack/eslint-plugin
+'@rushstack/pair-react-dom-render-unmount': 1,
+```
+
+Then locate the following two rules and delete them:
+
+```javascript
+'@microsoft/spfx/import-requires-chunk-name': 1,
+
+'@microsoft/spfx/pair-react-dom-render-unmount': 1
+```
+
+## Update npm scripts in package.json
+
+Replace the existing `build`, `test`, and `clean` scripts in the **package.json** file with the following to use Heft instead of Gulp.
+
+```json
+{
+  ..
+  "scripts": {
+    "build": "heft build --clean",
+    "clean": "heft clean",
+    "test": "heft test"
+  }
+  ..
+}
+```
+
+### Optionally add additional scripts to package.json
+
+The project templates created for SPFx v1.22 include additional scripts to the **package.json** file. While these are optional, you can add them to your project's **package.json** to match the default projects:
+
+```json
+{
+  ..
+  "scripts": {
+    ..
+    "build": "heft test --clean --production && heft package-solution --production",
+    "start": "heft start --clean",
+    "clean": "heft clean",
+    "eject-webpack": "heft eject-webpack"
+  }
+  ..
+}
+```
+
+> [!TIP]
+> While not required, we recommend installing the Heft CLI globally:
+>
+> ```console
+> npm install @rushstack/heft --global
+> ```
+>
+> Once the Heft CLI is installed globally, you can run Heft commands without using the npm scripts.
+
+## Add the SPFx Heft rig to the project
+
+With the Heft toolchain now installed after removing the Gulp toolchain, the next step is to add a reference to the SPFx build rig. This is done by adding a new file to your project's configuration folder. That will reference the rig that the project will use.
+
+Add a new file, **./config/rig.json**, to your project with the following contents:
+
+```json
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/rig-package/rig.schema.json",
+  "rigPackageName": "@microsoft/spfx-web-build-rig"
+}
+```
+
+## Replace the Sass configuration file
+
+Replace the entire contents of the existing **./config/sass.json** file with the following to use the Heft Sass configuration in the SPFx Heft rig. This is where you can modify the default settings on the [Heft Sass Plugin](https://heft.rushstack.io/pages/plugins/sass/):
+
+```json
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/heft/v0/heft-sass-plugin.schema.json",
+  "extends": "@microsoft/spfx-web-build-rig/profiles/default/config/sass.json"
+}
+```
+
+## Add the Heft TypeScript Plugin configuration
+
+Add a new file, **./config/typescript.json**, to your project with the following code. This configures the [Heft TypeScript Plugin](https://heft.rushstack.io/pages/plugins/typescript/) used in the SPFx Heft rig:
+
+```json
+{
+  "extends": "@microsoft/spfx-web-build-rig/profiles/default/config/typescript.json",
+  "staticAssetsToCopy": {
+    "fileExtensions": [".resx", ".jpg", ".png", ".woff", ".eot", ".ttf", ".svg", ".gif"],
+    "includeGlobs": ["webparts/*/loc/*.js"]
+  }
+}
+```
+
+## Replace the TypeScript compiler configuration
+
+Replace the contents of the existing **./tsconfig.json** file with the following code. This assumes the same TypeScript configuration as the SPFx Heft rig's TypeScript configuration.
+
+```json
+{
+  "extends": "./node_modules/@microsoft/spfx-web-build-rig/profiles/default/tsconfig-base.json"
+}
+```
+
+## Delete gulpfile.js
+
+Delete the **./gulpfile.js** file from your project as it is no longer used.
+
+> [!TIP]
+> If you've made changes to your **gulpfile.js**, you may want to keep it until you've migrated those changes to the equivalent Heft extensibility options. Learn more about customizing the Heft-based toolchain: [Customizing the Heft-based build toolchain](customize-heft-toolchain-overview.md#customizing-the-heft-based-build-toolchain).
+
+## Upgrade production dependencies
+
+Finally, upgrade the production dependencies in the project to SPFx v1.22:
+
+```console
+npm install @microsoft/sp-component-base@1.22.1 \
+            @microsoft/sp-core-library@1.22.1 \
+            @microsoft/sp-lodash-subset@1.22.1 \
+            @microsoft/sp-office-ui-fabric-core@1.22.1 \
+            @microsoft/sp-property-pane@1.22.1 \
+            @microsoft/sp-webpart-base@1.22.1 \
+            --save-exact
+```
+
+> [!TIP]
+> After making so many changes to the packages, consider deleting the **node_modules** and **./package-lock.json** (*or the equivalent lock file for the package manager you use*) and then re-running `npm install`. This ensures you will have a clean dependency tree.
+
+## Test the project migration to the Heft-based toolchain
+
+Test your changes by running the **build** command in the console from the root of your project.
+
+```console
+# if you have heft installed globally...
+heft build --production
+
+# ... or you can run the npm helper script
+npm run build
+```
+
+## See also
+
+- [SharePoint Framework Toolchain: Rush Stack, Heft, and Webpack](sharepoint-framework-toolchain-rushstack-heft.md)
+- [Customize the Heft-based SPFx Toolchain](./customize-heft-toolchain-overview.md)

--- a/docs/spfx/toolchain/migrate-gulptoolchain-hefttoolchain.md
+++ b/docs/spfx/toolchain/migrate-gulptoolchain-hefttoolchain.md
@@ -3,6 +3,7 @@ title: Migrate from the Gulp-based to the Heft-based Toolchain
 description: Learn what changes when migrating a SharePoint Framework project from the Gulp-based build toolchain to the Heft-based build toolchain introduced in SPFx v1.22, and how to perform the migration using CLI for Microsoft 365.
 ms.date: 12/30/2025
 ms.localizationpriority: high
+ai-usage: ai-assisted
 ---
 # Migrate from the Gulp-based to the Heft-based Toolchain
 

--- a/docs/spfx/toolchain/migrate-gulptoolchain-hefttoolchain.md
+++ b/docs/spfx/toolchain/migrate-gulptoolchain-hefttoolchain.md
@@ -9,7 +9,7 @@ ms.localizationpriority: high
 SPFx v1.22 introduced a new Heft-based build toolchain, replacing the Gulp-based toolchain used in SPFx v1.0–v1.21.1. This article explains what changes during the migration and how to perform it.
 
 > [!IMPORTANT]
-> This migration involves changes across more than 12 files including package removals, new package installations, configuration file replacements, new file creation, ESLint rule changes, and build script rewrites. Do not attempt to perform these changes manually — use the CLI for Microsoft 365 to generate the complete set of changes for your project.
+> This migration involves changes across more than 12 files including package removals, new package installations, configuration file replacements, new file creation, ESLint rule changes, and build script rewrites. Don't attempt to perform these changes manually — use the CLI for Microsoft 365 to generate the complete set of changes for your project.
 
 > [!TIP]
 > Use the [CLI for Microsoft 365 spfx project upgrade](https://pnp.github.io/cli-microsoft365/cmd/spfx/project/project-upgrade/) command to perform this migration automatically. It handles upgrades across any version gap — not just from v1.21.1 — by detecting your current version and generating the precise changes needed for your project. The report includes a single script to apply all changes in one go. See the [release notes](../release-1.22.2.md) for your target version for the specific command to run.
@@ -42,13 +42,13 @@ A new `config/rig.json` file is added to point the project at the `@microsoft/sp
 
 ### Removed files
 
-The `gulpfile.js` and `src/index.ts` files are removed as they are no longer needed by the Heft-based build system.
+The `gulpfile.js` and `src/index.ts` files are removed as they're no longer needed by the Heft-based build system.
 
 ### Production dependencies
 
 All `@microsoft/sp-*` packages in `dependencies` are updated to the target SPFx version.
 
-## How to perform the migration
+## How to do the migration
 
 Run the following command from the root of your project to generate a complete upgrade report:
 
@@ -56,7 +56,7 @@ Run the following command from the root of your project to generate a complete u
 npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.22.2 --output md
 ```
 
-The report lists every required change and includes a consolidated script at the end that applies all changes in a single execution. Review the report, then run the script to complete the migration.
+The report lists every required change and includes a combined script at the end that applies all changes in a single execution. Review the report, then run the script to complete the migration.
 
 ## Verify the migration
 
@@ -70,3 +70,4 @@ npm run build
 
 - [SharePoint Framework Toolchain: Rush Stack, Heft, and Webpack](sharepoint-framework-toolchain-rushstack-heft.md)
 - [Customize the Heft-based SPFx Toolchain](./customize-heft-toolchain-overview.md)
+- [Migrate from the Gulp-based to the Heft-based Toolchain Manually](migrate-gulptoolchain-hefttoolchain-manual.md)

--- a/docs/spfx/toolchain/migrate-gulptoolchain-hefttoolchain.md
+++ b/docs/spfx/toolchain/migrate-gulptoolchain-hefttoolchain.md
@@ -1,220 +1,68 @@
 ---
 title: Migrate from the Gulp-based to the Heft-based Toolchain
-description: In this article, you'll learn how to migrate an existing SharePoint Framework v1.21.1 project based on the legacy Gulp-based build toolchain to the Heft-based build toolchain introduced in SPFx v1.22.\*.
+description: Learn what changes when migrating a SharePoint Framework project from the Gulp-based build toolchain to the Heft-based build toolchain introduced in SPFx v1.22, and how to perform the migration using CLI for Microsoft 365.
 ms.date: 12/30/2025
 ms.localizationpriority: high
 ---
 # Migrate from the Gulp-based to the Heft-based Toolchain
 
-The migration steps in moving from a Gulp-based toolchain SharePoint Framework (SPFx) project to a Heft-based toolchain are more involved than a typical SPFx project upgrade from one version to another version.
-
-In this article, you'll walk through in detail all of the steps required for removing the Gulp toolchain from a SPFx version v1.21.1 project and adding the Heft-based toolchain as part of the upgrade to an SPFx v1.22.\* project.
+SPFx v1.22 introduced a new Heft-based build toolchain, replacing the Gulp-based toolchain used in SPFx v1.0–v1.21.1. This article explains what changes during the migration and how to perform it.
 
 > [!IMPORTANT]
-> **This article assumes that you are upgrading an existing SPFx v1.21.1 React web part project.**
->
-> The steps for upgrading other types of projects, such as those not using React, using SPFx extensions, or SPFx Adaptive Card Extensions instead of web parts are similar to the steps in this article.
+> This migration involves changes across more than 12 files including package removals, new package installations, configuration file replacements, new file creation, ESLint rule changes, and build script rewrites. Do not attempt to perform these changes manually — use the CLI for Microsoft 365 to generate the complete set of changes for your project.
 
 > [!TIP]
-> The steps in this page involve making numerous and significant changes to to your project. Before proceeding, strongly consider making a copy of your project or, if it's in source control, to start with a clean state (ie: no unstaged files).
+> Use the [CLI for Microsoft 365 spfx project upgrade](https://pnp.github.io/cli-microsoft365/cmd/spfx/project/project-upgrade/) command to perform this migration automatically. It handles upgrades across any version gap — not just from v1.21.1 — by detecting your current version and generating the precise changes needed for your project. The report includes a single script to apply all changes in one go. See the [release notes](../release-1.22.2.md) for your target version for the specific command to run.
 
-## Uninstall Gulp toolchain dependencies
+[!INCLUDE [pnp-o365cli](../../../includes/snippets/open-source/pnp-o365cli.md)]
 
-Start by first uninstalling the gulp-based toolchain packages from your project.
+## What changes in this migration
 
-```console
-npm uninstall @microsoft/sp-build-web ajv gulp
-```
+The following areas of your project are affected when migrating from the Gulp-based toolchain to the Heft-based toolchain:
 
-Next, uninstall the **@microsoft/rush-stack-compiler-\*** which maps to the current version of TypeScript that your project currently uses.
+### Build toolchain packages
 
-For instance, the default SPFx v1.21.1 project uses TypeScript v5.3, so you would uninstall the **@microsoft/rush-stack-compiler-5.3** package:
+The Gulp-based packages (`@microsoft/sp-build-web`, `ajv`, `gulp`, and `@microsoft/rush-stack-compiler-*`) are removed and replaced with Heft-based equivalents (`@microsoft/spfx-web-build-rig`, `@microsoft/spfx-heft-plugins`, `@rushstack/heft`, `@typescript-eslint/parser`, and `@types/heft-jest`).
 
-```console
-npm uninstall @microsoft/rush-stack-compiler-5.3
-```
+### TypeScript configuration
 
-If you're using a different version of TypeScript, make sure that you uninstall the **@microsoft/rush-stack-compiler-\*** package with the TypeScript version in the name of the **@microsoft/rush-stack-compiler-\*** package.
+The existing `tsconfig.json` with its full `compilerOptions` block is replaced with a minimal file that extends the SPFx build rig's base TypeScript configuration. A new `config/typescript.json` file is added to configure static asset copying for the Heft TypeScript plugin.
 
-## Install Heft toolchain dependencies
+### Build scripts
 
-The next step is to install all of the dependencies the Heft-based toolchain requires:
+The `scripts` change from Gulp commands (`gulp bundle`, `gulp clean`, `gulp test`) to Heft commands (`heft build`, `heft clean`, `heft start`).
 
-```console
-npm install @microsoft/spfx-web-build-rig@1.22.1 \
-            @microsoft/spfx-heft-plugins@1.22.1 \
-            @microsoft/eslint-config-spfx@1.22.1 \
-            @microsoft/eslint-plugin-spfx@1.22.1 \
-            @microsoft/sp-module-interfaces@1.22.1 \
-            @rushstack/eslint-config@4.5.2 \
-            @rushstack/heft@1.1.2 \
-            @types/heft-jest@1.0.2 \
-            @typescript-eslint/parser@8.46.2 \
-            --save-dev --save-exact --force
-```
+### ESLint rules
 
-## Optionally upgrade TypeScript
+Two ESLint rules move from the `@microsoft/spfx/` namespace to the `@rushstack/` namespace: `import-requires-chunk-name` and `pair-react-dom-render-unmount`.
 
-The Heft-based SPFx toolchain supports any version of TypeScript supported by the [Heft TypeScript Plugin](https://heft.rushstack.io/pages/plugins/typescript/) that toolchain is using.
+### Configuration files
 
-> [!TIP]
-> The **[loadTypeScriptTool.ts](https://github.com/microsoft/rushstack/blob/main/heft-plugins/heft-typescript-plugin/src/loadTypeScriptTool.ts)** file defines the TypeScript supported versions by the plugin. Ensure you are looking at the correct version of the plugin when considering the version of TypeScript to install.
+A new `config/rig.json` file is added to point the project at the `@microsoft/spfx-web-build-rig` shared configuration package. The existing `config/sass.json` is updated to use the Heft SASS plugin schema and extend the rig's default SASS configuration.
+
+### Removed files
+
+The `gulpfile.js` and `src/index.ts` files are removed as they are no longer needed by the Heft-based build system.
+
+### Production dependencies
+
+All `@microsoft/sp-*` packages in `dependencies` are updated to the target SPFx version.
+
+## How to perform the migration
+
+Run the following command from the root of your project to generate a complete upgrade report:
 
 ```console
-npm install typescript@~5.8.0 --save-dev
+npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.22.2 --output md
 ```
 
-## Update the ESLint configuration
+The report lists every required change and includes a consolidated script at the end that applies all changes in a single execution. Review the report, then run the script to complete the migration.
 
-Next, modify the default ESLint configuration for your project.
+## Verify the migration
 
-Open the **./eslintrc.js** file and locate the following line:
-
-```javascript
-'@rushstack/hoist-jest-mock': 1,
-```
-
-Add the following immediately after that line:
-
-```javascript
-// Require chunk names for dynamic imports in SPFx projects. https://www.npmjs.com/package/@rushstack/eslint-plugin
-'@rushstack/import-requires-chunk-name': 1,
-// Ensure that React components rendered with ReactDOM.render() are unmounted with ReactDOM.unmountComponentAtNode(). https://www.npmjs.com/package/@rushstack/eslint-plugin
-'@rushstack/pair-react-dom-render-unmount': 1,
-```
-
-Then locate the following two rules and delete them:
-
-```javascript
-'@microsoft/spfx/import-requires-chunk-name': 1,
-
-'@microsoft/spfx/pair-react-dom-render-unmount': 1
-```
-
-## Update npm scripts in package.json
-
-Replace the existing `build`, `test`, and `clean` scripts in the **package.json** file with the following to use Heft instead of Gulp.
-
-```json
-{
-  ..
-  "scripts": {
-    "build": "heft build --clean",
-    "clean": "heft clean",
-    "test": "heft test"
-  }
-  ..
-}
-```
-
-### Optionally add additional scripts to package.json
-
-The project templates created for SPFx v1.22 include additional scripts to the **package.json** file. While these are optional, you can add them to your project's **package.json** to match the default projects:
-
-```json
-{
-  ..
-  "scripts": {
-    ..
-    "build": "heft test --clean --production && heft package-solution --production",
-    "start": "heft start --clean",
-    "clean": "heft clean",
-    "eject-webpack": "heft eject-webpack"
-  }
-  ..
-}
-```
-
-> [!TIP]
-> While not required, we recommend installing the Heft CLI globally:
->
-> ```console
-> npm install @rushstack/heft --global
-> ```
->
-> Once the Heft CLI is installed globally, you can run Heft commands without using the npm scripts.
-
-## Add the SPFx Heft rig to the project
-
-With the Heft toolchain now installed after removing the Gulp toolchain, the next step is to add a reference to the SPFx build rig. This is done by adding a new file to your project's configuration folder. That will reference the rig that the project will use.
-
-Add a new file, **./config/rig.json**, to your project with the following contents:
-
-```json
-{
-  "$schema": "https://developer.microsoft.com/json-schemas/rig-package/rig.schema.json",
-  "rigPackageName": "@microsoft/spfx-web-build-rig"
-}
-```
-
-## Replace the Sass configuration file
-
-Replace the entire contents of the existing **./config/sass.json** file with the following to use the Heft Sass configuration in the SPFx Heft rig. This is where you can modify the default settings on the [Heft Sass Plugin](https://heft.rushstack.io/pages/plugins/sass/):
-
-```json
-{
-  "$schema": "https://developer.microsoft.com/json-schemas/heft/v0/heft-sass-plugin.schema.json",
-  "extends": "@microsoft/spfx-web-build-rig/profiles/default/config/sass.json"
-}
-```
-
-## Add the Heft TypeScript Plugin configuration
-
-Add a new file, **./config/typescript.json**, to your project with the following code. This configures the [Heft TypeScript Plugin](https://heft.rushstack.io/pages/plugins/typescript/) used in the SPFx Heft rig:
-
-```json
-{
-  "extends": "@microsoft/spfx-web-build-rig/profiles/default/config/typescript.json",
-  "staticAssetsToCopy": {
-    "fileExtensions": [".resx", ".jpg", ".png", ".woff", ".eot", ".ttf", ".svg", ".gif"],
-    "includeGlobs": ["webparts/*/loc/*.js"]
-  }
-}
-```
-
-## Replace the TypeScript compiler configuration
-
-Replace the contents of the existing **./tsconfig.json** file with the following code. This assumes the same TypeScript configuration as the SPFx Heft rig's TypeScript configuration.
-
-```json
-{
-  "extends": "./node_modules/@microsoft/spfx-web-build-rig/profiles/default/tsconfig-base.json"
-}
-```
-
-## Delete gulpfile.js
-
-Delete the **./gulpfile.js** file from your project as it is no longer used.
-
-> [!TIP]
-> If you've made changes to your **gulpfile.js**, you may want to keep it until you've migrated those changes to the equivalent Heft extensibility options. Learn more about customizing the Heft-based toolchain: [Customizing the Heft-based build toolchain](customize-heft-toolchain-overview.md#customizing-the-heft-based-build-toolchain).
-
-## Upgrade production dependencies
-
-Finally, upgrade the production dependencies in the project to SPFx v1.22:
+After applying the changes, verify the migration by running the build command:
 
 ```console
-npm install @microsoft/sp-component-base@1.22.1 \
-            @microsoft/sp-core-library@1.22.1 \
-            @microsoft/sp-lodash-subset@1.22.1 \
-            @microsoft/sp-office-ui-fabric-core@1.22.1 \
-            @microsoft/sp-property-pane@1.22.1 \
-            @microsoft/sp-webpart-base@1.22.1 \
-            --save-exact
-```
-
-> [!TIP]
-> After making so many changes to the packages, consider deleting the **node_modules** and **./package-lock.json** (*or the equivalent lock file for the package manager you use*) and then re-running `npm install`. This ensures you will have a clean dependency tree.
-
-## Test the project migration to the Heft-based toolchain
-
-Test your changes by running the **build** command in the console from the root of your project.
-
-```console
-# if you have heft installed globally...
-heft build --production
-
-# ... or you can run the npm helper script
 npm run build
 ```
 

--- a/includes/snippets/spfx-release-upgrade-tip.md
+++ b/includes/snippets/spfx-release-upgrade-tip.md
@@ -1,3 +1,0 @@
-
-> [!TIP]
-> The [CLI for Microsoft 365](https://aka.ms/o365cli) provides an easy step-by-step guidance to [upgrade](https://pnp.github.io/cli-microsoft365/cmd/spfx/project/project-upgrade/) your solutions to latest SharePoint Framework version.

--- a/includes/snippets/spfx-release-upgrade-warning.md
+++ b/includes/snippets/spfx-release-upgrade-warning.md
@@ -1,0 +1,3 @@
+
+> [!WARNING]
+> Upgrading from a previous minor version requires changes across package versions, build configuration files, and toolchain settings that vary depending on your source version. Manually updating package.json alone will result in build failures.


### PR DESCRIPTION
## Summary

Updates all SPFx release notes pages and the Gulp-to-Heft migration guide to improve upgrade guidance by directing developers to use CLI for Microsoft 365.

## Changes

### All release pages (40 files)

- **Replaced shared TIP** (recommending CLI for Microsoft 365) with a **WARNING** explaining that upgrading requires changes across package versions, build configuration, and toolchain settings — manually updating `package.json` alone will cause build failures.
- **Added a version-specific TIP** with the exact `npx` command to run `m365 spfx project upgrade --toVersion <version>` for each release page.
- **Added the community disclaimer** NOTE (existing `pnp-o365cli` snippet) clarifying CLI for Microsoft 365 is open-source with no Microsoft SLA.
- **Renamed snippet** from `spfx-release-upgrade-tip.md` → `spfx-release-upgrade-warning.md` to reflect its new content.

### `docs/spfx/release-1.22.0.md`

- Restructured the upgrade section: warning/tip/disclaimer appear first, followed by a link to the migration guide.
- Removed redundant "See more details" bullet under "Transitioning from Gulp-based toolchain".

### `docs/spfx/toolchain/migrate-gulptoolchain-hefttoolchain.md`

- **Complete rewrite**: replaced the detailed manual step-by-step migration instructions with:
  - An overview of what changes during the migration (packages, TypeScript config, build scripts, ESLint rules, configuration files, removed files, production deps).
  - Direction to use `m365 spfx project upgrade` to generate the full set of changes automatically.
  - A verification step.