### PR TITLE
Cross-reference the minimal-permissions page migration guide

### DIFF
--- a/docs/transform/modernize-userinterface-site-pages-powershell.md
+++ b/docs/transform/modernize-userinterface-site-pages-powershell.md
@@ -176,3 +176,4 @@ Enable-PnPFeature -Identity "B6917CB1-93A0-4B97-A84D-7CF49975D4EC" -Scope Web
 - [Modernize your classic SharePoint sites](modernize-classic-sites.md)
 - [Understanding and configuring the page transformation model](modernize-userinterface-site-pages-model.md)
 - [Classic and modern web part experiences](https://support.office.com/article/classic-and-modern-web-part-experiences-3fdae6c3-8fc1-49ab-8708-8c104b882e64)
+- [Migrate classic pages to modern with the least permission possible](https://pnp.github.io/pnpassessment/classic/migrate-minimal-permissions.html)


### PR DESCRIPTION
## Summary

Adds a single cross-reference, in the **See also** section, from the *Transform classic pages to modern pages using PowerShell* article to the new guide:

- [Migrate classic SharePoint pages to modern — with the least permission possible](https://pnp.github.io/pnpassessment/classic/migrate-minimal-permissions.html)

That guide shows a site owner how to run `ConvertTo-PnPPage` while requesting the smallest Entra app permission that works (`AllSites.Manage`, escalating to `AllSites.FullControl` only to preserve item-level unique permissions), and how the user-consent vs. admin-consent paths play out. It complements this PowerShell how-to, which documents the cmdlet itself but not the app-registration/consent angle.

## Change

- One bullet added to the `## See also` list. No other content touched; existing CRLF line endings preserved (net diff: +1 line).