### PR TITLE
Add SharePoint Embedded MCP server getting-started article

### DIFF
--- a/docs/embedded/getting-started/sharepoint-embedded-mcp-server.md
+++ b/docs/embedded/getting-started/sharepoint-embedded-mcp-server.md
@@ -4,7 +4,6 @@ description: Use the open-source SharePoint Embedded MCP server to provision and
 ms.date: 07/10/2026
 ms.localizationpriority: high
 ms.author: grjoseph
-ms.service: sharepoint-embedded
 ---
 
 # SharePoint Embedded Model Context Protocol (MCP) server

--- a/docs/embedded/getting-started/spe-mcp-server.md
+++ b/docs/embedded/getting-started/spe-mcp-server.md
@@ -7,7 +7,7 @@ ms.localizationpriority: high
 
 # SharePoint Embedded Model Context Protocol (MCP) server
 
-The SharePoint Embedded MCP server is an open-source [Model Context Protocol](https://modelcontextprotocol.io/) server that lets any MCP-compatible AI client—such as GitHub Copilot in Visual Studio Code, Claude Desktop, Cursor, or Azure AI Foundry—set up and manage SharePoint Embedded through natural language. It's distributed as the [`@microsoft/spe-mcp-server`](https://github.com/microsoft/SharePoint-Embedded-MCP-Server) npm package and runs locally on your machine as a developer tool.
+The SharePoint Embedded MCP server is an open-source [Model Context Protocol](https://modelcontextprotocol.io/) server that lets any MCP-compatible AI client—such as GitHub Copilot in Visual Studio Code, Claude Desktop, Cursor, or Azure AI Foundry—set up and manage SharePoint Embedded through natural language. It's distributed as the [`@microsoft/spe-mcp`](https://github.com/microsoft/SharePoint-Embedded-MCP-Server) npm package and runs locally on your machine as a developer tool.
 
 Instead of clicking through portals and stitching together Microsoft Graph and Azure CLI commands by hand, you describe what you want—"create a trial container type for my app"—and the AI client calls the server's tools to do it.
 
@@ -51,7 +51,7 @@ Add an MCP server entry to `.vscode/mcp.json` in your workspace:
     "spe": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@microsoft/spe-mcp-server"]
+      "args": ["-y", "@microsoft/spe-mcp"]
     }
   }
 }
@@ -68,7 +68,7 @@ Add the server to `%APPDATA%\Claude\claude_desktop_config.json` (Windows) or `~/
   "mcpServers": {
     "spe": {
       "command": "npx",
-      "args": ["-y", "@microsoft/spe-mcp-server"]
+      "args": ["-y", "@microsoft/spe-mcp"]
     }
   }
 }
@@ -76,7 +76,7 @@ Add the server to `%APPDATA%\Claude\claude_desktop_config.json` (Windows) or `~/
 
 ### Cursor and other MCP clients
 
-Any client that supports MCP servers over the stdio transport can run the server with the same `npx -y @microsoft/spe-mcp-server` command. See your client's documentation for where to register MCP servers.
+Any client that supports MCP servers over the stdio transport can run the server with the same `npx -y @microsoft/spe-mcp` command. See your client's documentation for where to register MCP servers.
 
 ## Choose how the server authenticates
 
@@ -96,7 +96,7 @@ The server supports two running modes.
       "spe": {
         "type": "stdio",
         "command": "npx",
-        "args": ["-y", "@microsoft/spe-mcp-server"],
+        "args": ["-y", "@microsoft/spe-mcp"],
         "env": {
           "SPE_CLIENT_ID": "your-client-id",
           "SPE_TENANT_ID": "your-tenant-id"

--- a/docs/embedded/getting-started/spe-mcp-server.md
+++ b/docs/embedded/getting-started/spe-mcp-server.md
@@ -1,0 +1,137 @@
+---
+title: SharePoint Embedded Model Context Protocol (MCP) server
+description: Use the open-source SharePoint Embedded MCP server to provision and manage SharePoint Embedded from any MCP-compatible AI client through natural language.
+ms.date: 07/10/2026
+ms.localizationpriority: high
+---
+
+# SharePoint Embedded Model Context Protocol (MCP) server
+
+The SharePoint Embedded MCP server is an open-source [Model Context Protocol](https://modelcontextprotocol.io/) server that lets any MCP-compatible AI client—such as GitHub Copilot in Visual Studio Code, Claude Desktop, Cursor, or Azure AI Foundry—set up and manage SharePoint Embedded through natural language. It's distributed as the [`@microsoft/spe-mcp-server`](https://github.com/microsoft/SharePoint-Embedded-MCP-Server) npm package and runs locally on your machine as a developer tool.
+
+Instead of clicking through portals and stitching together Microsoft Graph and Azure CLI commands by hand, you describe what you want—"create a trial container type for my app"—and the AI client calls the server's tools to do it.
+
+> [!NOTE]
+> The SharePoint Embedded MCP server is an open-source developer tool released in preview. Its source code, full tool reference, and issue tracker live in the [microsoft/SharePoint-Embedded-MCP-Server](https://github.com/microsoft/SharePoint-Embedded-MCP-Server) repository on GitHub.
+
+> [!IMPORTANT]
+> To start building with SharePoint Embedded, you'll need administrative access to a Microsoft 365 tenant.
+> If you don't already have a tenant, you can get your own with the [Microsoft 365 Developer Program](https://developer.microsoft.com/microsoft-365/dev-program), [Microsoft Customer Digital Experience](https://cdx.transform.microsoft.com/), or a free trial of a [Microsoft 365 E3 license](https://www.microsoft.com/microsoft-365/enterprise/microsoft365-plans-and-pricing).
+
+## What you can do with it
+
+The server exposes tools that an AI client can call on your behalf, grouped by task:
+
+- **Provisioning and status** – Check your signed-in identity and provisioning readiness, create the owning Microsoft Entra ID application, and create, register, list, update, or delete [container types](containertypes.md) and containers. A single `project_provision` tool can run the whole sequence—app → container type → billing → registration → container—in one call.
+- **Billing** – Pick an Azure subscription and resource group, register the `Microsoft.Syntex` resource provider, link a container type to [standard billing](../administration/billing/billing.md), and inspect billing classification or trial expiry.
+- **Scaffold, run, and deploy** – Generate a runnable reference application (a React single-page app with Azure Functions, or a C# web app), write its runtime configuration from your provisioning state, seed sample content, run it locally, and deploy it to Azure.
+- **Content operations (opt-in)** – After a separate, explicit consent, upload files, create folders, search, preview, manage sharing and permissions, and archive or restore containers.
+- **Documentation** – Search and fetch official SharePoint Embedded and Microsoft Graph documentation, grounded through the [Microsoft Learn MCP server](/training/support/mcp).
+
+For the complete, versioned list of tools, CLI flags, and environment variables, see the [server README](https://github.com/microsoft/SharePoint-Embedded-MCP-Server#available-tools).
+
+## Prerequisites
+
+- **Node.js** version 18 or later.
+- **[Azure CLI](/cli/azure/install-azure-cli)**, signed in with `az login --allow-no-subscriptions`. The `--allow-no-subscriptions` flag is required for Microsoft 365–only tenants that have no Azure subscription.
+- A Microsoft 365 tenant with **SharePoint Embedded** enabled and tenant-admin access (Global Administrator or Application Administrator).
+- An **MCP-compatible client**, such as [Visual Studio Code](https://code.visualstudio.com/) with GitHub Copilot, Claude Desktop, or Cursor.
+
+## Install and configure
+
+MCP clients launch the server with `npx`, so there's no separate global install. Add a server entry to your client's MCP configuration.
+
+### Visual Studio Code
+
+Add an MCP server entry to `.vscode/mcp.json` in your workspace:
+
+```json
+{
+  "servers": {
+    "spe": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@microsoft/spe-mcp-server"]
+    }
+  }
+}
+```
+
+The `-y` flag lets Visual Studio Code launch the server non-interactively. After the server is registered, use Copilot Chat in agent mode to call its tools.
+
+### Claude Desktop
+
+Add the server to `%APPDATA%\Claude\claude_desktop_config.json` (Windows) or `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS):
+
+```json
+{
+  "mcpServers": {
+    "spe": {
+      "command": "npx",
+      "args": ["-y", "@microsoft/spe-mcp-server"]
+    }
+  }
+}
+```
+
+### Cursor and other MCP clients
+
+Any client that supports MCP servers over the stdio transport can run the server with the same `npx -y @microsoft/spe-mcp-server` command. See your client's documentation for where to register MCP servers.
+
+## Choose how the server authenticates
+
+The server supports two running modes.
+
+- **Bootstrap mode (recommended to get started)** – No app registration required. The server uses your Azure CLI session for the control plane and provisions the owning Microsoft Entra ID application on demand. Sign in once and start the server with no client ID:
+
+  ```console
+  az login --allow-no-subscriptions
+  ```
+
+- **Pre-provisioned-app mode** – Pass an existing public-client Microsoft Entra ID application that already has admin-consented delegated permissions for `FileStorageContainer.Selected`, `FileStorageContainerType.Manage.All`, and `FileStorageContainerTypeReg.Manage.All`. Provide the app and tenant IDs through the `SPE_CLIENT_ID` and `SPE_TENANT_ID` environment variables (or the `--client-id` and `--tenant-id` flags):
+
+  ```json
+  {
+    "servers": {
+      "spe": {
+        "type": "stdio",
+        "command": "npx",
+        "args": ["-y", "@microsoft/spe-mcp-server"],
+        "env": {
+          "SPE_CLIENT_ID": "your-client-id",
+          "SPE_TENANT_ID": "your-tenant-id"
+        }
+      }
+    }
+  }
+  ```
+
+In bootstrap mode, the first SharePoint Embedded call opens a browser for a one-time consent and caches the token, so no separate terminal step is needed. For the full authentication waterfall, token storage details, and headless/automation guidance, see the [server README](https://github.com/microsoft/SharePoint-Embedded-MCP-Server#authentication).
+
+## Try it
+
+With the server registered in your client and an Azure CLI sign-in complete, ask your AI client to work with SharePoint Embedded. For example, in Copilot Chat:
+
+- *"List my SharePoint Embedded container types."*
+- *"Create a trial container type called Contoso Docs for app ID abc-123."*
+- *"Provision a new SharePoint Embedded app and scaffold a React sample."*
+
+The client calls the matching tools, prompts you for consent the first time, and reports the results.
+
+## Control what the server can do
+
+The server includes controls to limit which tools are exposed and callable—useful when you want an AI client to explore your environment without making changes:
+
+- **Read-only mode** – Advertise and allow only read, list, get, and search tools, and reject any mutating call. Set the `--read-only` flag or the `SPE_READ_ONLY` environment variable.
+- **Tool profiles** – Restrict the exposed tools to a profile (`readOnly`, `docsOnly`, `provisioning`, `content`, or `admin`) or a comma-separated list of tool names, using the `--tools` flag or the `SPE_TOOLS` environment variable.
+
+The **content operations** tools are also gated behind a separate, explicit consent, so an AI client can't read or change files in your containers until you opt in. For the full security model, see [security controls](https://github.com/microsoft/SharePoint-Embedded-MCP-Server/blob/main/docs/SECURITY-CONTROLS.md) in the server repository.
+
+## Related content
+
+- [SharePoint Embedded MCP server on GitHub](https://github.com/microsoft/SharePoint-Embedded-MCP-Server) – source code, full tool reference, and issues.
+- [SharePoint Embedded for Visual Studio Code](spembedded-for-vscode.md) – a guided extension for getting started for free.
+- [SharePoint Embedded container types](containertypes.md)
+- [SharePoint Embedded app architecture](../development/app-architecture.md)
+- [Authentication and authorization](../development/auth.md)
+- [Model Context Protocol](https://modelcontextprotocol.io/)

--- a/docs/embedded/getting-started/spe-mcp-server.md
+++ b/docs/embedded/getting-started/spe-mcp-server.md
@@ -3,6 +3,8 @@ title: SharePoint Embedded Model Context Protocol (MCP) server
 description: Use the open-source SharePoint Embedded MCP server to provision and manage SharePoint Embedded from any MCP-compatible AI client through natural language.
 ms.date: 07/10/2026
 ms.localizationpriority: high
+ms.author: grjoseph
+ms.service: sharepoint-embedded
 ---
 
 # SharePoint Embedded Model Context Protocol (MCP) server
@@ -16,17 +18,18 @@ Instead of clicking through portals and stitching together Microsoft Graph and A
 
 > [!IMPORTANT]
 > To start building with SharePoint Embedded, you'll need administrative access to a Microsoft 365 tenant.
+>
 > If you don't already have a tenant, you can get your own with the [Microsoft 365 Developer Program](https://developer.microsoft.com/microsoft-365/dev-program), [Microsoft Customer Digital Experience](https://cdx.transform.microsoft.com/), or a free trial of a [Microsoft 365 E3 license](https://www.microsoft.com/microsoft-365/enterprise/microsoft365-plans-and-pricing).
 
 ## What you can do with it
 
 The server exposes tools that an AI client can call on your behalf, grouped by task:
 
-- **Provisioning and status** – Check your signed-in identity and provisioning readiness, create the owning Microsoft Entra ID application, and create, register, list, update, or delete [container types](containertypes.md) and containers. A single `project_provision` tool can run the whole sequence—app → container type → billing → registration → container—in one call.
-- **Billing** – Pick an Azure subscription and resource group, register the `Microsoft.Syntex` resource provider, link a container type to [standard billing](../administration/billing/billing.md), and inspect billing classification or trial expiry.
-- **Scaffold, run, and deploy** – Generate a runnable reference application (a React single-page app with Azure Functions, or a C# web app), write its runtime configuration from your provisioning state, seed sample content, run it locally, and deploy it to Azure.
-- **Content operations (opt-in)** – After a separate, explicit consent, upload files, create folders, search, preview, manage sharing and permissions, and archive or restore containers.
-- **Documentation** – Search and fetch official SharePoint Embedded and Microsoft Graph documentation, grounded through the [Microsoft Learn MCP server](/training/support/mcp).
+- **Provisioning and status**: Check your signed-in identity and provisioning readiness, create the owning Microsoft Entra ID application, and create, register, list, update, or delete [container types](containertypes.md) and containers. A single `project_provision` tool can run the whole sequence—app → container type → billing → registration → container—in one call.
+- **Billing**: Pick an Azure subscription and resource group, register the `Microsoft.Syntex` resource provider, link a container type to [standard billing](../administration/billing/billing.md), and inspect billing classification or trial expiry.
+- **Scaffold, run, and deploy**: Generate a runnable reference application (a React single-page app with Azure Functions, or a C# web app), write its runtime configuration from your provisioning state, seed sample content, run it locally, and deploy it to Azure.
+- **Content operations (opt-in)**: After a separate, explicit consent, upload files, create folders, search, preview, manage sharing and permissions, and archive or restore containers.
+- **Documentation**: Search and fetch official SharePoint Embedded and Microsoft Graph documentation, grounded through the [Microsoft Learn MCP server](/training/support/mcp).
 
 For the complete, versioned list of tools, CLI flags, and environment variables, see the [server README](https://github.com/microsoft/SharePoint-Embedded-MCP-Server#available-tools).
 
@@ -82,29 +85,29 @@ Any client that supports MCP servers over the stdio transport can run the server
 
 The server supports two running modes.
 
-- **Bootstrap mode (recommended to get started)** – No app registration required. The server uses your Azure CLI session for the control plane and provisions the owning Microsoft Entra ID application on demand. Sign in once and start the server with no client ID:
+- **Bootstrap mode (recommended to get started)**: No app registration required. The server uses your Azure CLI session for the control plane and provisions the owning Microsoft Entra ID application on demand. Sign in once and start the server with no client ID:
 
-  ```console
-  az login --allow-no-subscriptions
-  ```
+    ```console
+    az login --allow-no-subscriptions
+    ```
 
-- **Pre-provisioned-app mode** – Pass an existing public-client Microsoft Entra ID application that already has admin-consented delegated permissions for `FileStorageContainer.Selected`, `FileStorageContainerType.Manage.All`, and `FileStorageContainerTypeReg.Manage.All`. Provide the app and tenant IDs through the `SPE_CLIENT_ID` and `SPE_TENANT_ID` environment variables (or the `--client-id` and `--tenant-id` flags):
+- **Pre-provisioned-app mode**: Pass an existing public-client Microsoft Entra ID application that already has admin-consented delegated permissions for `FileStorageContainer.Selected`, `FileStorageContainerType.Manage.All`, and `FileStorageContainerTypeReg.Manage.All`. Provide the app and tenant IDs through the `SPE_CLIENT_ID` and `SPE_TENANT_ID` environment variables (or the `--client-id` and `--tenant-id` flags):
 
-  ```json
-  {
-    "servers": {
-      "spe": {
-        "type": "stdio",
-        "command": "npx",
-        "args": ["-y", "@microsoft/spe-mcp"],
-        "env": {
-          "SPE_CLIENT_ID": "your-client-id",
-          "SPE_TENANT_ID": "your-tenant-id"
+    ```json
+    {
+      "servers": {
+        "spe": {
+          "type": "stdio",
+          "command": "npx",
+          "args": ["-y", "@microsoft/spe-mcp"],
+          "env": {
+            "SPE_CLIENT_ID": "your-client-id",
+            "SPE_TENANT_ID": "your-tenant-id"
+          }
         }
       }
     }
-  }
-  ```
+    ```
 
 In bootstrap mode, the first SharePoint Embedded call opens a browser for a one-time consent and caches the token, so no separate terminal step is needed. For the full authentication waterfall, token storage details, and headless/automation guidance, see the [server README](https://github.com/microsoft/SharePoint-Embedded-MCP-Server#authentication).
 
@@ -122,8 +125,8 @@ The client calls the matching tools, prompts you for consent the first time, and
 
 The server includes controls to limit which tools are exposed and callable—useful when you want an AI client to explore your environment without making changes:
 
-- **Read-only mode** – Advertise and allow only read, list, get, and search tools, and reject any mutating call. Set the `--read-only` flag or the `SPE_READ_ONLY` environment variable.
-- **Tool profiles** – Restrict the exposed tools to a profile (`readOnly`, `docsOnly`, `provisioning`, `content`, or `admin`) or a comma-separated list of tool names, using the `--tools` flag or the `SPE_TOOLS` environment variable.
+- **Read-only mode**: Advertise and allow only read, list, get, and search tools, and reject any mutating call. Set the `--read-only` flag or the `SPE_READ_ONLY` environment variable.
+- **Tool profiles**: Restrict the exposed tools to a profile (`readOnly`, `docsOnly`, `provisioning`, `content`, or `admin`) or a comma-separated list of tool names, using the `--tools` flag or the `SPE_TOOLS` environment variable.
 
 The **content operations** tools are also gated behind a separate, explicit consent, so an AI client can't read or change files in your containers until you opt in. For the full security model, see [security controls](https://github.com/microsoft/SharePoint-Embedded-MCP-Server/blob/main/docs/SECURITY-CONTROLS.md) in the server repository.
 

--- a/docs/embedded/whats-new.md
+++ b/docs/embedded/whats-new.md
@@ -9,7 +9,7 @@ ms.localizationpriority: medium
 
 ## July 2026
 
-- The [SharePoint Embedded Model Context Protocol (MCP) server](./getting-started/spe-mcp-server.md) is available in preview as an open-source npm package ([`@microsoft/spe-mcp-server`](https://github.com/microsoft/SharePoint-Embedded-MCP-Server)), letting any MCP-compatible AI client—such as GitHub Copilot in Visual Studio Code, Claude, or Cursor—provision and manage SharePoint Embedded through natural language.
+- The [SharePoint Embedded Model Context Protocol (MCP) server](./getting-started/spe-mcp-server.md) is available in preview as an open-source npm package ([`@microsoft/spe-mcp`](https://github.com/microsoft/SharePoint-Embedded-MCP-Server)), letting any MCP-compatible AI client—such as GitHub Copilot in Visual Studio Code, Claude, or Cursor—provision and manage SharePoint Embedded through natural language.
 
 ## June 2026
 

--- a/docs/embedded/whats-new.md
+++ b/docs/embedded/whats-new.md
@@ -9,7 +9,7 @@ ms.localizationpriority: medium
 
 ## July 2026
 
-- The [SharePoint Embedded Model Context Protocol (MCP) server](./getting-started/spe-mcp-server.md) is available in preview as an open-source npm package ([`@microsoft/spe-mcp`](https://github.com/microsoft/SharePoint-Embedded-MCP-Server)), letting any MCP-compatible AI client—such as GitHub Copilot in Visual Studio Code, Claude, or Cursor—provision and manage SharePoint Embedded through natural language.
+- The [SharePoint Embedded Model Context Protocol (MCP) server](./getting-started/sharepoint-embedded-mcp-server.md) is available in preview as an open-source npm package ([`@microsoft/spe-mcp`](https://github.com/microsoft/SharePoint-Embedded-MCP-Server)), letting any MCP-compatible AI client—such as GitHub Copilot in Visual Studio Code, Claude, or Cursor—provision and manage SharePoint Embedded through natural language.
 
 ## June 2026
 

--- a/docs/embedded/whats-new.md
+++ b/docs/embedded/whats-new.md
@@ -7,6 +7,10 @@ ms.localizationpriority: medium
 
 # What's new in SharePoint Embedded
 
+## July 2026
+
+- The [SharePoint Embedded Model Context Protocol (MCP) server](./getting-started/spe-mcp-server.md) is available in preview as an open-source npm package ([`@microsoft/spe-mcp-server`](https://github.com/microsoft/SharePoint-Embedded-MCP-Server)), letting any MCP-compatible AI client—such as GitHub Copilot in Visual Studio Code, Claude, or Cursor—provision and manage SharePoint Embedded through natural language.
+
 ## June 2026
 
 - The [`FileStorageContainerType.Manage.All`](/graph/permissions-reference#filestoragecontainertypemanageall) Microsoft Graph permission no longer requires the [SharePoint Embedded Administrator](./administration/adminrole.md) or [Global Administrator](/entra/identity/role-based-access-control/permissions-reference#global-administrator) role. Any non-guest user in the owning tenant can [create a container type](./getting-started/containertypes.md#creating-container-types) and is automatically assigned as an [owner of that container type](./development/auth.md#container-type-owner-capabilities).

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -602,6 +602,8 @@
     items:
     - name: SharePoint Embedded Visual Studio Code Extension
       href: embedded/getting-started/spembedded-for-vscode.md
+    - name: SharePoint Embedded Model Context Protocol (MCP) Server
+      href: embedded/getting-started/spe-mcp-server.md
     - name: Container Types
       href: embedded/getting-started/containertypes.md
     - name: Register Container Type API

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -507,7 +507,7 @@
     - name: Overview
       href: spfx/roadmap.md
     - name: SPFx v1.23.2 - June 30, 2026
-      href: spfx/release-1.23.2.md      
+      href: spfx/release-1.23.2.md
     - name: SPFx v1.23.0 - May 13, 2026
       href: spfx/release-1.23.0.md
     - name: SPFx v1.22.2 - January 28, 2026
@@ -603,7 +603,7 @@
     - name: SharePoint Embedded Visual Studio Code Extension
       href: embedded/getting-started/spembedded-for-vscode.md
     - name: SharePoint Embedded Model Context Protocol (MCP) Server
-      href: embedded/getting-started/spe-mcp-server.md
+      href: embedded/getting-started/sharepoint-embedded-mcp-server.md
     - name: Container Types
       href: embedded/getting-started/containertypes.md
     - name: Register Container Type API


### PR DESCRIPTION
## Summary

Adds a getting-started article for the **SharePoint Embedded MCP server** — an open-source [Model Context Protocol](https://modelcontextprotocol.io/) server that lets MCP-compatible AI clients (VS Code Copilot, Claude Desktop, Cursor, Azure AI Foundry) manage SharePoint Embedded resources through natural language.

### Changes
- **New article:** `docs/embedded/getting-started/spe-mcp-server.md` — overview, install, running modes (bootstrap / pre-provisioned app), configuration, and a tool-capability summary.
- **TOC:** adds the article under **Getting Started** in `docs/toc.yml`.
- **What''s New:** adds a July 2026 entry in `docs/embedded/whats-new.md`.

### Notes for reviewers
- The article is marked **preview** with a `[!NOTE]`; the package (`@microsoft/spe-mcp-server`) is in alpha.
- The **What''s New** entry and the `npx` install guidance reference the public npm package. Please hold the announcement until the package is published to public npm.
- Content mirrors the canonical README in the OSS repo (`microsoft/SharePoint-Embedded-MCP-Server`), which links back to this article for bidirectional docs.
