### PR TITLE
Fix: add required 'start' subcommand to SPE MCP server launch examples

### DIFF
--- a/docs/embedded/build/sharepoint-embedded-mcp-server.md
+++ b/docs/embedded/build/sharepoint-embedded-mcp-server.md
@@ -54,7 +54,7 @@ Add an MCP server entry to `.vscode/mcp.json` in your workspace:
     "spe": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@microsoft/spe-mcp"]
+      "args": ["-y", "@microsoft/spe-mcp", "start"]
     }
   }
 }
@@ -71,7 +71,7 @@ Add the server to `%APPDATA%\Claude\claude_desktop_config.json` (Windows) or `~/
   "mcpServers": {
     "spe": {
       "command": "npx",
-      "args": ["-y", "@microsoft/spe-mcp"]
+      "args": ["-y", "@microsoft/spe-mcp", "start"]
     }
   }
 }
@@ -79,7 +79,7 @@ Add the server to `%APPDATA%\Claude\claude_desktop_config.json` (Windows) or `~/
 
 ### Cursor and other MCP clients
 
-Any client that supports MCP servers over the stdio transport can run the server with the same `npx -y @microsoft/spe-mcp` command. See your client's documentation for where to register MCP servers.
+Any client that supports MCP servers over the stdio transport can run the server with the same `npx -y @microsoft/spe-mcp start` command. See your client's documentation for where to register MCP servers.
 
 ## Choose how the server authenticates
 
@@ -99,7 +99,7 @@ The server supports two running modes.
         "spe": {
           "type": "stdio",
           "command": "npx",
-          "args": ["-y", "@microsoft/spe-mcp"],
+          "args": ["-y", "@microsoft/spe-mcp", "start"],
           "env": {
             "SPE_CLIENT_ID": "your-client-id",
             "SPE_TENANT_ID": "your-tenant-id"


### PR DESCRIPTION
## Summary

The [**Use the MCP server to build apps with a coding agent**](https://learn.microsoft.com/sharepoint/dev/embedded/build/sharepoint-embedded-mcp-server) article shows the SharePoint Embedded MCP server being launched as `npx -y @microsoft/spe-mcp` **without the required `start` subcommand**.

The `@microsoft/spe-mcp` CLI exposes `start` / `auth` / `logout` subcommands. It only auto-defaults to `start` when **no other arguments** are present (`process.argv.length <= 2`). As soon as a user adds any flag to a `start`-less config the server prints help and exits with code 1, and the examples diverge from the canonical invocation documented in the package README (`"args": ["-y", "@microsoft/spe-mcp", "start"]`).

## Changes

Adds the `start` subcommand to all four launch examples in `docs/embedded/build/sharepoint-embedded-mcp-server.md`:

- Visual Studio Code (`.vscode/mcp.json`)
- Claude Desktop (`claude_desktop_config.json`)
- Cursor and other MCP clients (inline `npx` command)
- Pre-provisioned-app mode config (with `SPE_CLIENT_ID` / `SPE_TENANT_ID`)

No other content changes. 4 insertions, 4 deletions.