### PR TITLE
Apply SharePoint Embedded docs review fixes (review 20260717-223227)

### DIFF
--- a/docs/embedded/admin/admin-overview.md
+++ b/docs/embedded/admin/admin-overview.md
@@ -1,5 +1,5 @@
 ---
-title: Admin Overview
+title: Admin overview
 description: Learn how administrators manage SharePoint Embedded apps, containers, billing, and compliance in Microsoft 365.
 ms.date: 07/13/2026
 ms.reviewer: shsaravanan

--- a/docs/embedded/admin/apply-security-compliance-controls.md
+++ b/docs/embedded/admin/apply-security-compliance-controls.md
@@ -1,5 +1,5 @@
 ---
-title: Apply Security and Compliance Controls
+title: Apply security and compliance controls
 description: Apply Microsoft Purview and SharePoint controls to protect and govern SharePoint Embedded content.
 ms.date: 07/13/2026
 ms.reviewer: dilucesr
@@ -14,7 +14,7 @@ ai-usage: ai-assisted
 
 <!-- agent:
 task_type: how-to
-audience: compliance
+audience: administrator
 outcome: Apply supported Microsoft Purview and SharePoint controls to SharePoint Embedded containers and content.
 next: ../reference/troubleshooting.md
 -->
@@ -23,7 +23,7 @@ Apply security and compliance controls to SharePoint Embedded content by using M
 
 SharePoint Embedded uses Microsoft 365 compliance and data governance capabilities so organizations can protect, govern, and investigate content stored by embedded applications.
 
-Some compliance scenarios require the owning application to provide the end-user experience because SharePoint Embedded is API-only and doesn't have its own user interface.
+Some compliance scenarios require the owning application to provide the user experience because SharePoint Embedded is API-only and doesn't have its own user interface.
 
 > [!IMPORTANT]
 > Coordinate compliance controls with the SharePoint Embedded app owner.
@@ -124,7 +124,7 @@ Use selected container URLs when a policy applies only to specific data.
 ![Microsoft Purview retention policy scoped to selected SharePoint Embedded container URLs.](../images/sc5.png)
 
 > [!NOTE]
-> SharePoint Embedded doesn't provide a native end-user interface for retention label interactions.
+> SharePoint Embedded doesn't provide a native user interface for retention label interactions.
 > If users need to apply or respond to retention labels in an app, the owning app must provide that experience.
 
 For Microsoft Purview Data Lifecycle Management, see [Learn about Microsoft Purview Data Lifecycle Management](/purview/data-lifecycle-management).
@@ -184,7 +184,7 @@ For label concepts, see [Learn about sensitivity labels](/purview/sensitivity-la
 SharePoint Administrators and Global Administrators can block file downloads from SharePoint Embedded containers with the SharePoint site policy cmdlet.
 
 ```powershell
-Set-SPOSite -Identity <ContainerSiteURL> -BlockDownloadPolicy $true
+Set-SPOContainer -Identity <ContainerSiteURL> -BlockDownloadPolicy $true
 ```
 
 A SharePoint Advanced Management license is needed to enforce this policy.

--- a/docs/embedded/admin/consuming-tenant-admin.md
+++ b/docs/embedded/admin/consuming-tenant-admin.md
@@ -12,7 +12,7 @@ ai-usage: ai-assisted
 **Applies to:** Consuming tenant admin — SharePoint Embedded admin / Global admin
 
 > [!IMPORTANT]
-> Assign the SharePoint Embedded Administrator role available in Microsoft 365 Admin Center or Microsoft Entra ID to execute SharePoint Embedded Container cmdlets mentioned in this article.
+> Assign the SharePoint Embedded Administrator role available in Microsoft 365 admin center or Microsoft Entra ID to execute SharePoint Embedded Container cmdlets mentioned in this article.
 >
 > Global Administrators can continue to execute SharePoint Embedded container cmdlets.
 >
@@ -27,13 +27,13 @@ outcome: Understand the consuming tenant administrator role and the admin tools 
 next: install-sharepoint-embedded-app.md
 -->
 
-## Consuming Tenant Admin Role
+## Consuming tenant admin role
 
-Microsoft 365 SharePoint Embedded Administrator serves as the consuming tenant admin. Global Administrators in Microsoft 365 can assign users the SharePoint Embedded Administrator role. The Global Administrator role already has all the permissions of the SharePoint Embedded Administrator role. The SharePoint Embedded Role is available in Microsoft Entra ID and Microsoft 365 Admin Center.
+Microsoft 365 SharePoint Embedded Administrator serves as the consuming tenant admin. Global Administrators in Microsoft 365 can assign users the SharePoint Embedded Administrator role. The Global Administrator role already has all the permissions of the SharePoint Embedded Administrator role. The SharePoint Embedded Administrator role is available in Microsoft Entra ID and Microsoft 365 admin center.
 
 For information on the SharePoint Embedded Administrator role, see [Admin overview](admin-overview.md).
 
-## Administration Tools
+## Administration tools
 
 Consuming tenant admins can manage SharePoint Embedded applications with the following options:
 
@@ -52,16 +52,16 @@ On PowerShell, the SharePoint Embedded Admin can run the following cmdlets:
 
 1. Enumerate applications in a tenant
 1. Enumerate containers of an application in a tenant
-1. Enumerate containers of an application sorted by storage basis storage
+1. Enumerate containers of an application sorted by storage usage
 1. Enumerate archived containers of an application
 1. Edit the sensitivity label on a container
 1. Set the sharing capability configuration on a container
 
 For information on consuming tenant admin in PowerShell, see [Manage containers with PowerShell](manage-containers-powershell.md).
 
-### SharePoint Administrator Center
+### SharePoint admin center
 
-The SharePoint Embedded Admin can access the Active and Deleted containers page on SPAC and perform SharePoint Embedded application-level and container-level actions. This includes the following:
+The SharePoint Embedded Admin can access the Active and Deleted containers page in the SharePoint admin center and perform SharePoint Embedded application-level and container-level actions. This includes the following:
 
 1. View the Active container page
 1. View the Archived container page
@@ -78,13 +78,13 @@ SharePoint Embedded uses Microsoft’s comprehensive compliance and data governa
 
 ## Set up billing for pass-through container type
 
-To use a pass-through billing SharePoint Embedded app, the SharePoint Embedded admin needs to set up Microsoft Syntex billing in the [Microsoft 365 admin center](https://admin.microsoft.com/). No user can access any pass-through SharePoint Embedded apps before valid billing is set up for the SharePoint Embedded platform.
+To use a pass-through billing SharePoint Embedded app, a Global Administrator needs to set up Microsoft Syntex billing in the [Microsoft 365 admin center](https://admin.microsoft.com/). The SharePoint Embedded Administrator role can't configure billing. No user can access any pass-through SharePoint Embedded apps before valid billing is set up for the SharePoint Embedded platform.
 
 ### [Meters](../reference/billing-meters.md)
 
 SharePoint Embedded employs a pay-as-you-go (PAYG) billing model through an Azure subscription. Billing is determined by how much data in GB you store in SharePoint Embedded in active and archived states, transactions used to access and modify the container and container contents, and data that's egressed from the SharePoint Embedded platform. Each of these factors contributes to the overall cost, ensuring that you only pay for the resources and services you use. You can view this usage and billing details in the [Microsoft Cost Management](https://portal.azure.com/).
 
-SharePoint Embedded has three billing meters, as shown. Refer to the [product page](https://adoption.microsoft.com/en-us/sharepoint/embedded/) for pricing details
+SharePoint Embedded has four billing meters, as shown. Refer to the [product page](https://adoption.microsoft.com/en-us/sharepoint/embedded/) for pricing details.
 
 | SharePoint Embedded Service Meters |   Meter Unit   |
 | ---------------------------------- | -------------- |
@@ -93,7 +93,7 @@ SharePoint Embedded has three billing meters, as shown. Refer to the [product pa
 | API Transactions                   | $/Transactions |
 | Egress                             | $/GB           |
 
-### Set Up Guide
+### Set up guide
 
 1. A valid Azure subscription is required. You can create one by following the steps here to [create an Azure subscription](/azure/cloud-adoption-framework/ready/azure-best-practices/initial-subscriptions).
 1. A valid Azure resource group is required. You can create one by following the steps here to [create a resource group](/azure/azure-resource-manager/management/manage-resource-groups-portal).
@@ -106,15 +106,15 @@ SharePoint Embedded has three billing meters, as shown. Refer to the [product pa
 
     ![Microsoft 365 admin center SharePoint Embedded Billing setting](../images/DTCBilling2.png)
 
-1. Follow the instructions on the **SharePoint Embedded** flyer to turn on SharePoint Embedded apps.
+1. Follow the instructions on the **SharePoint Embedded** flyout to turn on SharePoint Embedded apps.
 
 ### [Billing management](monitor-usage-billing-cost.md)
 
 The [Microsoft Cost Management portal](https://portal.azure.com/#view/Microsoft_Azure_CostManagement/Menu/~/overview/openedBy/AzurePortal) provides a comprehensive overview of your costs, allowing you to track and analyze your spending for the SharePoint Embedded application. This guide walks you through the steps to view your billing details and SharePoint Embedded consumption in the Microsoft Cost Management portal.
 
-### Invalid Billing/Turn off SharePoint Embedded
+### Invalid billing / turn off SharePoint Embedded
 
-If you turn off SharePoint Embedded or disconnect the linked Azure subscription, all users will immediately lose access to any application built on the service along with any read and write permissions.
+If you turn off SharePoint Embedded or disconnect the linked Azure subscription, all users immediately lose access to any application built on the service along with any read and write permissions.
 
 ## Next steps
 

--- a/docs/embedded/admin/create-apps-powershell.md
+++ b/docs/embedded/admin/create-apps-powershell.md
@@ -10,7 +10,7 @@ ai-usage: ai-assisted
 
 # Create apps with PowerShell
 
-**Applies to:** Owning tenant administrator — SharePoint Embedded admin / Global admin
+**Applies to:** Developer tenant administrator — SharePoint Embedded admin / Global admin
 
 <!-- agent:
 task_type: how-to
@@ -49,7 +49,7 @@ Add-SPOContainerTypeBilling -ContainerTypeId <ContainerTypeId> -AzureSubscriptio
 
 ## Create a pass-through billed app
 
-Use pass-through billing, also known as direct-to-customer billing, when the consuming tenant pays for SharePoint Embedded usage.
+Use pass-through billing when the consuming tenant pays for SharePoint Embedded usage.
 
 ```powershell
 New-SPOContainerType -IsPassThroughBilling -ContainerTypeName <ContainerTypeName> -OwningApplicationId <OwningApplicationId>

--- a/docs/embedded/admin/create-apps-sharepoint-admin-center.md
+++ b/docs/embedded/admin/create-apps-sharepoint-admin-center.md
@@ -1,5 +1,5 @@
 ---
-title: Create Apps in SharePoint Admin Center
+title: Create apps in SharePoint admin center
 description: Create a SharePoint Embedded app from the SharePoint admin center and validate the new app registration.
 ms.date: 07/13/2026
 ms.reviewer: shsaravanan
@@ -10,7 +10,7 @@ ai-usage: ai-assisted
 
 # Create apps in SharePoint admin center
 
-**Applies to:** Owning tenant administrator — SharePoint Embedded admin / Global admin
+**Applies to:** Developer tenant administrator — SharePoint Embedded admin / Global admin
 
 <!-- agent:
 task_type: how-to

--- a/docs/embedded/admin/grant-admin-consent-permissions.md
+++ b/docs/embedded/admin/grant-admin-consent-permissions.md
@@ -1,5 +1,5 @@
 ---
-title: Grant Admin Consent and Permissions
+title: Grant admin consent and permissions
 description: Review SharePoint Embedded permissions, grant admin consent, and verify the consent state in a consuming tenant.
 ms.date: 07/13/2026
 ms.reviewer: dilucesr
@@ -32,7 +32,7 @@ Use this article to review requested permissions, grant consent, and troubleshoo
 Confirm these prerequisites:
 
 - You can grant admin consent (see [Grant tenant-wide admin consent](/entra/identity/enterprise-apps/grant-admin-consent?pivots=portal#prerequisites)).
-- You know you Microsoft Entra tenant ID (see [How to find your Microsof Entra tenant ID](/entra/fundamentals/how-to-find-tenant))
+- You know your Microsoft Entra tenant ID (see [How to find your Microsoft Entra tenant ID](/entra/fundamentals/how-to-find-tenant)).
 - You know the owning application client ID.
 - You understand why the app needs each requested permission.
 - The app owner has provided installation and consent instructions.
@@ -73,13 +73,13 @@ Before granting consent, review the requested permissions with the app owner.
 Ask the app owner to explain any permission that doesn't align with the expected scenario.
 
 > [!CAUTION]
-> - DON'T grant consent from a copied URL unless you've verified the `client_id` value in the URL. A consent URL grants permissions to the app identified by that client ID.
+> - Don't grant consent from a copied URL unless you've verified the `client_id` value in the URL. A consent URL grants permissions to the app identified by that client ID.
 >
-> - DON'T grant consent if you don't understand why each permission is being requested.
+> - Don't grant consent if you don't understand why each permission is being requested.
 
 ## Grant admin consent from the consent endpoint
 
-The SharePoint Embedded may request admin consent on your tenant by providing you with, or redirecting you to, the admin consent URL. To learn more about the admin consent URL, see [Admin consent on the Microsoft identity platform](/entra/identity-platform/v2-admin-consent).
+The SharePoint Embedded app may request admin consent on your tenant by providing you with, or redirecting you to, the admin consent URL. To learn more about the admin consent URL, see [Admin consent on the Microsoft identity platform](/entra/identity-platform/v2-admin-consent).
 
 ```http
 https://login.microsoftonline.com/{your-tenant-id}/v2.0/adminconsent?client_id={owning-app-clientid}&scope=https://graph.microsoft.com/.default&redirect_uri={spe-app-redirect-uri}

--- a/docs/embedded/admin/manage-containers-powershell.md
+++ b/docs/embedded/admin/manage-containers-powershell.md
@@ -243,9 +243,9 @@ Use `Set-SPOApplicationPermission` for this scenario.
 
 ```powershell
 Set-SPOApplicationPermission
-   [[-OwningApplicationId] <OwningApplicationid>]
-   [[-GuestApplicationId] <GuestApplicationId>]
-   [[-PermissionAppOnly] <AppOnlyPermission>]
+   [-OwningApplicationId] <OwningApplicationid>
+   [-GuestApplicationId] <GuestApplicationId>
+   [-PermissionAppOnly] <AppOnlyPermission>
    [[-PermissionDelegated] <DelegatedPermission>]
 ```
 

--- a/docs/embedded/admin/manage-containers-sharepoint-admin-center.md
+++ b/docs/embedded/admin/manage-containers-sharepoint-admin-center.md
@@ -160,6 +160,9 @@ For broader controls, see [Apply security and compliance controls](apply-securit
 
 Archive a container when it's no longer actively used but must be retained for legal, compliance, or business purposes. Documents in an archived container can't be accessed by any user or application until the container is reactivated.
 
+> [!NOTE]
+> Container archival relies on Microsoft 365 Archive, which is in preview for SharePoint Embedded. Validate tenant availability, billing, and API behavior before you archive production containers. For more information, see [Archive and restore containers](../build/archive-restore-containers.md).
+
 1. Open **Active containers**.
 1. Select the container.
 1. Select **Archive**.

--- a/docs/embedded/admin/monitor-usage-billing-cost.md
+++ b/docs/embedded/admin/monitor-usage-billing-cost.md
@@ -83,7 +83,7 @@ Calls made by internal services to containers aren't charged when the applicatio
 Nonchargeable transactions include:
 
 - eDiscovery service queries that search container content for compliance or legal purposes.
-- Admin actions taken by SharePoint Embedded Admins or Global Admins through SharePoint admin center or SharePoint PowerShell.
+- Admin actions taken by SharePoint Embedded Administrators or Global Administrators through SharePoint admin center or SharePoint PowerShell.
 
 Use app telemetry from the owning application to correlate app releases, user activity, and transaction growth.
 

--- a/docs/embedded/admin/review-audit-events.md
+++ b/docs/embedded/admin/review-audit-events.md
@@ -14,7 +14,7 @@ ai-usage: ai-assisted
 
 <!-- agent:
 task_type: how-to
-audience: compliance
+audience: administrator
 outcome: Review SharePoint Embedded audit events in Microsoft Purview and use container fields for investigations.
 next: apply-security-compliance-controls.md
 -->

--- a/docs/embedded/build/archive-restore-containers.md
+++ b/docs/embedded/build/archive-restore-containers.md
@@ -1,5 +1,5 @@
 ---
-title: Archive and Restore Containers
+title: Archive and restore containers
 description: Archive inactive SharePoint Embedded containers and reactivate them with Microsoft Graph beta APIs.
 ms.date: 07/13/2026
 ms.reviewer: jaeccles
@@ -19,7 +19,7 @@ outcome: Enable archival and call Graph beta archive or unarchive operations.
 next: fluid-framework.md
 -->
 
-Use SharePoint Embedded container archival when a container must be retained but no longer needs to be active accessed or used for collaboration. Archival uses Microsoft 365 Archive, a cold-storage tier that reduces storage cost while keeping the same security, compliance, and search standards. For the Microsoft 365 Archive overview, see [Microsoft 365 Archive](/microsoft-365/archive/archive-overview).
+Use SharePoint Embedded container archival when a container must be retained but no longer needs to be actively accessed or used for collaboration. Archival uses Microsoft 365 Archive, a cold-storage tier that reduces storage cost while keeping the same security, compliance, and search standards. For the Microsoft 365 Archive overview, see [Microsoft 365 Archive](/microsoft-365/archive/archive-overview).
 
 > [!IMPORTANT]
 > Microsoft 365 Archive is in Preview for SharePoint Embedded. Validate tenant availability, billing, and API behavior before you expose archive actions to users.

--- a/docs/embedded/build/configure-authentication-authorization.md
+++ b/docs/embedded/build/configure-authentication-authorization.md
@@ -1,5 +1,5 @@
 ---
-title: Configure Authentication and Authorization
+title: Configure authentication and authorization
 description: Configure Microsoft Entra ID authentication and SharePoint Embedded authorization for your application.
 ms.date: 07/13/2026
 ms.reviewer: cindylay
@@ -175,7 +175,7 @@ The owning application grants container type application permissions through [co
 Any Microsoft Entra user that isn't an external identity can be a container type owner. Owners are managed through the [permissions](/graph/api/filestoragecontainertype-post-permissions) navigation property on the [fileStorageContainerType](/graph/api/resources/filestoragecontainertype) resource. Each entry has the `owner` role and identifies the user through `grantedToV2`.
 
 - **Automatic assignment**: The user who [creates a container type](/graph/api/filestorage-post-containertypes) is automatically assigned as an owner.
-- **Add owners**: Use [`POST /containerTypes/{id}/permissions`](/graph/api/filestoragecontainertype-post-permissions) to add up to three owners per container type.
+- **Add owners**: Use [`POST /containerTypes/{id}/permissions`](/graph/api/filestoragecontainertype-post-permissions) to add owners. A container type can have at most three owners in total, including the creator who is automatically assigned as the first owner.
 - **Remove owners**: Use [`DELETE /containerTypes/{id}/permissions/{id}`](/graph/api/filestoragecontainertype-delete-permissions) to remove an owner.
 - **Read owners**: Use [`GET /containerTypes/{id}?$expand=permissions`](/graph/api/filestoragecontainertype-get) or [`GET /containerTypes/{id}/permissions`](/graph/api/filestoragecontainertype-list-permissions) to retrieve owners.
 

--- a/docs/embedded/build/container-metadata.md
+++ b/docs/embedded/build/container-metadata.md
@@ -1,5 +1,5 @@
 ---
-title: Store and Query Container Metadata
+title: Store and query container metadata
 description: Define SharePoint Embedded metadata columns and query drive items by field values.
 ms.date: 07/13/2026
 ms.reviewer: cindylay
@@ -25,11 +25,11 @@ Use metadata when your app needs structured fields on files in a SharePoint Embe
 
 Call the metadata APIs with an app-only or delegated bearer token. Use `FileStorageContainer.Selected` for application and delegated calls.
 
-Container owners can create, update, and delete columns. Container members can read and list columns.
+Container owners and managers can create, update, and delete columns. Container members can read and list columns.
 
 ## Choose column types
 
-SharePoint Embedded metadata supports these column type properties : `boolean`, `choice`, `currency`, `dateTime`, `hyperlinkOrPicture`, `number`, `personOrGroup`, and `text`. It also supports column settings such as `indexed`, `isDeletable`, `isSealed`, `name`, `readOnly`, and `type`.
+SharePoint Embedded metadata supports these column type properties: `boolean`, `choice`, `currency`, `dateTime`, `hyperlinkOrPicture`, `number`, `personOrGroup`, and `text`. It also supports column settings such as `indexed`, `isDeletable`, `isSealed`, `name`, `readOnly`, and `type`.
 
 Column names must follow SharePoint rules. Don't use names that contain `!`, start with a digit or punctuation, contain spaces, look like spreadsheet cell references, represent localized true or false values, or use reserved names such as `Author`, `Created`, or `Description`.
 

--- a/docs/embedded/build/create-container-type.md
+++ b/docs/embedded/build/create-container-type.md
@@ -91,7 +91,7 @@ The following restrictions are applied to trial container types:
 
 Use standard billing when the developer or app owner tenant pays for consumption.
 
-Each tenant can have up to 25 standard container types at a time.
+Each tenant can create up to 25 container types in total. One of these can be a free trial container type; the rest are standard (billed) container types.
 
 1. Create or identify the owning Microsoft Entra ID application.
 1. Create the container type with the `standard` billing classification.
@@ -122,7 +122,7 @@ Under **Syntex services for**, select **Apps**, then select **SharePoint Embedde
 
 ![Microsoft 365 admin center Apps panel with SharePoint Embedded selected to activate pay-as-you-go billing.](../images/SyntexPAYGActivateSPE.png)
 
-## Configure the owning Entra app
+## Configure the owning Microsoft Entra ID app
 
 Configure the app so it can own exactly one container type.
 

--- a/docs/embedded/build/create-manage-containers.md
+++ b/docs/embedded/build/create-manage-containers.md
@@ -1,5 +1,5 @@
 ---
-title: Create and Manage Containers
+title: Create and manage containers
 description: Create, list, update, recycle, restore, and delete SharePoint Embedded containers in your app.
 ms.date: 07/13/2026
 ms.reviewer: jaeccles
@@ -101,7 +101,6 @@ For trial development, the Visual Studio Code extension can create containers.
 1. Right-click **Containers**.
 1. Select **Create container**.
 1. Enter a name.
-
 1. Confirm the container appears under the container type.
 
 See [Quickstart: Build your first app with VS Code](quickstart-vscode.md) for the extension flow.

--- a/docs/embedded/build/fluid-framework.md
+++ b/docs/embedded/build/fluid-framework.md
@@ -43,6 +43,7 @@ Create an empty `.env` file in the sample folder and add the SharePoint Embedded
 ```text
 SPE_CLIENT_ID=YOUR_CLIENTID
 SPE_CONTAINER_TYPE_ID=YOUR_CONTAINERTYPE_ID
+SPE_ENTRA_TENANT_ID=YOUR_ENTRA_TENANT_ID
 ```
 
 Install packages and start the development server.

--- a/docs/embedded/build/manage-files.md
+++ b/docs/embedded/build/manage-files.md
@@ -1,5 +1,5 @@
 ---
-title: Upload, Download, and Manage Files
+title: Upload, download, and manage files
 description: Use Microsoft Graph DriveItem APIs to upload, download, organize, update, delete, and restore SharePoint Embedded files.
 ms.date: 07/13/2026
 ms.reviewer: cindylay
@@ -64,7 +64,6 @@ In your app:
 1. Store the container ID returned when the container is created.
 1. Use the container ID when calling DriveItem APIs that require a drive identifier.
 1. Store item IDs returned by upload or folder creation operations.
-
 1. Avoid reconstructing IDs from URLs.
 
 ## Upload files
@@ -153,7 +152,7 @@ A restore flow should identify the deleted item or version, confirm permission, 
 
 > [!NOTE]
 > [recycleBinItem: restore](/graph/api/filestoragecontainer-restore-recyclebinitem) supports `driveItemId` as an alternate key (October 2025). If you know the ID of the original **driveItem**, you can restore the corresponding **recycleBinItem** directly without first enumerating the recycle bin.
-> [!NOTE]
+>
 > For exact file operation request and response details, use Microsoft Graph DriveItem documentation.
 
 ## Connect to Office and preview experiences
@@ -162,7 +161,7 @@ After upload, add richer experiences:
 
 - [Open Office files from your app](open-office-files.md) for Word, Excel, and PowerPoint launch behavior.
 - [Preview files in your app](preview-files.md) for browser previews.
-- [Search containers and files](../build/search-containers-files.md) for discovery.
+- [Search containers and files](search-containers-files.md) for discovery.
 
 ## Validate file operations
 

--- a/docs/embedded/build/open-office-files.md
+++ b/docs/embedded/build/open-office-files.md
@@ -1,5 +1,5 @@
 ---
-title: Open Office Files From Your App
+title: Open Office files from your app
 description: Launch Word, Excel, and PowerPoint files from SharePoint Embedded in Office web or desktop clients.
 ms.date: 07/13/2026
 ms.reviewer: cindylay

--- a/docs/embedded/build/preview-files.md
+++ b/docs/embedded/build/preview-files.md
@@ -1,5 +1,5 @@
 ---
-title: Preview Files in Your App
+title: Preview files in your app
 description: Create Microsoft Graph preview links and embed supported SharePoint Embedded file previews in your app.
 ms.date: 07/13/2026
 ms.reviewer: cindylay
@@ -98,9 +98,8 @@ Use this C# SDK pattern:
 
 ```csharp
 ItemPreviewInfo preview = await graphServiceClient.Drives[driveId].Items[itemId]
-    .Preview()
-    .Request()
-    .PostAsync();
+    .Preview
+    .PostAsync(null);
 ```
 
 The response includes preview URL information:
@@ -250,7 +249,7 @@ Test with multiple file types and users:
 
 After preview is working, add discovery experiences so users can find content across containers and files.
 
-Continue to [Search containers and files](../build/search-containers-files.md).
+Continue to [Search containers and files](search-containers-files.md).
 
 ## Next steps
 

--- a/docs/embedded/build/quickstart-vscode.md
+++ b/docs/embedded/build/quickstart-vscode.md
@@ -8,7 +8,7 @@ ms.localizationpriority: high
 ai-usage: ai-assisted
 ---
 
-# Quickstart: build your first app with VS Code
+# Quickstart: Build your first app with VS Code
 
 **Applies to:** Developer
 
@@ -36,7 +36,6 @@ Before you start, make sure you have:
 - Permission to grant admin consent in Microsoft Entra ID.
 
 > [!IMPORTANT]
-
 > You need administrative access to a Microsoft 365 tenant. If you don't have a tenant, use the Microsoft 365 Developer Program, Microsoft Customer Digital Experience, or a Microsoft 365 E3 trial.
 
 ## Install the extension
@@ -92,6 +91,7 @@ Every container type has one owning Microsoft Entra ID application.
 
 > [!CAUTION]
 > If you select an existing application, the extension updates that app's configuration. Don't use a production app for this quickstart.
+
 For the model, see [SharePoint Embedded app architecture](../plan/app-tenant-architecture.md).
 
 ## Configure standard billing
@@ -140,7 +140,6 @@ A container is the basic storage unit and security boundary in SharePoint Embedd
 
 1. Review the warning about local plain text secrets.
 1. If prompted to create a client secret, select **OK** for local development.
-
 1. Let the extension populate the runtime configuration file.
 
 > [!IMPORTANT]

--- a/docs/embedded/build/register-application-permissions.md
+++ b/docs/embedded/build/register-application-permissions.md
@@ -1,5 +1,5 @@
 ---
-title: Register Application Permissions
+title: Register application permissions
 description: Register SharePoint Embedded container type application permissions in a consuming tenant.
 ms.date: 07/13/2026
 ms.reviewer: stpuceli
@@ -49,6 +49,7 @@ The owning application must have:
 
 > [!NOTE]
 > The container type registration API is available in Microsoft Graph v1.0.
+
 When the owning application calls the registration API on behalf of a user (delegated), that user must be assigned the [SharePoint Embedded Administrator](/entra/identity/role-based-access-control/permissions-reference#sharepoint-embedded-administrator) or [Global Administrator](/entra/identity/role-based-access-control/permissions-reference#global-administrator) role. When it calls without a user context (app-only), it uses the client credentials grant flow.
 
 ## Grant admin consent
@@ -123,7 +124,7 @@ Use this pattern when a guest app needs a defined workload, such as backup or pr
       "applicationPermissions": ["full"]
     },
     {
-      "appId": "89ea5c94-7736-4e25-95ad-3fa95f62b6",
+      "appId": "89ea5c94-7736-4e25-95ad-3fa95f62b6cd",
       "delegatedPermissions": ["read", "write"],
       "applicationPermissions": ["none"]
     }
@@ -154,7 +155,6 @@ Replace both app IDs with your applications.
 | `Full` | Grant all permissions. |
 
 > [!NOTE]
-
 > `WriteContent` can't be granted without `ReadContent`.
 
 ## Validate registration

--- a/docs/embedded/build/search-containers-files.md
+++ b/docs/embedded/build/search-containers-files.md
@@ -1,5 +1,5 @@
 ---
-title: Search Containers and Files
+title: Search containers and files
 description: Search SharePoint Embedded containers and files with Microsoft Search in Microsoft Graph.
 ms.date: 07/13/2026
 ms.reviewer: cindylay
@@ -120,10 +120,10 @@ Use `from` and `size` to page through ranked results. Read `hitsContainers[].tot
 For container custom properties, append `OWSTEXT` to the custom property name in the query string.
 
 ```text
-customPropertyNametOWSTEXT:customPropertyValue AND ContainerTypeId:498c6855-8f0e-0de7-142e-4e9ff86af9ae
+customPropertyNameOWSTEXT:customPropertyValue AND ContainerTypeId:498c6855-8f0e-0de7-142e-4e9ff86af9ae
 ```
 
-Use full-text **search** (the `/beta/search/query` endpoint above) when users type free-text terms and you want relevance ranking across containers. Use direct enumeration instead of search when your app must filter on known metadata values without relevance ranking. For example, query drive items with `$filter`, `$expand`, and `$orderby`:
+Use full-text search (the `/beta/search/query` endpoint above) when users type free-text terms and you want relevance ranking across containers. Use direct enumeration instead of search when your app must filter on known metadata values without relevance ranking. For example, query drive items with `$filter`, `$expand`, and `$orderby`:
 
 ```http
 GET https://graph.microsoft.com/v1.0/drives/{container-id}/items?$filter=startswith(listitem/fields/{column}, '{value}')&$expand=listitem($expand=fields)

--- a/docs/embedded/build/sharepoint-embedded-mcp-server.md
+++ b/docs/embedded/build/sharepoint-embedded-mcp-server.md
@@ -4,10 +4,20 @@ description: Use the open-source SharePoint Embedded MCP server with a coding ag
 ms.date: 07/10/2026
 ms.localizationpriority: high
 ms.author: grjoseph
+ms.reviewer: cindylay
 ai-usage: ai-assisted
 ---
 
 # Use the MCP server to build apps with a coding agent
+
+**Applies to:** Developer
+
+<!-- agent:
+task_type: how-to
+audience: developer
+outcome: Use the SharePoint Embedded MCP server with a coding agent to provision, configure, scaffold, and manage SharePoint Embedded applications through natural language.
+next: quickstart-vscode.md
+-->
 
 The SharePoint Embedded MCP server is an open-source [Model Context Protocol](https://modelcontextprotocol.io/) server that lets any MCP-compatible AI client—such as GitHub Copilot in Visual Studio Code or CLI, Claude Desktop, Cursor, or Azure AI Foundry—set up and manage SharePoint Embedded applications through natural language. It's distributed as the [`@microsoft/spe-mcp`](https://github.com/microsoft/SharePoint-Embedded-MCP-Server) npm package and runs locally on your machine as a developer tool.
 
@@ -135,6 +145,6 @@ The **content operations** tools are also gated behind a separate, explicit cons
 - [SharePoint Embedded MCP server on GitHub](https://github.com/microsoft/SharePoint-Embedded-MCP-Server) – source code, full tool reference, and issues.
 - [Quickstart: Build your first app with VS Code](quickstart-vscode.md) – a guided extension for getting started for free.
 - [SharePoint Embedded container types](../plan/container-types-containers.md)
-- [SharePoint Embedded app architecture](../development/app-architecture.md)
-- [Authentication and authorization](../development/auth.md)
+- [SharePoint Embedded app architecture](../plan/app-tenant-architecture.md)
+- [Authentication and authorization](configure-authentication-authorization.md)
 - [Model Context Protocol](https://modelcontextprotocol.io/)

--- a/docs/embedded/overview.md
+++ b/docs/embedded/overview.md
@@ -1,5 +1,5 @@
 ---
-title: SharePoint Embedded Overview
+title: SharePoint Embedded overview
 description: Microsoft SharePoint Embedded is an API-only file and document management platform built on Microsoft 365. Start here and route to the right task.
 ms.date: 07/13/2026
 ms.reviewer: shsaravanan

--- a/docs/embedded/plan/app-tenant-architecture.md
+++ b/docs/embedded/plan/app-tenant-architecture.md
@@ -1,5 +1,5 @@
 ---
-title: Understand App and Tenant Architecture
+title: Understand app and tenant architecture
 description: Plan how SharePoint Embedded apps, tenants, container types, and containers relate across owning and consuming tenants.
 ms.date: 07/13/2026
 ms.reviewer: dilucesr

--- a/docs/embedded/plan/authentication-permissions.md
+++ b/docs/embedded/plan/authentication-permissions.md
@@ -1,5 +1,5 @@
 ---
-title: Plan Authentication and Permissions
+title: Plan authentication and permissions
 description: Plan SharePoint Embedded authentication, admin consent, delegated access, app-only access, and container permissions.
 ms.date: 07/13/2026
 ms.reviewer: mawin
@@ -118,7 +118,7 @@ Container type creation, management, and registration are now Microsoft Graph op
 
 ## Container type application permissions
 
-Container type application permissions are granted by the owner application through container type registration.
+Container type application permissions are granted by the owning application through container type registration.
 
 These permissions define what an application can do against containers of the container type.
 

--- a/docs/embedded/plan/choose-app-model.md
+++ b/docs/embedded/plan/choose-app-model.md
@@ -1,5 +1,5 @@
 ---
-title: "Choose an App Model: Single-Tenant or Multitenant"
+title: "Choose an app model: single-tenant or multitenant"
 description: Compare single-tenant and multitenant SharePoint Embedded app models before you create container types and containers.
 ms.date: 07/13/2026
 ms.reviewer: mawin

--- a/docs/embedded/plan/choose-billing-model.md
+++ b/docs/embedded/plan/choose-billing-model.md
@@ -1,5 +1,5 @@
 ---
-title: Choose a Billing Model
+title: Choose a billing model
 description: Compare standard and pass-through SharePoint Embedded billing models before you create production container types.
 ms.date: 07/13/2026
 ms.reviewer: shsaravanan

--- a/docs/embedded/plan/limits-calling-patterns.md
+++ b/docs/embedded/plan/limits-calling-patterns.md
@@ -1,5 +1,5 @@
 ---
-title: Understand Limits and Calling Patterns
+title: Understand limits and calling patterns
 description: Plan SharePoint Embedded service limits, throttling behavior, retry handling, and performance-sensitive calling patterns.
 ms.date: 07/13/2026
 ms.reviewer: mawin
@@ -16,7 +16,7 @@ ai-usage: ai-assisted
 task_type: concept
 audience: developer
 outcome: Design SharePoint Embedded calls that respect service limits, throttling, and resource unit costs.
-next:
+next: ../build/quickstart-vscode.md
 -->
 
 Use this article to plan SharePoint Embedded calling patterns before you build high-volume container and content operations. SharePoint Embedded expresses throughput as **resource units per minute** (a normalized request-cost model) rather than as a fixed requests-per-second rate; the [API rate limits](#api-rate-limits) section explains how to translate resource units into an expected request rate.

--- a/docs/embedded/plan/security-compliance-governance.md
+++ b/docs/embedded/plan/security-compliance-governance.md
@@ -1,5 +1,5 @@
 ---
-title: Plan Security, Compliance, and Governance
+title: Plan security, compliance, and governance
 description: Plan how Microsoft Purview, audit, DLP, retention, labels, and access policies apply to SharePoint Embedded content.
 ms.date: 07/13/2026
 ms.reviewer: mawin
@@ -27,7 +27,7 @@ Supported consumer Microsoft 365 tenant settings and Microsoft Purview capabilit
 
 ## Governance model
 
-SharePoint Embedded is API-only and doesn't provide a built-in end-user interface.
+SharePoint Embedded is API-only and doesn't provide a built-in user interface.
 
 The owning application provides the user experience.
 
@@ -121,7 +121,7 @@ Retention policies configured for all SharePoint sites apply to all SharePoint s
 
 To selectively enforce a policy on one or more SharePoint Embedded containers, use the container URL when configuring the policy.
 
-Because SharePoint Embedded has no built-in UI, app support is required for user-interaction scenarios such as an end user applying a retention label through the app.
+Because SharePoint Embedded has no built-in UI, app support is required for user-interaction scenarios such as a user applying a retention label through the app.
 
 For more information, see [Learn about Microsoft Purview Data Lifecycle Management](/purview/data-lifecycle-management).
 

--- a/docs/embedded/publish/choose-app-billing-model.md
+++ b/docs/embedded/publish/choose-app-billing-model.md
@@ -115,7 +115,7 @@ Before a customer can use a pass-through SharePoint Embedded app, the consuming 
 - Owner or contributor permissions for the admin who creates the billing relationship.
 - Completed app registration and consent steps.
 
-No user can access any pass-through SharePoint Embedded app before valid billing is set up for the SharePoint Embedded platform in the consuming tenant.
+Until valid billing is set up for the SharePoint Embedded platform in the consuming tenant, users can't create new containers in a pass-through SharePoint Embedded app. Existing containers and their content remain accessible.
 For the customer-facing setup path, see [Guide customers through tenant setup](customer-tenant-setup-guide.md).
 
 ## Impact on customer onboarding
@@ -143,7 +143,7 @@ Tell the customer:
 1. The customer can track usage in Azure Cost Management.
 
 > [!TIP]
-> Put the billing model in the first page of your installation guide.
+> Put the billing model on the first page of your installation guide.
 > Customer admins often need to involve both Microsoft 365 and Azure billing owners.
 
 ## Decision checklist
@@ -192,4 +192,5 @@ Before you proceed, record:
 Use these values in [Prepare your app for customer installation](prepare-customer-installation.md) and [Guide customers through tenant setup](customer-tenant-setup-guide.md).
 
 ## Next steps
+
 After you choose a billing model, prepare customer-facing tenant setup instructions: [Guide customers through tenant setup](customer-tenant-setup-guide.md).

--- a/docs/embedded/publish/customer-tenant-setup-guide.md
+++ b/docs/embedded/publish/customer-tenant-setup-guide.md
@@ -25,7 +25,7 @@ Use this article to build the setup guide you hand to customers who install your
 
 ## Customer admin role
 
-Tell customers who should perform the setup. A consuming tenant admin is either a **Global Administrator** or a user assigned the **SharePoint Embedded Administrator** role. The role is available in Microsoft Entra ID and the Microsoft 365 Admin Center. Global Administrators already have these permissions.
+Tell customers who should perform the setup. A consuming tenant admin is either a **Global Administrator** or a user assigned the **SharePoint Embedded Administrator** role. The role is available in Microsoft Entra ID and the Microsoft 365 admin center. Global Administrators already have these permissions.
 
 For the role details, see [Install a SharePoint Embedded app](../admin/install-sharepoint-embedded-app.md).
 
@@ -42,7 +42,7 @@ Ask the customer to confirm these prerequisites before the setup meeting or inst
 | Billing | An Azure subscription and resource group are available if the app uses pass-through billing. |
 | Support | The customer has your app ID, support contact, and validation checklist. |
 
-Users don't need an Office license to collaborate on Microsoft Office documents stored in a container.
+Users don't need an Office license to collaborate on Microsoft Office documents stored in a container, except for documented exceptional experiences such as mentions.
 
 ## Information to give the customer
 

--- a/docs/embedded/publish/prepare-customer-installation.md
+++ b/docs/embedded/publish/prepare-customer-installation.md
@@ -1,5 +1,5 @@
 ---
-title: Prepare Your App for Customer Installation
+title: Prepare your app for customer installation
 description: Prepare a multitenant SharePoint Embedded app, container type, permissions, billing choice, and admin handoff for customer tenants.
 ms.date: 07/13/2026
 ms.reviewer: stpuceli

--- a/docs/embedded/publish/validate-customer-installation.md
+++ b/docs/embedded/publish/validate-customer-installation.md
@@ -9,7 +9,7 @@ ai-usage: ai-assisted
 ---
 # Validate customer app installation
 
-**Applies to:** ISV / developer
+**Applies to:** ISV / Developer
 
 <!-- agent:
 task_type: how-to
@@ -74,7 +74,7 @@ Confirm that the container type is registered in the consuming tenant.
 An app can't create or interact with containers until its container type is registered in that tenant.
 Use your product's setup portal or registration flow to show the registration state.
 
-Ask the customer admin to use the [SharePoint admin center](https://go.microsoft.com/fwlink/?linkid=2185219) to verify that your SharePoint Embedded app is listed under the installed apps tab in the Active apps page under SharePoint Embedded. The customer admin may verify details of your SharePoint Embedded app such as:
+Ask the customer admin to use the [SharePoint admin center](https://go.microsoft.com/fwlink/?linkid=2185219) to verify that your SharePoint Embedded app is listed under the installed apps tab in the Active apps page under SharePoint Embedded. The customer admin can verify details of your SharePoint Embedded app such as:
 
 - The owning application ID.
 - The container type ID.
@@ -90,7 +90,7 @@ To verify that your app is properly installed on the customer tenant:
 1. Use the token to [get the registration for your container type in the tenant](/graph/api/filestoragecontainertyperegistration-get). If a registration is returned, it means that your SharePoint Embedded app is installed correctly.
 
 > [!TIP]
-> You may also validate that your guest apps are properly set up by requesting an access token for the Microsoft Graph `.default` scope in the consuming tenant and validating that the scopes/roles you expect are present and that you can use the token to interact with content. Only the owning app can access a container type registration in a tenant.
+> You can also validate that your guest apps are properly set up by requesting an access token for the Microsoft Graph `.default` scope in the consuming tenant and validating that the scopes/roles you expect are present and that you can use the token to interact with content. Only the owning app can access a container type registration in a tenant.
 
 Confirm that the customer granted the expected permissions and no unexpected app ID was used.
 
@@ -215,7 +215,7 @@ Use this checklist as the final customer signoff.
 - [ ] Container type registration is complete.
 - [ ] Customer admin sees your SharePoint Embedded app in SharePoint admin center.
 - [ ] Billing is valid or not required for the customer tenant.
-- [ ] Test user can sign into your app.
+- [ ] Test user can sign in to your app.
 - [ ] Test container can be created or opened.
 - [ ] Test file operations work.
 - [ ] Customer admin can view the app or container in administration tools.

--- a/docs/embedded/reference/billing-meters.md
+++ b/docs/embedded/reference/billing-meters.md
@@ -1,5 +1,5 @@
 ---
-title: Billing Meters
+title: Billing meters
 description: Reference for SharePoint Embedded pay-as-you-go billing meters and pricing resources.
 ms.date: 07/13/2026
 ms.reviewer: pemtaira

--- a/docs/embedded/reference/glossary.md
+++ b/docs/embedded/reference/glossary.md
@@ -31,7 +31,7 @@ next: ../plan/choose-app-model.md
 | Standard billing | A billing model where consumption charges are billed to the tenant that owns or develops the application. See [choose a billing model](../plan/choose-billing-model.md). |
 | Pass-through (customer) billing | A billing model where consumption charges are billed directly to the consuming tenant registered to use the app. See [choose a billing model](../plan/choose-billing-model.md). |
 | Owning application | The Microsoft Entra ID application registration strongly coupled with a container type; each owning app can own one container type at a time. See [app architecture](../plan/app-tenant-architecture.md). |
-| Partition | The API-only SharePoint storage partition created in a consumer's Microsoft 365 tenant for SharePoint Embedded app documents. See [SharePoint Embedded overview](../overview.md). |
+| Partition | The API-only SharePoint storage partition created in a consuming tenant for SharePoint Embedded app documents. See [SharePoint Embedded overview](../overview.md). |
 
 ## Related resources
 

--- a/docs/embedded/reference/powershell.md
+++ b/docs/embedded/reference/powershell.md
@@ -1,5 +1,5 @@
 ---
-title: PowerShell Reference
+title: PowerShell reference
 description: Reference for SharePoint Online PowerShell cmdlets used to administer SharePoint Embedded.
 ms.date: 07/13/2026
 ms.reviewer: dilucesr

--- a/docs/embedded/scenarios-and-use-cases.md
+++ b/docs/embedded/scenarios-and-use-cases.md
@@ -1,5 +1,5 @@
 ---
-title: Scenarios and Use Cases
+title: Scenarios and use cases
 description: Explore scenarios and use cases for SharePoint Embedded.
 ms.date: 07/13/2026
 ms.reviewer: stpuceli


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- fixes n/a
- partially n/a
- mentioned in n/a

## What's in this Pull Request?

Apply 88 high-confidence fixes across 39 files under docs/embedded/ from the multi-agent docs review:

- Correct billing setup role to Global Administrator (SharePoint Embedded Administrator can't configure billing) and fix "three" -> "four" billing meters.
- Fix container metadata schema-change permission: owners and managers (not owners only) can create/update/delete columns.
- Add missing conventions to sharepoint-embedded-mcp-server.md (Applies to line, agent metadata block, fixed links).
- Apply M365/Acrolinx style fixes: sentence-case headings, admin center casing, terminology consistency, and typo corrections.
