### PR TITLE
Docs: align packaging and setup articles with Heft (SPFx 1.22)

### DIFF
--- a/docs/spfx/debug-in-vscode.md
+++ b/docs/spfx/debug-in-vscode.md
@@ -1,7 +1,7 @@
 ---
 title: Debug SharePoint Framework solutions in Visual Studio Code
 description: Prerequisites and steps for configuring Visual Studio Code for debugging SharePoint Framework solutions.
-ms.date: 04/21/2017
+ms.date: 07/23/2026
 ms.localizationpriority: high
 ---
 # Debug SharePoint Framework solutions in Visual Studio Code
@@ -34,7 +34,7 @@ You can locate the debug configurations in the **./vscode/launch.json** file und
     ```console
     heft start
     ```
-    ![The gulp serve command typed in the integrated terminal in Visual Studio Code](../images/vscode-debugging-gulp-serve.png)
+    ![The heft start command typed in the integrated terminal in Visual Studio Code](../images/vscode-debugging-gulp-serve.png)
 
 ### Start debugging in Visual Studio Code
 

--- a/docs/spfx/debug-in-vscode.md
+++ b/docs/spfx/debug-in-vscode.md
@@ -1,7 +1,7 @@
 ---
 title: Debug SharePoint Framework solutions in Visual Studio Code
 description: Prerequisites and steps for configuring Visual Studio Code for debugging SharePoint Framework solutions.
-ms.date: 07/23/2026
+ms.date: 04/21/2017
 ms.localizationpriority: high
 ---
 # Debug SharePoint Framework solutions in Visual Studio Code

--- a/docs/spfx/set-up-your-development-environment.md
+++ b/docs/spfx/set-up-your-development-environment.md
@@ -1,7 +1,7 @@
 ---
 title: Set up your SharePoint Framework development environment
 description: Learn how set up your development environment for the SharePoint Framework Heft-based toolchain.
-ms.date: 08/18/2016
+ms.date: 07/23/2026
 ms.localizationpriority: high
 ms.custom: scenarios:getting-started
 ---
@@ -125,7 +125,7 @@ heft trust-dev-cert
 
 ## Set the SPFX_SERVE_TENANT_DOMAIN environment variable (optional)
 
-Starting with [SPFx v1.17](release-1.17.1.md), Microsoft replaced the hosted workbench URL launched when you execute gulp serve with a dynamic value. This is defined in the project's **./config/serve.json** file in the `initialPage` property:
+Starting with [SPFx v1.17](release-1.17.1.md), Microsoft replaced the hosted workbench URL launched when you execute `heft start` with a dynamic value. This is defined in the project's **./config/serve.json** file in the `initialPage` property:
 
 ```json
 {

--- a/docs/spfx/set-up-your-development-environment.md
+++ b/docs/spfx/set-up-your-development-environment.md
@@ -1,7 +1,7 @@
 ---
 title: Set up your SharePoint Framework development environment
 description: Learn how set up your development environment for the SharePoint Framework Heft-based toolchain.
-ms.date: 07/23/2026
+ms.date: 08/18/2016
 ms.localizationpriority: high
 ms.custom: scenarios:getting-started
 ---

--- a/docs/spfx/web-parts/basics/notes-on-solution-packaging.md
+++ b/docs/spfx/web-parts/basics/notes-on-solution-packaging.md
@@ -1,12 +1,12 @@
 ---
 title: SharePoint solution packaging
-description: The package-solution gulp task looks at /config/package-solution.json for various configuration details in SharePoint Framework, including ISolution and IFeature definitions.
-ms.date: 03/11/2026
+description: The package-solution Heft task looks at /config/package-solution.json for various configuration details in SharePoint Framework, including ISolution and IFeature definitions.
+ms.date: 07/23/2026
 ms.localizationpriority: high
 ---
 # SharePoint solution packaging
 
-The **package-solution** gulp task looks at **./config/package-solution.json** for various configuration details, including some generic filepaths, and defines the relationship between components (*WebParts* and *Applications*) in a package.
+The **package-solution** Heft task looks at **./config/package-solution.json** for various configuration details, including some generic filepaths, and defines the relationship between components (*WebParts* and *Applications*) in a package.
 
 The schema for the configuration file is as follows:
 

--- a/docs/spfx/web-parts/basics/notes-on-solution-packaging.md
+++ b/docs/spfx/web-parts/basics/notes-on-solution-packaging.md
@@ -1,7 +1,7 @@
 ---
 title: SharePoint solution packaging
 description: The package-solution Heft task looks at /config/package-solution.json for various configuration details in SharePoint Framework, including ISolution and IFeature definitions.
-ms.date: 07/23/2026
+ms.date: 03/11/2026
 ms.localizationpriority: high
 ---
 # SharePoint solution packaging


### PR DESCRIPTION
## Category

- [x] Content fix

## Related issues

- mentioned in #10545

## What's in this Pull Request?

Hi team — I'm helping with the Heft doc refresh from #10545.

This PR updates a few spots that still pointed readers at the old gulp workflow:

- **notes-on-solution-packaging.md** — describes the package-solution step as a Heft task (same idea as in the provisioning docs).
- **debug-in-vscode.md** — image alt text now matches `heft start` instead of gulp serve.
- **set-up-your-development-environment.md** — hosted workbench note references `heft start`.

I bumped `ms.date` on the pages I touched. Happy to split into separate PRs if you prefer one file per change.

— Zain (@zainshahbaz786)