### PR TITLE
Update SPE docs for retrieval API 1.0 with PAYG

### DIFF
--- a/docs/embedded/build/agent-experiences.md
+++ b/docs/embedded/build/agent-experiences.md
@@ -34,7 +34,7 @@ Choose the knowledge source when you want Foundry to manage retrieval and agent 
 The [Microsoft 365 Copilot Retrieval API](/microsoft-365/copilot/extensibility/api/ai-services/retrieval/copilotroot-retrieval) returns relevant text extracts that your app passes to its own model as grounding data. Set `dataSource` to `sharePointEmbedded` to retrieve from SharePoint Embedded content.
 
 > [!NOTE]
-> The `sharePointEmbedded` data source is in preview in its entirety, including its pay-as-you-go billing. The Copilot Retrieval API itself is generally available on the Microsoft Graph `v1.0` endpoint, but don't use the `sharePointEmbedded` data source in production.
+> Retrieval API support for the `sharePointEmbedded` data source is in preview.
 
 ### Retrieval API prerequisites
 

--- a/docs/embedded/build/agent-experiences.md
+++ b/docs/embedded/build/agent-experiences.md
@@ -1,7 +1,7 @@
 ---
 title: Add Microsoft 365 Copilot and agent experiences
 description: Ground agents in SharePoint Embedded content with Microsoft Foundry knowledge sources and the Copilot Retrieval API.
-ms.date: 07/28/2026
+ms.date: 07/10/2026
 ms.reviewer: pemtaira
 ms.author: mawin
 ms.localizationpriority: high
@@ -19,17 +19,22 @@ outcome: Configure Foundry knowledge sources and the Copilot Retrieval API over 
 next: migrate-azure-blob-storage.md
 -->
 
-SharePoint Embedded agent experiences let your app answer questions over files stored in SharePoint Embedded containers. The recommended path is to use **Microsoft Foundry Agent Service** with a **SharePoint knowledge source** configured for SharePoint Embedded. For setup steps, see [Set up SharePoint Embedded as a Foundry knowledge source](sharepoint-embedded-knowledge-source.md).
+SharePoint Embedded agent experiences let your app answer questions over files stored in SharePoint Embedded containers. Two separate products ground those experiences in container content:
+
+- **Microsoft Foundry Agent Service with a SharePoint knowledge source** — for agents you build on Foundry. Foundry runs retrieval for you as part of the agent. For setup steps, see [Set up SharePoint Embedded as a Foundry knowledge source](sharepoint-embedded-knowledge-source.md).
+- **Microsoft 365 Copilot Retrieval API** — for custom agents and apps that run their own grounding step. Call it from any app, including a Foundry agent that doesn't use the SharePoint knowledge source.
+
+Choose the knowledge source when you want Foundry to manage retrieval and agent orchestration. Choose the Retrieval API when you want to control the grounding step, the prompt, and the model yourself.
 
 > [!CAUTION]
-> The earlier **SharePoint Embedded agent SDK** (the React `ChatEmbedded` control) was **deprecated in March 2026** and replaced by [Microsoft Foundry Agent Service](/azure/foundry/agents/overview) with a [SharePoint knowledge source (preview)](/azure/search/agentic-knowledge-source-how-to-sharepoint-remote) configured for SharePoint Embedded. Use the Foundry knowledge source for new work.
+> The earlier **SharePoint Embedded agent SDK** (the React `ChatEmbedded` control) was **deprecated in March 2026** and replaced by [Microsoft Foundry Agent Service](/azure/foundry/agents/overview) with a [SharePoint knowledge source (preview)](/azure/search/agentic-knowledge-source-how-to-sharepoint-remote) configured for SharePoint Embedded. Use one of the two options in this article for new work.
 
 ## Use the Retrieval API
 
-Use the [Microsoft 365 Copilot Retrieval API](/graph/api/copilotroot-retrieval) when your app builds its own grounding step instead of using a Foundry knowledge source. Set `dataSource` to `sharePointEmbedded` to scope retrieval to SharePoint Embedded content.
+The [Microsoft 365 Copilot Retrieval API](/microsoft-365/copilot/extensibility/api/ai-services/retrieval/copilotroot-retrieval) returns relevant text extracts that your app passes to its own model as grounding data. Set `dataSource` to `sharePointEmbedded` to retrieve from SharePoint Embedded content.
 
 > [!NOTE]
-> Retrieval API support for the `sharePointEmbedded` data source is in preview.
+> The `sharePointEmbedded` data source is in preview in its entirety, including its pay-as-you-go billing. The Copilot Retrieval API itself is generally available on the Microsoft Graph `v1.0` endpoint, but don't use the `sharePointEmbedded` data source in production.
 
 ### Retrieval API prerequisites
 
@@ -46,9 +51,7 @@ Call `POST /copilot/retrieval` with a delegated token. Set `dataSource` to `shar
 ```http
 POST https://graph.microsoft.com/v1.0/copilot/retrieval
 Content-Type: application/json
-```
 
-```json
 {
   "queryString": "What are the terms of the Contoso agreement?",
   "dataSource": "sharePointEmbedded",
@@ -56,8 +59,7 @@ Content-Type: application/json
     "sharePointEmbedded": {
       "containerTypeId": "{containerTypeId}"
     }
-  },
-  "resourceMetadata": ["containerTypeId"]
+  }
 }
 ```
 
@@ -69,20 +71,21 @@ The response returns a `retrievalHits` collection. Each hit identifies a source 
 {
   "retrievalHits": [
     {
-      "webUrl": "https://contoso.sharepoint.com/contentstorage/...&file=agreement.docx",
+      "webUrl": "https://contoso.com/spe/file",
       "extracts": [
         {
           "text": "The agreement renews annually unless either party gives 30 days' notice.",
           "relevanceScore": 0.8421
         }
-      ],
-      "resourceMetadata": {
-        "containerTypeId": "{containerTypeId}"
-      }
+      ]
     }
   ]
 }
 ```
+
+The shape of `webUrl` depends on the container type's `urlTemplate` setting, so treat it as an opaque link rather than parsing it. To resolve file details, call [Get a driveItem](/graph/api/driveitem-get). For more information about `urlTemplate`, see [Create and configure a container type](create-container-type.md#configure-container-type-behavior).
+
+To return extra fields such as `title` or `author` with each hit, add a `resourceMetadata` collection to the request. Request only the fields your app uses, because each field adds to the response payload.
 
 Pass the extracts to your own model or answer-generation step as grounding data. This snippet sends the query and reads the top extract from each hit:
 
@@ -98,8 +101,7 @@ const response = await fetch("https://graph.microsoft.com/v1.0/copilot/retrieval
     dataSource: "sharePointEmbedded",
     dataSourceConfiguration: {
       sharePointEmbedded: { containerTypeId: containerTypeId }
-    },
-    resourceMetadata: ["containerTypeId"]
+    }
   })
 });
 
@@ -121,7 +123,7 @@ For meter details, see [Billing meters](../reference/billing-meters.md). To comp
 
 ## Test user experience
 
-Sign in with a user who has a Microsoft 365 Copilot license when required. Upload supported files to a container, wait for indexing, open the chat, and ask questions the file content can answer. If answers omit expected files, check:
+Sign in with a user who can access the container content. Upload supported files to a container, wait for indexing, open the chat, and ask questions the file content can answer. If answers omit expected files, check:
 
 - Discoverability.
 - Supported file formats.
@@ -134,3 +136,4 @@ Sign in with a user who has a Microsoft 365 Copilot license when required. Uploa
 
 - [Set up SharePoint Embedded as a Foundry knowledge source](sharepoint-embedded-knowledge-source.md)
 - [Billing meters](../reference/billing-meters.md)
+- [Choose a billing model](../plan/choose-billing-model.md)

--- a/docs/embedded/build/agent-experiences.md
+++ b/docs/embedded/build/agent-experiences.md
@@ -1,7 +1,7 @@
 ---
 title: Add Microsoft 365 Copilot and agent experiences
-description: Ground Copilot-style agents in SharePoint Embedded content and expose SharePoint Embedded to Microsoft Foundry.
-ms.date: 07/10/2026
+description: Ground agents in SharePoint Embedded content with Microsoft Foundry knowledge sources and the Copilot Retrieval API.
+ms.date: 07/28/2026
 ms.reviewer: pemtaira
 ms.author: mawin
 ms.localizationpriority: high
@@ -15,7 +15,7 @@ ai-usage: ai-assisted
 <!-- agent:
 task_type: how-to
 audience: developer
-outcome: Configure Foundry knowledge sources over SharePoint Embedded containers.
+outcome: Configure Foundry knowledge sources and the Copilot Retrieval API over SharePoint Embedded containers.
 next: migrate-azure-blob-storage.md
 -->
 
@@ -23,6 +23,101 @@ SharePoint Embedded agent experiences let your app answer questions over files s
 
 > [!CAUTION]
 > The earlier **SharePoint Embedded agent SDK** (the React `ChatEmbedded` control) was **deprecated in March 2026** and replaced by [Microsoft Foundry Agent Service](/azure/foundry/agents/overview) with a [SharePoint knowledge source (preview)](/azure/search/agentic-knowledge-source-how-to-sharepoint-remote) configured for SharePoint Embedded. Use the Foundry knowledge source for new work.
+
+## Use the Retrieval API
+
+Use the [Microsoft 365 Copilot Retrieval API](/graph/api/copilotroot-retrieval) when your app builds its own grounding step instead of using a Foundry knowledge source. Set `dataSource` to `sharePointEmbedded` to scope retrieval to SharePoint Embedded content.
+
+> [!NOTE]
+> Retrieval API support for the `sharePointEmbedded` data source is in preview.
+
+### Retrieval API prerequisites
+
+- A SharePoint Embedded app with at least one container, plus the container type ID.
+- Pay-as-you-go billing configured for the container type.
+- At least one user in the tenant with a Microsoft 365 Copilot license, so the semantic index initializes. For more information, see [Semantic index for Microsoft 365 Copilot](/microsoftsearch/semantic-index-for-copilot).
+
+The `sharePointEmbedded` data source bills pay-as-you-go, so each user who queries the Retrieval API doesn't need an individual Microsoft 365 Copilot license.
+
+### Retrieve content from a container type
+
+Call `POST /copilot/retrieval` with a delegated token. Set `dataSource` to `sharePointEmbedded` and pass your container type ID in `dataSourceConfiguration`. The request needs the `FileStorageContainer.Selected` delegated permission, and the service trims results to content the signed-in user can access.
+
+```http
+POST https://graph.microsoft.com/v1.0/copilot/retrieval
+Content-Type: application/json
+```
+
+```json
+{
+  "queryString": "What are the terms of the Contoso agreement?",
+  "dataSource": "sharePointEmbedded",
+  "dataSourceConfiguration": {
+    "sharePointEmbedded": {
+      "containerTypeId": "{containerTypeId}"
+    }
+  },
+  "resourceMetadata": ["containerTypeId"]
+}
+```
+
+Replace `{containerTypeId}` with your container type ID.
+
+The response returns a `retrievalHits` collection. Each hit identifies a source file through `webUrl` and carries one or more `extracts`, ordered by `relevanceScore`.
+
+```json
+{
+  "retrievalHits": [
+    {
+      "webUrl": "https://contoso.sharepoint.com/contentstorage/...&file=agreement.docx",
+      "extracts": [
+        {
+          "text": "The agreement renews annually unless either party gives 30 days' notice.",
+          "relevanceScore": 0.8421
+        }
+      ],
+      "resourceMetadata": {
+        "containerTypeId": "{containerTypeId}"
+      }
+    }
+  ]
+}
+```
+
+Pass the extracts to your own model or answer-generation step as grounding data. This snippet sends the query and reads the top extract from each hit:
+
+```javascript
+const response = await fetch("https://graph.microsoft.com/v1.0/copilot/retrieval", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${accessToken}`
+  },
+  body: JSON.stringify({
+    queryString: query,
+    dataSource: "sharePointEmbedded",
+    dataSourceConfiguration: {
+      sharePointEmbedded: { containerTypeId: containerTypeId }
+    },
+    resourceMetadata: ["containerTypeId"]
+  })
+});
+
+const data = await response.json();
+const grounding = (data.retrievalHits ?? []).map(hit => ({
+  url: hit.webUrl,
+  text: hit.extracts?.[0]?.text?.trim(),
+  score: hit.extracts?.[0]?.relevanceScore
+}));
+```
+
+Retrieval covers every container of the container type that the signed-in user can access. If a request returns no hits, confirm that the semantic index initialized, that indexing finished, and that the user has access to the content.
+
+### Retrieval API billing
+
+Retrieval API requests that use the `sharePointEmbedded` data source bill on the Copilot Studio message meter. Charges follow the billing model configured for the container type. Standard billing charges the owning tenant's Azure subscription, and pass-through billing charges the consuming tenant's subscription.
+
+For meter details, see [Billing meters](../reference/billing-meters.md). To compare models, see [Choose a billing model](../plan/choose-billing-model.md).
 
 ## Test user experience
 
@@ -38,3 +133,4 @@ Sign in with a user who has a Microsoft 365 Copilot license when required. Uploa
 ## Next steps
 
 - [Set up SharePoint Embedded as a Foundry knowledge source](sharepoint-embedded-knowledge-source.md)
+- [Billing meters](../reference/billing-meters.md)

--- a/docs/embedded/build/sharepoint-embedded-knowledge-source.md
+++ b/docs/embedded/build/sharepoint-embedded-knowledge-source.md
@@ -1,7 +1,7 @@
 ---
 title: Set up SharePoint Embedded as a Foundry knowledge source
 description: Configure Microsoft Foundry Agent Service to use SharePoint Embedded content as a SharePoint knowledge source.
-ms.date: 07/13/2026
+ms.date: 07/28/2026
 ms.reviewer: dilucesr
 ms.author: mawin
 ms.localizationpriority: high
@@ -21,20 +21,23 @@ next: migrate-azure-blob-storage.md
 
 Use Microsoft Foundry Agent Service with a SharePoint knowledge source when your app needs a grounded agent experience over files stored in SharePoint Embedded containers.
 
+For SharePoint Embedded container types, the knowledge source grounds answers through the [Microsoft 365 Copilot Retrieval API](/graph/api/copilotroot-retrieval). Foundry issues the retrieval calls for you, so the same prerequisites, indexing behavior, and billing apply. To call the API directly instead, see [Use the Retrieval API](agent-experiences.md#use-the-retrieval-api).
+
 > [!NOTE]
 > SharePoint knowledge sources for SharePoint Embedded are in preview.
 
 ## Prerequisites
 
-Before you start, make sure you have:
+Before you start, verify that you have:
 
 - A SharePoint Embedded app with at least one container.
 - The container type ID for the SharePoint Embedded app.
 - A Microsoft Foundry Agent Service project.
-- At least one Microsoft 365 Copilot license in the tenant during preview.
+- Pay-as-you-go billing configured for the container type.
+- At least one user in the tenant with a Microsoft 365 Copilot license, so the semantic index initializes. For more information, see [Semantic index for Microsoft 365 Copilot](/microsoftsearch/semantic-index-for-copilot).
 - Permission to update the container type registration in each consuming tenant where the agent must access content.
 
-During preview, the Copilot license is required. Billing requirements after preview are subject to change.
+Users who query the agent don't each need a Microsoft 365 Copilot license. Usage bills on the Copilot Studio message meter, and charges follow the billing model configured for the container type. For more information, see [Billing meters](../reference/billing-meters.md).
 
 ## Configure the SharePoint knowledge source
 
@@ -76,6 +79,7 @@ If the answer omits expected files, check:
 
 - Container type registration in the consuming tenant.
 - Foundry application permission grants.
+- Semantic index initialization in the tenant.
 - User access to the container and files.
 - Supported file formats.
 - Content discoverability settings.
@@ -83,5 +87,6 @@ If the answer omits expected files, check:
 
 ## Next steps
 
+- [Use the Retrieval API](agent-experiences.md#use-the-retrieval-api)
 - [Add Microsoft 365 Copilot and agent experiences](agent-experiences.md)
 - [Register application permissions](register-application-permissions.md)

--- a/docs/embedded/build/sharepoint-embedded-knowledge-source.md
+++ b/docs/embedded/build/sharepoint-embedded-knowledge-source.md
@@ -1,7 +1,7 @@
 ---
 title: Set up SharePoint Embedded as a Foundry knowledge source
 description: Configure Microsoft Foundry Agent Service to use SharePoint Embedded content as a SharePoint knowledge source.
-ms.date: 07/28/2026
+ms.date: 07/13/2026
 ms.reviewer: dilucesr
 ms.author: mawin
 ms.localizationpriority: high
@@ -21,7 +21,7 @@ next: migrate-azure-blob-storage.md
 
 Use Microsoft Foundry Agent Service with a SharePoint knowledge source when your app needs a grounded agent experience over files stored in SharePoint Embedded containers.
 
-For SharePoint Embedded container types, the knowledge source grounds answers through the [Microsoft 365 Copilot Retrieval API](/graph/api/copilotroot-retrieval). Foundry issues the retrieval calls for you, so the same prerequisites, indexing behavior, and billing apply. To call the API directly instead, see [Use the Retrieval API](agent-experiences.md#use-the-retrieval-api).
+For SharePoint Embedded container types, the knowledge source grounds answers through the generally available [Microsoft 365 Copilot Retrieval API](/microsoft-365/copilot/extensibility/api/ai-services/retrieval/copilotroot-retrieval). Foundry runs the retrieval calls as part of the agent, so the same prerequisites, indexing behavior, and billing apply. The `sharePointEmbedded` data source that Foundry uses is in preview. To run your own grounding step instead, call the Retrieval API directly, as described in [Use the Retrieval API](agent-experiences.md#use-the-retrieval-api).
 
 > [!NOTE]
 > SharePoint knowledge sources for SharePoint Embedded are in preview.

--- a/docs/embedded/reference/billing-meters.md
+++ b/docs/embedded/reference/billing-meters.md
@@ -1,7 +1,7 @@
 ---
 title: Billing meters
 description: Reference for SharePoint Embedded pay-as-you-go billing meters and pricing resources.
-ms.date: 07/28/2026
+ms.date: 07/13/2026
 ms.reviewer: pemtaira
 ms.author: mawin
 ms.localizationpriority: high
@@ -51,7 +51,7 @@ Egress is data that exits the SharePoint Embedded platform, such as a document d
 
 The private preview SharePoint Embedded agent meter uses the Copilot Studio message meter. One SharePoint Embedded agent interaction uses 12 messages: two for generative answer and 10 for tenant graph grounding.
 
-[Copilot Retrieval API](/graph/api/copilotroot-retrieval) requests that use the preview `sharePointEmbedded` data source also bill on the Copilot Studio message meter. Charges follow the billing model configured for the container type, so standard billing container types charge the owning tenant and pass-through billing container types charge the consuming tenant. For more information, see [Add Microsoft 365 Copilot and agent experiences](../build/agent-experiences.md#use-the-retrieval-api).
+[Copilot Retrieval API](/microsoft-365/copilot/extensibility/api/ai-services/retrieval/copilotroot-retrieval) requests that use the `sharePointEmbedded` data source also bill on the Copilot Studio message meter. The `sharePointEmbedded` data source is in preview in its entirety, including its pay-as-you-go billing, although the Retrieval API itself is generally available. Charges follow the billing model configured for the container type, so standard billing container types charge the owning tenant and pass-through billing container types charge the consuming tenant. For more information, see [Add Microsoft 365 Copilot and agent experiences](../build/agent-experiences.md#use-the-retrieval-api).
 
 ## Pricing links
 

--- a/docs/embedded/reference/billing-meters.md
+++ b/docs/embedded/reference/billing-meters.md
@@ -1,7 +1,7 @@
 ---
 title: Billing meters
 description: Reference for SharePoint Embedded pay-as-you-go billing meters and pricing resources.
-ms.date: 07/13/2026
+ms.date: 07/28/2026
 ms.reviewer: pemtaira
 ms.author: mawin
 ms.localizationpriority: high
@@ -29,7 +29,7 @@ For setup guidance, see [choose a billing model](../plan/choose-billing-model.md
 | Archived storage | $/GB | Storage consumed by archived containers within a tenant. | Archiving moves data to the cold storage tier, which offers lower storage costs than active storage. |
 | API transactions | $/Transactions | Each Microsoft Graph call made explicitly by the SharePoint Embedded application. | Internal service calls, such as eDiscovery queries and admin actions in SharePoint admin center or SharePoint PowerShell, aren't charged as application transactions. |
 | Egress | $/GB | Data that exits the SharePoint Embedded platform, such as documents downloaded to a customer's client device or data transferred to a server operated by the customer. Charges are based on total volume transferred out (GB). | Downloads from the SharePoint Embedded application server to Office Desktop clients or Web Application Companion, the Microsoft-integrated Office web experience, aren't charged as egress. |
-| Pay-as-you-go message (private preview) | Message | SharePoint Embedded agent interactions. | SharePoint Embedded agents use the Copilot Studio meter. Each agent interaction uses 12 messages. |
+| Pay-as-you-go message (private preview) | Message | SharePoint Embedded agent interactions and Copilot Retrieval API requests that use the preview `sharePointEmbedded` data source. | Both use the Copilot Studio meter. Each agent interaction uses 12 messages. |
 
 ## Storage
 
@@ -50,6 +50,8 @@ Egress is data that exits the SharePoint Embedded platform, such as a document d
 ## Agent message meter
 
 The private preview SharePoint Embedded agent meter uses the Copilot Studio message meter. One SharePoint Embedded agent interaction uses 12 messages: two for generative answer and 10 for tenant graph grounding.
+
+[Copilot Retrieval API](/graph/api/copilotroot-retrieval) requests that use the preview `sharePointEmbedded` data source also bill on the Copilot Studio message meter. Charges follow the billing model configured for the container type, so standard billing container types charge the owning tenant and pass-through billing container types charge the consuming tenant. For more information, see [Add Microsoft 365 Copilot and agent experiences](../build/agent-experiences.md#use-the-retrieval-api).
 
 ## Pricing links
 

--- a/docs/embedded/reference/troubleshooting.md
+++ b/docs/embedded/reference/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting
 description: Common SharePoint Embedded setup, auth, billing, Office, search, webhook, and admin issues.
-ms.date: 07/28/2026
+ms.date: 07/09/2026
 ms.reviewer: pemtaira
 ms.author: mawin
 ms.localizationpriority: high

--- a/docs/embedded/reference/troubleshooting.md
+++ b/docs/embedded/reference/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting
 description: Common SharePoint Embedded setup, auth, billing, Office, search, webhook, and admin issues.
-ms.date: 07/09/2026
+ms.date: 07/28/2026
 ms.reviewer: pemtaira
 ms.author: mawin
 ms.localizationpriority: high
@@ -33,6 +33,7 @@ Use this reference to identify likely causes and fixes. For end-to-end setup, se
 | Search API calls fail because of permissions. | Search scenarios require delegated Microsoft Graph permissions during preview, including `Files.Read.All` in addition to `FileStorageContainer.Selected`. | Request and consent to the required delegated permissions and retest with a signed-in user. | [Build search experiences](../build/search-containers-files.md) |
 | Webhook subscription validation fails. | The notification endpoint doesn't echo the `validationToken` as plain text, or the endpoint isn't publicly reachable. | Return `200` with the `validationToken` and `Content-Type: text/plain`; expose the endpoint through a reachable public URL. | [Use webhooks](../build/respond-to-changes-webhooks.md) |
 | Webhook notifications don't identify the intended container. | The subscription notification URL doesn't carry the container ID, or the handler doesn't read it. | Append `driveId={{ContainerId}}` to the notification URL and have the handler read the `driveId` query parameter. | [Use webhooks](../build/respond-to-changes-webhooks.md) |
+| Copilot Retrieval API requests against the preview `sharePointEmbedded` data source return no results. | No user in the tenant has a Microsoft 365 Copilot license, so the semantic index never initialized. Content might also still be indexing. | Assign a Microsoft 365 Copilot license to at least one user in the tenant, then retry after indexing completes. Individual querying users don't need their own license. For more information, see [Semantic index for Microsoft 365 Copilot](/microsoftsearch/semantic-index-for-copilot). | [Use the Retrieval API](../build/agent-experiences.md#use-the-retrieval-api) |
 | Container isn't visible in SharePoint admin center. | The admin is using the wrong owning application ID, identity, or role. | Confirm the owning application ID and admin role, then refresh the admin experience. | [Admin overview](../admin/admin-overview.md) |
 
 ## Diagnostic links

--- a/docs/embedded/whats-new.md
+++ b/docs/embedded/whats-new.md
@@ -20,6 +20,7 @@ next: overview.md
 
 ## July 2026
 
+- The [Copilot Retrieval API](/graph/api/copilotroot-retrieval) supports the `sharePointEmbedded` data source in preview with pay-as-you-go billing.
 - You can [use the Model Context Protocol (MCP) server to build apps with a coding agent](./build/sharepoint-embedded-mcp-server.md). The open-source SharePoint Embedded MCP server npm package ([`@microsoft/spe-mcp`](https://github.com/microsoft/SharePoint-Embedded-MCP-Server)) is preview software. It lets MCP-compatible AI clients, such as GitHub Copilot in Visual Studio Code or the CLI, Claude, or Cursor, provision and manage SharePoint Embedded applications through natural language.
 
 ## June 2026

--- a/docs/embedded/whats-new.md
+++ b/docs/embedded/whats-new.md
@@ -20,7 +20,7 @@ next: overview.md
 
 ## July 2026
 
-- The [Copilot Retrieval API](/graph/api/copilotroot-retrieval) supports the `sharePointEmbedded` data source in preview with pay-as-you-go billing.
+- The [Copilot Retrieval API](/microsoft-365/copilot/extensibility/api/ai-services/retrieval/copilotroot-retrieval) is generally available and now offers a `sharePointEmbedded` data source in preview, with pay-as-you-go billing on the Copilot Studio message meter. Users who query the API no longer each need a Microsoft 365 Copilot license, but one licensed user still initializes the semantic index. For more information, see [Use the Retrieval API](./build/agent-experiences.md#use-the-retrieval-api).
 - You can [use the Model Context Protocol (MCP) server to build apps with a coding agent](./build/sharepoint-embedded-mcp-server.md). The open-source SharePoint Embedded MCP server npm package ([`@microsoft/spe-mcp`](https://github.com/microsoft/SharePoint-Embedded-MCP-Server)) is preview software. It lets MCP-compatible AI clients, such as GitHub Copilot in Visual Studio Code or the CLI, Claude, or Cursor, provision and manage SharePoint Embedded applications through natural language.
 
 ## June 2026


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## What's in this Pull Request?

Documents Copilot Retrieval API support for the `sharePointEmbedded` data source in the SharePoint Embedded docs.

The Retrieval API is generally available, and its new `sharePointEmbedded` data source (in preview) is billed pay-as-you-go. Two facts weren't documented anywhere under `docs/embedded/`:

- **Licensing** — Because the data source is pay-as-you-go, users who query the API no longer each need a Microsoft 365 Copilot license. One licensed user in the tenant is still required to initialize the semantic index. The prerequisites link to [Semantic index for Microsoft 365 Copilot](/microsoftsearch/semantic-index-for-copilot) rather than restating it.
- **Billing** — Requests bill on the Copilot Studio message meter, and charges follow the billing model configured for the container type (standard or pass-through).

### Changes

| File | Change |
| --- | --- |
| `build/agent-experiences.md` | New **Use the Retrieval API** section: preview note, prerequisites, a `POST /copilot/retrieval` request/response example with a JavaScript snippet, and billing. |
| `build/sharepoint-embedded-knowledge-source.md` | Notes that Foundry grounds through the Retrieval API for SharePoint Embedded container types; prerequisites updated from "at least one Copilot license during preview" to the semantic index and pay-as-you-go billing model. |
| `reference/billing-meters.md` | Retrieval API requests added to the Copilot Studio message meter. |
| `plan/choose-billing-model.md` | Retrieval API charges follow the container type's billing model. |
| `reference/troubleshooting.md` | New row for "no results returned" caused by an uninitialized semantic index. |
| `whats-new.md` | July 2026 entry. |

All six articles state that the Retrieval API is generally available while the `sharePointEmbedded` data source is in preview in its entirety, including its pay-as-you-go billing. `ms.date` updated to 07/28/2026 on each file. No new articles, so `docs/toc.yml` is unchanged.