### PR TITLE
Restore modernization article publication dates

### DIFF
--- a/docs/transform/assessment-tool-classic-pages-report.md
+++ b/docs/transform/assessment-tool-classic-pages-report.md
@@ -1,7 +1,7 @@
 ---
 title: Interpret the classic pages assessment report
 description: Use page, web part, usage, and rollup results from the Microsoft 365 Assessment tool to plan SharePoint page modernization.
-ms.date: 07/29/2026
+ms.date: 07/27/2026
 ms.localizationpriority: high
 ms.service: sharepoint
 ---

--- a/docs/transform/assessment-tool-classic-pages-report.md
+++ b/docs/transform/assessment-tool-classic-pages-report.md
@@ -1,7 +1,7 @@
 ---
 title: Interpret the classic pages assessment report
 description: Use page, web part, usage, and rollup results from the Microsoft 365 Assessment tool to plan SharePoint page modernization.
-ms.date: 07/27/2026
+ms.date: 07/22/2026
 ms.localizationpriority: high
 ms.service: sharepoint
 ---

--- a/docs/transform/assessment-tool-classic-pages-requirements.md
+++ b/docs/transform/assessment-tool-classic-pages-requirements.md
@@ -1,7 +1,7 @@
 ---
 title: Requirements for the classic pages assessment
 description: Configure authentication, permissions, audit access, and a supported environment for the Microsoft 365 Assessment tool classic pages component.
-ms.date: 07/29/2026
+ms.date: 07/27/2026
 ms.localizationpriority: high
 ms.service: sharepoint
 ---

--- a/docs/transform/assessment-tool-classic-pages-requirements.md
+++ b/docs/transform/assessment-tool-classic-pages-requirements.md
@@ -1,7 +1,7 @@
 ---
 title: Requirements for the classic pages assessment
 description: Configure authentication, permissions, audit access, and a supported environment for the Microsoft 365 Assessment tool classic pages component.
-ms.date: 07/27/2026
+ms.date: 07/22/2026
 ms.localizationpriority: high
 ms.service: sharepoint
 ---

--- a/docs/transform/assessment-tool-classic-pages-run.md
+++ b/docs/transform/assessment-tool-classic-pages-run.md
@@ -1,7 +1,7 @@
 ---
 title: Run a classic pages assessment
 description: Start, scope, monitor, and report a Microsoft 365 Assessment tool classic pages assessment.
-ms.date: 07/27/2026
+ms.date: 07/22/2026
 ms.localizationpriority: high
 ms.service: sharepoint
 ---

--- a/docs/transform/assessment-tool-classic-pages-run.md
+++ b/docs/transform/assessment-tool-classic-pages-run.md
@@ -1,7 +1,7 @@
 ---
 title: Run a classic pages assessment
 description: Start, scope, monitor, and report a Microsoft 365 Assessment tool classic pages assessment.
-ms.date: 07/29/2026
+ms.date: 07/27/2026
 ms.localizationpriority: high
 ms.service: sharepoint
 ---

--- a/docs/transform/assessment-tool-classic-pages.md
+++ b/docs/transform/assessment-tool-classic-pages.md
@@ -1,7 +1,7 @@
 ---
 title: Assess classic SharePoint pages
 description: Discover classic pages, inventory their web parts, and measure page modernization readiness.
-ms.date: 07/29/2026
+ms.date: 07/27/2026
 ms.localizationpriority: high
 ms.service: sharepoint
 ---

--- a/docs/transform/assessment-tool-classic-pages.md
+++ b/docs/transform/assessment-tool-classic-pages.md
@@ -1,7 +1,7 @@
 ---
 title: Assess classic SharePoint pages
 description: Discover classic pages, inventory their web parts, and measure page modernization readiness.
-ms.date: 07/27/2026
+ms.date: 07/22/2026
 ms.localizationpriority: high
 ms.service: sharepoint
 ---

--- a/docs/transform/assessment-tool-publishing-coverage.md
+++ b/docs/transform/assessment-tool-publishing-coverage.md
@@ -1,7 +1,7 @@
 ---
 title: Assess publishing pages for transformation
 description: Use Microsoft 365 Assessment tool publishing-page output to plan page transformation and page-layout mapping.
-ms.date: 07/29/2026
+ms.date: 07/27/2026
 ms.localizationpriority: high
 ms.service: sharepoint
 ---

--- a/docs/transform/assessment-tool-publishing-coverage.md
+++ b/docs/transform/assessment-tool-publishing-coverage.md
@@ -1,7 +1,7 @@
 ---
 title: Assess publishing pages for transformation
 description: Use Microsoft 365 Assessment tool publishing-page output to plan page transformation and page-layout mapping.
-ms.date: 07/27/2026
+ms.date: 07/22/2026
 ms.localizationpriority: high
 ms.service: sharepoint
 ---

--- a/docs/transform/modernize-userinterface-site-pages-powershell.md
+++ b/docs/transform/modernize-userinterface-site-pages-powershell.md
@@ -1,7 +1,7 @@
 ---
 title: Transform selected classic pages with PnP PowerShell
 description: Prepare a minimally privileged PnP PowerShell connection and transform approved classic pages with source-preserving defaults.
-ms.date: 02/09/2023
+ms.date: 11/19/2018
 ms.localizationpriority: high
 ms.service: sharepoint
 ---

--- a/docs/transform/modernize-userinterface-site-pages-powershell.md
+++ b/docs/transform/modernize-userinterface-site-pages-powershell.md
@@ -1,7 +1,7 @@
 ---
 title: Transform selected classic pages with PnP PowerShell
 description: Prepare a minimally privileged PnP PowerShell connection and transform approved classic pages with source-preserving defaults.
-ms.date: 07/29/2026
+ms.date: 02/09/2023
 ms.localizationpriority: high
 ms.service: sharepoint
 ---

--- a/docs/transform/modernize-userinterface-site-pages.md
+++ b/docs/transform/modernize-userinterface-site-pages.md
@@ -1,7 +1,7 @@
 ---
 title: Transform classic SharePoint pages to modern pages
 description: Select assessed classic pages, transform a representative wave with PnP PowerShell, validate the results, and expand safely.
-ms.date: 08/13/2024
+ms.date: 03/22/2018
 ms.localizationpriority: high
 ms.service: sharepoint
 ---

--- a/docs/transform/modernize-userinterface-site-pages.md
+++ b/docs/transform/modernize-userinterface-site-pages.md
@@ -1,7 +1,7 @@
 ---
 title: Transform classic SharePoint pages to modern pages
 description: Select assessed classic pages, transform a representative wave with PnP PowerShell, validate the results, and expand safely.
-ms.date: 07/28/2026
+ms.date: 08/13/2024
 ms.localizationpriority: high
 ms.service: sharepoint
 ---


### PR DESCRIPTION
## Summary

- Restore five Classic Page Assessment articles to their original publication date from PR #10961.
- Restore two existing page-transformation articles to the dates they had before PR #10964.
- Leave the dates on articles first introduced by PR #10961 or PR #10964 unchanged.

## Context

This follows the review guidance on PR #10959 that `ms.date` represents the article publication date rather than the date of a later update.

## Scope

This PR changes only seven `ms.date` values. It doesn't change article content, navigation, links, filenames, or Learn URLs.

## Restored values

| Articles | Restored `ms.date` |
| --- | --- |
| Five Classic Page Assessment articles published in PR #10961 | `07/27/2026` |
| PnP PowerShell page-transformation article | `02/09/2023` |
| Page-transformation overview | `08/13/2024` |

## Validation

- GitHub PR diff: seven files, with one `ms.date` replacement per file and no other changed lines.
- OpenPublishing, PoliCheck, and CLA pass on commit `6ba68a0be`.
