### PR TITLE
Removed 100K container limit and added limit for custom columns per c…

### DIFF
--- a/docs/embedded/plan/limits-calling-patterns.md
+++ b/docs/embedded/plan/limits-calling-patterns.md
@@ -48,7 +48,6 @@ SharePoint Embedded enforces the following size limits.
 | --- | --- |
 | Container types that a developer tenant can create | 25* |
 | Container types that an app can own | 1 |
-| Containers of a container type per consuming tenant | 100,000* |
 | Storage per container type per consuming tenant | 100 TB* |
 | Files and folders per container | 30 million |
 | Storage per container | 25 TB |
@@ -56,6 +55,7 @@ SharePoint Embedded enforces the following size limits.
 | File size | 250 GB |
 | Version count per file | 500 (default automatic version history limit) |
 | Number of users shared per folder or file | 5,000 |
+| Custom Columns per container | 40 |
 
 An asterisk (`*`) indicates a limit you can request to increase.
 


### PR DESCRIPTION
…ontainer

Added a new limit for custom columns per container to be 40.  Also removed the 100K container limit.  There is no hard upper limit and it confuses customers.

## Category

- [ x] Content fix
- [ ] New article
- [] Example checked item (*delete this line*)

## What's in this Pull Request?

Removed the 100K container limit.  There is no hard upper limit and it confuses customers giving them the impression that it doesn't scale for large solutions.

Added custom column support for each container to be at 40.


