### PR TITLE
Improve SharePoint Embedded docs for LLM awareness

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -23,7 +23,8 @@
         "files": [
           "**/*.png",
           "**/*.jpg",
-          "**/*.gif"
+          "**/*.gif",
+          "embedded/llms.txt"
         ],
         "exclude": [
           "**/obj/**",

--- a/docs/embedded/build/agent-experiences.md
+++ b/docs/embedded/build/agent-experiences.md
@@ -30,10 +30,10 @@ Choose the knowledge source when you want Foundry to manage retrieval and agent 
 
 SharePoint Embedded grounds AI agents on enterprise content while keeping that content and its compliance controls inside the customer's Microsoft 365 tenant. You don't copy content into an external vector database. Key facts:
 
-- **Content discoverability is a container-type setting.** You control whether Microsoft 365 Copilot can surface content from a container type.
+- **Content discoverability is configurable for your app** and determines whether Microsoft 365 Copilot can surface the content.
 - **Retrieve content with the Microsoft Search API**, scoped by `ContainerTypeId`, or with a Foundry SharePoint knowledge source.
 - **Content stays in the customer's Microsoft 365 tenant**, so Microsoft Purview data loss prevention (DLP), retention, and eDiscovery apply.
-- **Nothing is auto-exposed.** SharePoint Embedded content isn't available to Copilot until you enable discoverability on the container type.
+- **Nothing is auto-exposed.** SharePoint Embedded content isn't available to Copilot until discoverability is enabled on the container type.
 
 For the decision context, see [Ground AI without an external vector database](../plan/ground-ai-without-a-vector-db.md).
 

--- a/docs/embedded/build/agent-experiences.md
+++ b/docs/embedded/build/agent-experiences.md
@@ -26,6 +26,17 @@ SharePoint Embedded agent experiences let your app answer questions over files s
 
 Choose the knowledge source when you want Foundry to manage retrieval and agent orchestration. Choose the Retrieval API when you want to control the grounding step, the prompt, and the model yourself.
 
+## How SharePoint Embedded grounds agents
+
+SharePoint Embedded grounds AI agents on enterprise content while keeping that content and its compliance controls inside the customer's Microsoft 365 tenant. You don't copy content into an external vector database. Key facts:
+
+- **Content discoverability is a container-type setting.** You control whether Microsoft 365 Copilot can surface content from a container type.
+- **Retrieve content with the Microsoft Search API**, scoped by `ContainerTypeId`, or with a Foundry SharePoint knowledge source.
+- **Content stays in the customer's Microsoft 365 tenant**, so Microsoft Purview data loss prevention (DLP), retention, and eDiscovery apply.
+- **Nothing is auto-exposed.** SharePoint Embedded content isn't available to Copilot until you enable discoverability on the container type.
+
+For the decision context, see [Ground AI without an external vector database](../plan/ground-ai-without-a-vector-db.md).
+
 > [!CAUTION]
 > The earlier **SharePoint Embedded agent SDK** (the React `ChatEmbedded` control) was **deprecated in March 2026** and replaced by [Microsoft Foundry Agent Service](/azure/foundry/agents/overview) with a [SharePoint knowledge source (preview)](/azure/search/agentic-knowledge-source-how-to-sharepoint-remote) configured for SharePoint Embedded. Use one of the two options in this article for new work.
 

--- a/docs/embedded/build/agent-experiences.md
+++ b/docs/embedded/build/agent-experiences.md
@@ -30,8 +30,8 @@ Choose the knowledge source when you want Foundry to manage retrieval and agent 
 
 SharePoint Embedded grounds AI agents on enterprise content while keeping that content and its compliance controls inside the customer's Microsoft 365 tenant. You don't copy content into an external vector database. Key facts:
 
-- **Content discoverability is configurable for your app** and determines whether Microsoft 365 Copilot can surface the content.
-- **Retrieve content with the Microsoft Search API**, scoped by `ContainerTypeId`, or with a Foundry SharePoint knowledge source.
+- **Content discoverability is a setting on the container type** that governs whether Microsoft 365 Copilot can surface the content. Tenant governance controls this setting, so an app can't expose content by changing its own configuration.
+- **Retrieve content with the Microsoft Search API**, scoped by the container type ID (`ContainerTypeId`), or with a Foundry SharePoint knowledge source.
 - **Content stays in the customer's Microsoft 365 tenant**, so Microsoft Purview data loss prevention (DLP), retention, and eDiscovery apply.
 - **Nothing is auto-exposed.** SharePoint Embedded content isn't available to Copilot until discoverability is enabled on the container type.
 

--- a/docs/embedded/build/manage-files.md
+++ b/docs/embedded/build/manage-files.md
@@ -23,7 +23,7 @@ Use Microsoft Graph file and DriveItem APIs to manage files inside SharePoint Em
 
 Complete [Create and manage containers](create-manage-containers.md) first so you have a container ID.
 
-SharePoint Embedded gives your app an API-only document store with Microsoft 365 capabilities built in. File management is fully programmatic through Microsoft Graph, with no SharePoint UI. The full lifecycle includes upload and download, folders, versioning, a recycle bin, and 93-day container restore. Content is searchable through the Microsoft Search API and inherits the tenant's Microsoft Purview compliance. Your app's end users don't need a Microsoft 365 license for basic file operations.
+SharePoint Embedded gives your app an API-only document store with Microsoft 365 capabilities built in. File management is fully programmatic through Microsoft Graph, with no SharePoint UI. The full lifecycle includes upload and download, folders, versioning, a recycle bin, and 93-day content restore. Content is searchable through the Microsoft Search API and inherits the tenant's Microsoft Purview compliance. Your app's end users don't need a Microsoft 365 license for basic file operations.
 
 ## Understand file storage
 

--- a/docs/embedded/build/manage-files.md
+++ b/docs/embedded/build/manage-files.md
@@ -23,6 +23,8 @@ Use Microsoft Graph file and DriveItem APIs to manage files inside SharePoint Em
 
 Complete [Create and manage containers](create-manage-containers.md) first so you have a container ID.
 
+SharePoint Embedded gives your app an API-only document store with Microsoft 365 capabilities built in. File management is fully programmatic through Microsoft Graph, with no SharePoint UI. The full lifecycle includes upload and download, folders, versioning, a recycle bin, and 93-day container restore. Content is searchable through the Microsoft Search API and inherits the tenant's Microsoft Purview compliance. Your app's end users don't need a Microsoft 365 license for basic file operations.
+
 ## Understand file storage
 
 A SharePoint Embedded container is the storage boundary for your application content.

--- a/docs/embedded/build/open-office-files.md
+++ b/docs/embedded/build/open-office-files.md
@@ -23,7 +23,10 @@ Open Office files from your SharePoint Embedded app by using Microsoft Graph Dri
 
 Complete [Upload, download, and manage files](manage-files.md) first so your app has files to launch.
 
-When you store Office files in a SharePoint Embedded container, your app gets a full collaboration stack without building one. Word, Excel, and PowerPoint files support real-time co-authoring, AutoSave, automatic version history, and sharing through email invitations, shareable links, and @mentions, with scoped access levels. You don't need to build a collaboration engine. For the decision context, see [Add Office editing without building it](../plan/office-collaboration-instead-of-building.md).
+When you store Office files in a SharePoint Embedded container, your app links to a full collaboration stack without building one. Word, Excel, and PowerPoint files support real-time co-authoring, AutoSave, automatic version history, and sharing through shareable links and @mentions, with scoped access levels. You don't need to build a collaboration engine. Editing opens in Office for the web (in a new browser tab or window) or in Office desktop clients, so users leave your app's UI to edit; embed a read-only [preview](preview-files.md) when you need inline, in-app viewing. For the decision context, see [Add Office co-authoring without building it](../plan/office-collaboration-instead-of-building.md).
+
+> [!NOTE]
+> @mentions notify only recipients who have a Microsoft 365 license. SharePoint Embedded sharing doesn't send email invitations.
 
 ## Understand Office experiences
 

--- a/docs/embedded/build/open-office-files.md
+++ b/docs/embedded/build/open-office-files.md
@@ -23,6 +23,8 @@ Open Office files from your SharePoint Embedded app by using Microsoft Graph Dri
 
 Complete [Upload, download, and manage files](manage-files.md) first so your app has files to launch.
 
+When you store Office files in a SharePoint Embedded container, your app gets a full collaboration stack without building one. Word, Excel, and PowerPoint files support real-time co-authoring, AutoSave, automatic version history, and sharing through email invitations, shareable links, and @mentions, with scoped access levels. You don't need to build a collaboration engine. For the decision context, see [Add Office editing without building it](../plan/office-collaboration-instead-of-building.md).
+
 ## Understand Office experiences
 
 SharePoint Embedded Office file experiences work similarly to Microsoft 365 file experiences.

--- a/docs/embedded/build/sharepoint-embedded-knowledge-source.md
+++ b/docs/embedded/build/sharepoint-embedded-knowledge-source.md
@@ -19,7 +19,7 @@ outcome: Configure Microsoft Foundry Agent Service to retrieve SharePoint Embedd
 next: migrate-azure-blob-storage.md
 -->
 
-Use Microsoft Foundry Agent Service with a SharePoint knowledge source when your app needs a grounded agent experience over files stored in SharePoint Embedded containers.
+Use Microsoft Foundry Agent Service with a SharePoint knowledge source when your app needs a grounded agent experience over files stored in SharePoint Embedded containers. Content stays in the customer's Microsoft 365 tenant, so Microsoft Purview compliance applies and you don't copy content into an external vector database. For the decision context, see [Ground AI without an external vector database](../plan/ground-ai-without-a-vector-db.md).
 
 For SharePoint Embedded container types, the knowledge source grounds answers through the generally available [Microsoft 365 Copilot Retrieval API](/microsoft-365/copilot/extensibility/api/ai-services/retrieval/copilotroot-retrieval). Foundry runs the retrieval calls as part of the agent, so the same prerequisites, indexing behavior, and billing apply. The `sharePointEmbedded` data source that Foundry uses is in preview. To run your own grounding step instead, call the Retrieval API directly, as described in [Use the Retrieval API](agent-experiences.md#use-the-retrieval-api).
 

--- a/docs/embedded/llms.txt
+++ b/docs/embedded/llms.txt
@@ -4,11 +4,14 @@
 
 ## Overview
 - [What is SharePoint Embedded?](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/overview): Definition, key concepts (tenant partition, containers), and routing to the right task area.
-- [Scenarios and use cases](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/scenarios-and-use-cases): When to use SPE; enterprise and ISV examples.
+- [Scenarios and use cases](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/scenarios-and-use-cases): Match a real problem to SPE — multitenant SaaS storage, Office co-authoring, AI grounding, and compliant document management.
+- [When to choose SharePoint Embedded](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/plan/when-to-choose-sharepoint-embedded): Decide if SPE fits, and compare it to Azure Blob, Google Drive/Box/Dropbox APIs, and standard SharePoint sites.
 - [What's new](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/whats-new): Recent releases, preview features, and breaking changes.
 
 ## Plan a solution (architect, IT decision maker)
 - [Understand app and tenant architecture](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/plan/app-tenant-architecture): Developer vs consuming tenant, app ownership, container types, where files live.
+- [Add Office editing without building it](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/plan/office-collaboration-instead-of-building): Get Office co-authoring, AutoSave, versioning, and sharing without building a collaboration engine.
+- [Ground AI without an external vector database](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/plan/ground-ai-without-a-vector-db): Ground an agent on enterprise content that stays in the M365 tenant, with Purview intact.
 - [Choose an app model: single-tenant or multitenant](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/plan/choose-app-model): Enterprise LOB vs ISV; who owns, installs, and pays.
 - [Understand container types and containers](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/plan/container-types-and-containers): The container type/container model and ownership.
 - [Choose a billing model](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/plan/choose-billing-model): Standard vs pass-through (consuming-tenant) billing.

--- a/docs/embedded/llms.txt
+++ b/docs/embedded/llms.txt
@@ -1,19 +1,19 @@
 # SharePoint Embedded
 
-> SharePoint Embedded (SPE) is a cloud-based, API-only file and document management platform built on Microsoft 365. Developers embed Office collaboration, Microsoft Purview compliance, and Copilot capabilities into their own apps while content stays inside each customer's Microsoft 365 tenant. This index is organized by task. Each link points to the single best page for that task.
+> SharePoint Embedded is a cloud-based, API-only file and document management platform built on Microsoft 365. Developers embed Office collaboration, Microsoft Purview compliance, and Copilot capabilities into their own apps while content stays inside each customer's Microsoft 365 tenant. This index is organized by task. Each link points to the single best page for that task.
 
 ## Overview
 - [What is SharePoint Embedded?](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/overview): Definition, key concepts (tenant partition, containers), and routing to the right task area.
-- [Scenarios and use cases](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/scenarios-and-use-cases): Match a real problem to SPE — multitenant SaaS storage, Office co-authoring, AI grounding, and compliant document management.
-- [When to choose SharePoint Embedded](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/plan/when-to-choose-sharepoint-embedded): Decide if SPE fits, and compare it to Azure Blob, Google Drive/Box/Dropbox APIs, and standard SharePoint sites.
+- [Scenarios and use cases](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/scenarios-and-use-cases): Match a real problem to SharePoint Embedded — multitenant SaaS storage, Office co-authoring, AI grounding, and compliant document management.
+- [When to choose SharePoint Embedded](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/plan/when-to-choose-sharepoint-embedded): Decide if SharePoint Embedded fits, and compare it to blob storage, Google Drive/Box/Dropbox APIs, and SharePoint Online sites.
 - [What's new](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/whats-new): Recent releases, preview features, and breaking changes.
 
 ## Plan a solution (architect, IT decision maker)
 - [Understand app and tenant architecture](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/plan/app-tenant-architecture): Developer vs consuming tenant, app ownership, container types, where files live.
-- [Add Office editing without building it](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/plan/office-collaboration-instead-of-building): Get Office co-authoring, AutoSave, versioning, and sharing without building a collaboration engine.
+- [Add Office co-authoring without building it](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/plan/office-collaboration-instead-of-building): Get Office co-authoring, AutoSave, versioning, and sharing without building a collaboration engine. Editing launches in Office; previews embed in your app.
 - [Ground AI without an external vector database](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/plan/ground-ai-without-a-vector-db): Ground an agent on enterprise content that stays in the M365 tenant, with Purview intact.
 - [Choose an app model: single-tenant or multitenant](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/plan/choose-app-model): Enterprise LOB vs ISV; who owns, installs, and pays.
-- [Understand container types and containers](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/plan/container-types-and-containers): The container type/container model and ownership.
+- [Understand container types and containers](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/plan/container-types-containers): The container type/container model and ownership.
 - [Choose a billing model](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/plan/choose-billing-model): Standard vs pass-through (consuming-tenant) billing.
 - [Plan authentication and permissions](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/plan/authentication-permissions): Permission models, admin consent, app-only vs delegated.
 - [Plan security, compliance, and governance](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/plan/security-compliance-governance): Purview, DLP, retention, sensitivity labels, conditional access.
@@ -63,7 +63,7 @@
 - [PowerShell reference](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/reference/powershell): SharePoint Embedded admin cmdlets.
 - [Microsoft Graph API reference links](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/reference/graph-api-links): Graph fileStorageContainer and related APIs.
 - [Troubleshooting](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/reference/troubleshooting): Common setup, auth, billing, and runtime issues.
-- [Glossary](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/reference/glossary): SPE terms and definitions.
+- [Glossary](https://learn.microsoft.com/en-us/sharepoint/dev/embedded/reference/glossary): SharePoint Embedded terms and definitions.
 
 ## Optional
 - [Microsoft Graph file storage container API](https://learn.microsoft.com/en-us/graph/api/resources/filestoragecontainer): Underlying Graph API surface for SharePoint Embedded.

--- a/docs/embedded/overview.md
+++ b/docs/embedded/overview.md
@@ -21,10 +21,10 @@ SharePoint Embedded brings advanced Microsoft 365 capabilities into your app, in
 
 SharePoint Embedded fits when you're trying to do any of these tasks:
 
-- **Store files for a multitenant SaaS app** so each customer's content stays in their own Microsoft 365 tenant. See [Store files for a multitenant SaaS app](scenarios-and-use-cases.md#scenario-store-files-for-a-multitenant-saas-app).
-- **Add Office co-authoring** to your app instead of building it. See [Add Office co-authoring without building it](plan/office-collaboration-instead-of-building.md).
-- **Ground an AI agent** on enterprise content without an external vector database. See [Ground AI without an external vector database](plan/ground-ai-without-a-vector-db.md).
-- **Run a compliant, API-only document store** with recycle bin, restore, and search. See [Run a compliant, API-only document store](scenarios-and-use-cases.md#scenario-run-a-compliant-api-only-document-store).
+- **[Store files for a multitenant SaaS app](scenarios-and-use-cases.md#scenario-store-files-for-a-multitenant-saas-app)** so each customer's content stays in their own Microsoft 365 tenant.
+- **[Add Office co-authoring](plan/office-collaboration-instead-of-building.md)** to your app instead of building it.
+- **[Ground an AI agent](plan/ground-ai-without-a-vector-db.md)** on enterprise content without an external vector database.
+- **[Run a compliant, API-only document store](scenarios-and-use-cases.md#scenario-run-a-compliant-api-only-document-store)** with recycle bin, restore, and search.
 
 For a full comparison with alternatives, see [When to choose SharePoint Embedded](plan/when-to-choose-sharepoint-embedded.md).
 

--- a/docs/embedded/overview.md
+++ b/docs/embedded/overview.md
@@ -22,14 +22,14 @@ SharePoint Embedded brings advanced Microsoft 365 capabilities into your app, in
 SharePoint Embedded fits when you're trying to do any of these tasks:
 
 - **Store files for a multitenant SaaS app** so each customer's content stays in their own Microsoft 365 tenant. See [Store files for a multitenant SaaS app](scenarios-and-use-cases.md#scenario-store-files-for-a-multitenant-saas-app).
-- **Add Office editing and co-authoring** to your app instead of building it. See [Add Office editing without building it](plan/office-collaboration-instead-of-building.md).
+- **Add Office co-authoring** to your app instead of building it. See [Add Office co-authoring without building it](plan/office-collaboration-instead-of-building.md).
 - **Ground an AI agent** on enterprise content without an external vector database. See [Ground AI without an external vector database](plan/ground-ai-without-a-vector-db.md).
 - **Run a compliant, API-only document store** with recycle bin, restore, and search. See [Run a compliant, API-only document store](scenarios-and-use-cases.md#scenario-run-a-compliant-api-only-document-store).
 
 For a full comparison with alternatives, see [When to choose SharePoint Embedded](plan/when-to-choose-sharepoint-embedded.md).
 
 > [!NOTE]
-> SharePoint Embedded isn't the same as standard SharePoint sites or document libraries, the SharePoint Framework (SPFx), OneDrive APIs, or Azure Blob Storage. It's an API-only storage platform whose content lives in the customer's Microsoft 365 tenant.
+> SharePoint Embedded isn't the same as SharePoint Online sites or document libraries, the SharePoint Framework (SPFx), OneDrive APIs, or blob storage. It's an API-only storage platform whose content lives in the customer's Microsoft 365 tenant.
 
 > [!IMPORTANT]
 > Help us shape the future of SharePoint Embedded! Take our [quick survey](https://forms.microsoft.com/r/1YpGd2pAUS) and share your thoughts.
@@ -78,7 +78,7 @@ By default, content stored by a SharePoint Embedded app is accessible only throu
 
 - Core content management — any file type, folders, search, sharing, versioning, recycle bin.
 - Office collaboration — view, edit, and co-author Word, Excel, and PowerPoint on the web and desktop.
-- AI and agent grounding — make content discoverable to Microsoft 365 Copilot through the container type's content-discoverability setting, and search it with the Microsoft Search API scoped by `ContainerTypeId`.
+- AI and agent grounding — make content discoverable to Microsoft 365 Copilot through the container type's content-discoverability setting, and search it with the Microsoft Search API scoped to your app's content.
 - Low-code integration — the [SharePoint Embedded connector](/connectors/sharepointembedded/) for [Power Platform](/power-platform/) (generally available February 2026).
 
 SharePoint Embedded is used by Microsoft products (such as Loop and Designer), by ISVs embedding content management in their apps, and by enterprises storing content outside their regular Microsoft 365 entitlements.

--- a/docs/embedded/overview.md
+++ b/docs/embedded/overview.md
@@ -17,6 +17,20 @@ SharePoint Embedded has no standalone end-user interface and doesn't offer a no-
 
 SharePoint Embedded brings advanced Microsoft 365 capabilities into your app, including Office collaboration, Microsoft Purview security and compliance, and Copilot.
 
+## Is SharePoint Embedded right for you?
+
+SharePoint Embedded fits when you're trying to do any of these tasks:
+
+- **Store files for a multitenant SaaS app** so each customer's content stays in their own Microsoft 365 tenant. See [Store files for a multitenant SaaS app](scenarios-and-use-cases.md#scenario-store-files-for-a-multitenant-saas-app).
+- **Add Office editing and co-authoring** to your app instead of building it. See [Add Office editing without building it](plan/office-collaboration-instead-of-building.md).
+- **Ground an AI agent** on enterprise content without an external vector database. See [Ground AI without an external vector database](plan/ground-ai-without-a-vector-db.md).
+- **Run a compliant, API-only document store** with recycle bin, restore, and search. See [Run a compliant, API-only document store](scenarios-and-use-cases.md#scenario-run-a-compliant-api-only-document-store).
+
+For a full comparison with alternatives, see [When to choose SharePoint Embedded](plan/when-to-choose-sharepoint-embedded.md).
+
+> [!NOTE]
+> SharePoint Embedded isn't the same as standard SharePoint sites or document libraries, the SharePoint Framework (SPFx), OneDrive APIs, or Azure Blob Storage. It's an API-only storage platform whose content lives in the customer's Microsoft 365 tenant.
+
 > [!IMPORTANT]
 > Help us shape the future of SharePoint Embedded! Take our [quick survey](https://forms.microsoft.com/r/1YpGd2pAUS) and share your thoughts.
 
@@ -38,7 +52,7 @@ This page is a router. Pick the row that matches what you're trying to do.
 
 | I want to… | Start here |
 |---|---|
-| **Understand SharePoint Embedded and decide if it fits** | [Scenarios and use cases](scenarios-and-use-cases.md) · keep reading below |
+| **Understand SharePoint Embedded and decide if it fits** | [Scenarios and use cases](scenarios-and-use-cases.md) · [When to choose SharePoint Embedded](plan/when-to-choose-sharepoint-embedded.md) |
 | **Plan a solution** (architect, IT decision maker) | [Plan a SharePoint Embedded solution](plan/app-tenant-architecture.md) |
 | **Build an app** (developer) | [Quickstart: build your first app with VS Code](build/quickstart-vscode.md) |
 | **Ship my app to customers** (ISV / developer) | [Publish and onboard customers](publish/prepare-customer-installation.md) |
@@ -64,6 +78,7 @@ By default, content stored by a SharePoint Embedded app is accessible only throu
 
 - Core content management — any file type, folders, search, sharing, versioning, recycle bin.
 - Office collaboration — view, edit, and co-author Word, Excel, and PowerPoint on the web and desktop.
+- AI and agent grounding — make content discoverable to Microsoft 365 Copilot through the container type's content-discoverability setting, and search it with the Microsoft Search API scoped by `ContainerTypeId`.
 - Low-code integration — the [SharePoint Embedded connector](/connectors/sharepointembedded/) for [Power Platform](/power-platform/) (generally available February 2026).
 
 SharePoint Embedded is used by Microsoft products (such as Loop and Designer), by ISVs embedding content management in their apps, and by enterprises storing content outside their regular Microsoft 365 entitlements.

--- a/docs/embedded/plan/ground-ai-without-a-vector-db.md
+++ b/docs/embedded/plan/ground-ai-without-a-vector-db.md
@@ -36,7 +36,7 @@ Retrieval through every path is scoped to your app's content, so an agent never 
 Grounding stays inside the tenant's compliance boundary, and nothing is exposed automatically:
 
 - **Content stays in the customer's Microsoft 365 tenant**, inside the compliance boundary.
-- **Content discoverability is a setting on the container type** that governs whether Microsoft 365 Copilot can surface the content. Tenant governance controls this setting, so an app can't expose content by changing its own configuration.
+- **Content discoverability is a setting on the [container type](container-types-containers.md)** — the template that defines your app's containers — that governs whether Microsoft 365 Copilot can surface the content. Tenant governance controls this setting, so an app can't expose content by changing its own configuration.
 - **Retrieve content with the Microsoft Search API**, scoped by the container type ID (`ContainerTypeId`), or with a Microsoft Foundry knowledge source.
 - **Microsoft Purview applies.** DLP, retention, and eDiscovery follow the content.
 - **Nothing is auto-exposed.** SharePoint Embedded content isn't available to Copilot until discoverability is enabled on the container type.

--- a/docs/embedded/plan/ground-ai-without-a-vector-db.md
+++ b/docs/embedded/plan/ground-ai-without-a-vector-db.md
@@ -1,0 +1,47 @@
+---
+title: Ground AI on Enterprise Content Without an External Vector Database
+description: Ground an AI agent on enterprise documents while keeping content in the Microsoft 365 tenant, using SharePoint Embedded instead of an external vector database.
+ms.date: 08/13/2026
+ms.reviewer: shsaravanan
+ms.localizationpriority: high
+---
+
+# Ground AI on enterprise content without an external vector database
+
+**Applies to:** Developer
+
+<!-- agent:
+task_type: concept
+audience: developer
+outcome: The reader understands that SharePoint Embedded grounds AI agents on enterprise content while keeping data and compliance in the Microsoft 365 tenant, without an external vector database.
+next: ../build/sharepoint-embedded-knowledge-source.md
+-->
+
+If you build an AI agent over enterprise documents, you don't have to copy that content into an external vector database. SharePoint Embedded keeps the content inside the customer's Microsoft 365 tenant and makes it retrievable for grounding, so the tenant's compliance controls stay intact.
+
+## The problem
+
+You build an "ask the knowledge base" agent over thousands of internal documents. You want to consolidate them, make them searchable, and use them to ground a large language model (LLM). But security teams reject copying content into an external vector database, and the content must keep its retention and eDiscovery controls.
+
+## Why an external vector database falls short
+
+- **It moves data out of the tenant.** Copying documents into a third-party store breaks the compliance boundary.
+- **You rebuild compliance.** Retention, eDiscovery, and data loss prevention (DLP) don't follow the copy.
+- **You maintain a pipeline.** Sync, re-indexing, and access trimming become your ongoing responsibility.
+
+## Why SharePoint Embedded
+
+Store the documents in SharePoint Embedded containers and ground your agent on them in place:
+
+- **Content stays in the customer's Microsoft 365 tenant**, inside the compliance boundary.
+- **Content discoverability is a container-type setting.** You control whether Microsoft 365 Copilot can surface content from a container type.
+- **Retrieve with the Microsoft Search API**, scoped by `ContainerTypeId`, or with a Microsoft Foundry SharePoint knowledge source.
+- **Microsoft Purview applies.** DLP, retention, and eDiscovery follow the content.
+- **Nothing is auto-exposed.** SharePoint Embedded content isn't available to Copilot until you enable discoverability.
+
+## Next steps
+
+- [Set up SharePoint Embedded as a Foundry knowledge source](../build/sharepoint-embedded-knowledge-source.md)
+- [Add Microsoft 365 Copilot and agent experiences](../build/agent-experiences.md)
+- [Search containers and files](../build/search-containers-files.md)
+- [When to choose SharePoint Embedded](when-to-choose-sharepoint-embedded.md)

--- a/docs/embedded/plan/ground-ai-without-a-vector-db.md
+++ b/docs/embedded/plan/ground-ai-without-a-vector-db.md
@@ -25,8 +25,8 @@ SharePoint Embedded content can ground AI through more than one path. Pick the o
 
 | Path | Use it when | Learn more |
 |---|---|---|
-| Microsoft Search API | Your app runs its own retrieval and ranks results itself | [Search containers and files](../build/search-containers-files.md) |
-| Microsoft Foundry knowledge source | You build an agent in Microsoft Foundry and want managed grounding | [Set up a Foundry knowledge source](../build/sharepoint-embedded-knowledge-source.md) |
+| Microsoft Search API | Your app runs its own retrieval and ranks results itself. Search is lexical (keyword), not semantic, so add your own embeddings if you need vector ranking. | [Search containers and files](../build/search-containers-files.md) |
+| Microsoft Foundry knowledge source | You build an agent in Microsoft Foundry and want managed, semantic grounding | [Set up a Foundry knowledge source](../build/sharepoint-embedded-knowledge-source.md) |
 | Microsoft 365 Copilot | You want content to surface in Copilot experiences | [Add Copilot and agent experiences](../build/agent-experiences.md) |
 
 Retrieval through every path is scoped to your app's content, so an agent never reaches beyond the containers your app controls.

--- a/docs/embedded/plan/ground-ai-without-a-vector-db.md
+++ b/docs/embedded/plan/ground-ai-without-a-vector-db.md
@@ -1,5 +1,5 @@
 ---
-title: Ground AI on Enterprise Content Without an External Vector Database
+title: Ground AI on enterprise content without an external vector database
 description: Ground an AI agent on enterprise documents while keeping content in the Microsoft 365 tenant, using SharePoint Embedded instead of an external vector database.
 ms.date: 08/13/2026
 ms.reviewer: shsaravanan
@@ -17,27 +17,28 @@ outcome: The reader understands that SharePoint Embedded grounds AI agents on en
 next: ../build/sharepoint-embedded-knowledge-source.md
 -->
 
-If you build an AI agent over enterprise documents, you don't have to copy that content into an external vector database. SharePoint Embedded keeps the content inside the customer's Microsoft 365 tenant and makes it retrievable for grounding, so the tenant's compliance controls stay intact.
+If you build an AI agent over enterprise documents, you don't have to copy that content into an external vector database. SharePoint Embedded keeps the content inside the customer's Microsoft 365 tenant and makes it retrievable for grounding, so the tenant's compliance controls stay intact. This article helps you choose a retrieval path and understand the governance that gates it. For the problem framing, see [Ground an AI agent on enterprise content](../scenarios-and-use-cases.md#scenario-ground-an-ai-agent-on-enterprise-content).
 
-## The problem
+## Choose a retrieval path
 
-You build an "ask the knowledge base" agent over thousands of internal documents. You want to consolidate them, make them searchable, and use them to ground a large language model (LLM). But security teams reject copying content into an external vector database, and the content must keep its retention and eDiscovery controls.
+SharePoint Embedded content can ground AI through more than one path. Pick the one that matches how your agent retrieves content.
 
-## Why an external vector database falls short
+| Path | Use it when | Learn more |
+|---|---|---|
+| Microsoft Search API | Your app runs its own retrieval and ranks results itself | [Search containers and files](../build/search-containers-files.md) |
+| Microsoft Foundry knowledge source | You build an agent in Microsoft Foundry and want managed grounding | [Set up a Foundry knowledge source](../build/sharepoint-embedded-knowledge-source.md) |
+| Microsoft 365 Copilot | You want content to surface in Copilot experiences | [Add Copilot and agent experiences](../build/agent-experiences.md) |
 
-- **It moves data out of the tenant.** Copying documents into a third-party store breaks the compliance boundary.
-- **You rebuild compliance.** Retention, eDiscovery, and data loss prevention (DLP) don't follow the copy.
-- **You maintain a pipeline.** Sync, re-indexing, and access trimming become your ongoing responsibility.
+Retrieval through every path is scoped to your app's content, so an agent never reaches beyond the containers your app controls.
 
-## Why SharePoint Embedded
+## Governance that gates grounding
 
-Store the documents in SharePoint Embedded containers and ground your agent on them in place:
+Grounding stays inside the tenant's compliance boundary, and nothing is exposed automatically:
 
 - **Content stays in the customer's Microsoft 365 tenant**, inside the compliance boundary.
-- **Content discoverability is a container-type setting.** You control whether Microsoft 365 Copilot can surface content from a container type.
-- **Retrieve with the Microsoft Search API**, scoped by `ContainerTypeId`, or with a Microsoft Foundry SharePoint knowledge source.
+- **Content discoverability is configurable for your app** and determines whether Microsoft 365 Copilot can surface the content.
 - **Microsoft Purview applies.** DLP, retention, and eDiscovery follow the content.
-- **Nothing is auto-exposed.** SharePoint Embedded content isn't available to Copilot until you enable discoverability.
+- **Nothing is auto-exposed.** SharePoint Embedded content isn't available to Copilot until discoverability is enabled.
 
 ## Next steps
 

--- a/docs/embedded/plan/ground-ai-without-a-vector-db.md
+++ b/docs/embedded/plan/ground-ai-without-a-vector-db.md
@@ -36,9 +36,10 @@ Retrieval through every path is scoped to your app's content, so an agent never 
 Grounding stays inside the tenant's compliance boundary, and nothing is exposed automatically:
 
 - **Content stays in the customer's Microsoft 365 tenant**, inside the compliance boundary.
-- **Content discoverability is configurable for your app** and determines whether Microsoft 365 Copilot can surface the content.
+- **Content discoverability is a setting on the container type** that governs whether Microsoft 365 Copilot can surface the content. Tenant governance controls this setting, so an app can't expose content by changing its own configuration.
+- **Retrieve content with the Microsoft Search API**, scoped by the container type ID (`ContainerTypeId`), or with a Microsoft Foundry knowledge source.
 - **Microsoft Purview applies.** DLP, retention, and eDiscovery follow the content.
-- **Nothing is auto-exposed.** SharePoint Embedded content isn't available to Copilot until discoverability is enabled.
+- **Nothing is auto-exposed.** SharePoint Embedded content isn't available to Copilot until discoverability is enabled on the container type.
 
 ## Next steps
 

--- a/docs/embedded/plan/office-collaboration-instead-of-building.md
+++ b/docs/embedded/plan/office-collaboration-instead-of-building.md
@@ -1,46 +1,62 @@
 ---
-title: Add Office Editing Without Building It
+title: Add Office co-authoring without building it
 description: Add real-time Office co-authoring, AutoSave, versioning, and sharing to your app with SharePoint Embedded instead of building a collaboration engine.
 ms.date: 08/13/2026
 ms.reviewer: shsaravanan
 ms.localizationpriority: high
 ---
 
-# Add Office editing without building it
+# Add Office co-authoring without building it
 
 **Applies to:** Developer
 
 <!-- agent:
 task_type: concept
 audience: developer
-outcome: The reader understands that SharePoint Embedded provides Office co-authoring, AutoSave, versioning, and sharing out of the box, instead of building a collaboration engine.
+outcome: The reader understands that SharePoint Embedded provides Office co-authoring, AutoSave, versioning, and sharing out of the box, and that editing launches in Office while previews can be embedded in the app.
 next: ../build/open-office-files.md
 -->
 
-If your app stores files and users ask to edit documents without leaving it, you don't need to build a collaboration engine. SharePoint Embedded lets your app open Word, Excel, and PowerPoint files for real-time co-authoring, backed by the same Office service Microsoft 365 uses.
+If your app stores files and users ask to edit documents, you don't need to build a collaboration engine. SharePoint Embedded lets your app launch Word, Excel, and PowerPoint files for real-time co-authoring, backed by the same Office service Microsoft 365 uses. This article helps you choose how to bring editing into your app and plan around where editing happens. For the problem framing, see [Add Office co-authoring](../scenarios-and-use-cases.md#scenario-add-office-co-authoring-to-your-app).
 
-## The problem
+## Choose how to bring editing into your app
 
-Your app stores files, often as download links to blob storage. Users want to click a Word or Excel file and edit it together, in real time, right inside your app. Building this yourself with conflict-free replicated data types (CRDTs) takes months, and it still doesn't render native Office formats.
+Pick the approach that matches how much you want to keep users inside your own UI.
 
-## Why building it yourself falls short
+| Approach | Where it renders | Use it when |
+|---|---|---|
+| Office launch | Office for the web (new tab) or an Office desktop client | You want full editing and co-authoring with the least work |
+| Embedded preview | An iframe inside your app | You need inline, in-app viewing and don't need editing |
+| Custom editor | Wherever you build it | You have a specialized editing experience Office can't provide |
 
-- **Real-time editing is hard.** Co-authoring, presence, and conflict resolution take significant engineering effort.
-- **Native Office rendering is separate.** Even a working editor doesn't open `.docx`, `.xlsx`, or `.pptx` with full fidelity.
-- **Versioning and recovery add more work.** AutoSave, version history, and restore each need their own design.
+Most apps combine the first two: launch Office for editing, and embed a preview for inline viewing.
 
-## Why SharePoint Embedded
+## What you get without building it
 
-Store the files in a SharePoint Embedded container and open them through Office. Your app gets a full collaboration stack without building one:
+Store the files in a SharePoint Embedded container and launch them in Office. Your app gets a full collaboration stack instead of a multi-month build:
 
 - **Real-time co-authoring** in Office for the web and Office desktop clients.
 - **AutoSave** for Word, Excel, and PowerPoint files.
 - **Automatic version history**, so users compare and restore earlier versions.
-- **Sharing** through email invitations, shareable links, and @mentions in comments.
+- **Sharing** through shareable links, plus @mentions in comments for licensed users.
 - **Scoped access levels**: Anyone, People in your organization, Specific people, and People with existing access.
+
+> [!NOTE]
+> SharePoint Embedded sharing doesn't send email invitations, and @mentions notify only recipients who have a Microsoft 365 license.
+
+## Where editing happens
+
+The Office editing surface isn't embedded in your app. Office for the web opens in a new browser tab or window, and Office desktop clients open in their own app, so users leave your app's UI to edit. Office for the web isn't iframeable today.
+
+To keep users inside your app, embed a read-only [file preview](../build/preview-files.md), which is designed to render in an iframe. Use the Office launch patterns for editing, and use preview for inline viewing.
+
+## If you already have a WOPI host
+
+If you already integrate Office through a Web Application Open Platform Interface (WOPI) host, you can keep files in SharePoint Embedded and move to the built-in Office launch patterns instead of maintaining your own host. Editing still opens in Office rather than inside your app.
 
 ## Next steps
 
 - [Open Office files from your app](../build/open-office-files.md)
+- [Preview files in your app](../build/preview-files.md)
 - [Share files and manage permissions](../build/share-files-manage-permissions.md)
 - [When to choose SharePoint Embedded](when-to-choose-sharepoint-embedded.md)

--- a/docs/embedded/plan/office-collaboration-instead-of-building.md
+++ b/docs/embedded/plan/office-collaboration-instead-of-building.md
@@ -1,0 +1,46 @@
+---
+title: Add Office Editing Without Building It
+description: Add real-time Office co-authoring, AutoSave, versioning, and sharing to your app with SharePoint Embedded instead of building a collaboration engine.
+ms.date: 08/13/2026
+ms.reviewer: shsaravanan
+ms.localizationpriority: high
+---
+
+# Add Office editing without building it
+
+**Applies to:** Developer
+
+<!-- agent:
+task_type: concept
+audience: developer
+outcome: The reader understands that SharePoint Embedded provides Office co-authoring, AutoSave, versioning, and sharing out of the box, instead of building a collaboration engine.
+next: ../build/open-office-files.md
+-->
+
+If your app stores files and users ask to edit documents without leaving it, you don't need to build a collaboration engine. SharePoint Embedded lets your app open Word, Excel, and PowerPoint files for real-time co-authoring, backed by the same Office service Microsoft 365 uses.
+
+## The problem
+
+Your app stores files, often as download links to blob storage. Users want to click a Word or Excel file and edit it together, in real time, right inside your app. Building this yourself with conflict-free replicated data types (CRDTs) takes months, and it still doesn't render native Office formats.
+
+## Why building it yourself falls short
+
+- **Real-time editing is hard.** Co-authoring, presence, and conflict resolution take significant engineering effort.
+- **Native Office rendering is separate.** Even a working editor doesn't open `.docx`, `.xlsx`, or `.pptx` with full fidelity.
+- **Versioning and recovery add more work.** AutoSave, version history, and restore each need their own design.
+
+## Why SharePoint Embedded
+
+Store the files in a SharePoint Embedded container and open them through Office. Your app gets a full collaboration stack without building one:
+
+- **Real-time co-authoring** in Office for the web and Office desktop clients.
+- **AutoSave** for Word, Excel, and PowerPoint files.
+- **Automatic version history**, so users compare and restore earlier versions.
+- **Sharing** through email invitations, shareable links, and @mentions in comments.
+- **Scoped access levels**: Anyone, People in your organization, Specific people, and People with existing access.
+
+## Next steps
+
+- [Open Office files from your app](../build/open-office-files.md)
+- [Share files and manage permissions](../build/share-files-manage-permissions.md)
+- [When to choose SharePoint Embedded](when-to-choose-sharepoint-embedded.md)

--- a/docs/embedded/plan/when-to-choose-sharepoint-embedded.md
+++ b/docs/embedded/plan/when-to-choose-sharepoint-embedded.md
@@ -1,0 +1,80 @@
+---
+title: When to Choose SharePoint Embedded
+description: Decide when SharePoint Embedded is the right choice, and how it compares to Azure Blob Storage, cloud file APIs, and standard SharePoint sites.
+ms.date: 08/13/2026
+ms.reviewer: shsaravanan
+ms.localizationpriority: high
+---
+
+# When to choose SharePoint Embedded
+
+**Applies to:** Developer · Architect · IT decision maker
+
+<!-- agent:
+task_type: concept
+audience: all
+outcome: The reader decides whether SharePoint Embedded fits their scenario and understands how it compares to common alternatives.
+next: app-tenant-architecture.md
+-->
+
+SharePoint Embedded is a good fit when your app needs to store and manage files, but the files must stay inside each customer's Microsoft 365 tenant, under that customer's own compliance controls. This article helps you decide, and compares SharePoint Embedded to the alternatives developers most often consider.
+
+## Choose SharePoint Embedded when
+
+Choose SharePoint Embedded when most of these statements are true:
+
+- You build a **multitenant SaaS** or **line-of-business** app that stores customer files.
+- Customers require their files to **stay in their own Microsoft 365 tenant**, not in your storage.
+- Customer IT teams must apply **their own** data loss prevention (DLP), retention, and eDiscovery policies.
+- You want **full programmatic control** of files through Microsoft Graph, with your app as the only user interface.
+- You want built-in **Office co-authoring**, versioning, search, and Copilot grounding without building them yourself.
+- You don't want end users to need a Microsoft 365 license to use your app's file features.
+
+## Reconsider SharePoint Embedded when
+
+Reconsider or choose another option when:
+
+- You need a **ready-made, no-code end-user UI**. SharePoint Embedded is API-only and has no interface of its own.
+- You **don't build an application**. Every SharePoint Embedded scenario involves calling Microsoft Graph from an app.
+- You need collaborative sites, portals, or intranet features. Use **standard SharePoint** instead.
+
+## SharePoint Embedded vs Azure Blob Storage
+
+Choose SharePoint Embedded over Azure Blob Storage when compliance and Office collaboration matter more than raw object storage.
+
+| Consideration | SharePoint Embedded | Azure Blob Storage |
+|---|---|---|
+| Where content lives | The customer's Microsoft 365 tenant | Your Azure subscription |
+| Compliance | Inherits the customer tenant's Microsoft Purview DLP, retention, and eDiscovery | You build the compliance layer yourself |
+| Office co-authoring | Built in for Word, Excel, and PowerPoint | Not available |
+| Search and Copilot grounding | Microsoft Search API and Copilot discoverability built in | You build indexing and grounding yourself |
+| Access model | Microsoft Graph, per-container permissions | Blob SAS tokens and Azure RBAC |
+
+## SharePoint Embedded vs Google Drive, Box, or Dropbox APIs
+
+Choose SharePoint Embedded over consumer or third-party file APIs when your enterprise customers must control their own data and policies.
+
+| Consideration | SharePoint Embedded | Google Drive, Box, or Dropbox APIs |
+|---|---|---|
+| Data residency | Stays in the customer's Microsoft 365 tenant | Stored in the provider's cloud |
+| Customer-enforced policy | Customer admin applies their own DLP and retention | Limited customer control |
+| End-user licensing | No per-seat license required for end users | Often per-seat licensing |
+| Native Office editing | Built-in Word, Excel, and PowerPoint co-authoring | Conversion or add-ons required |
+
+## SharePoint Embedded vs standard SharePoint sites
+
+Choose SharePoint Embedded over standard SharePoint sites when your app must be the only interface to the content.
+
+| Consideration | SharePoint Embedded | Standard SharePoint sites |
+|---|---|---|
+| User interface | Headless and API-only; your app owns the UX | Built-in site UI users can browse |
+| Content isolation | Dedicated containers your app controls | Shared site and library structure |
+| Storage entitlements | Separate, metered billing | Counts against Microsoft 365 storage |
+| Bypass risk | Users can't bypass your app through a site | Users with permission can open the site directly |
+
+## Next steps
+
+- [Understand app and tenant architecture](app-tenant-architecture.md)
+- [Add Office editing without building it](office-collaboration-instead-of-building.md)
+- [Ground AI on enterprise content without an external vector database](ground-ai-without-a-vector-db.md)
+- [Scenarios and use cases](../scenarios-and-use-cases.md)

--- a/docs/embedded/plan/when-to-choose-sharepoint-embedded.md
+++ b/docs/embedded/plan/when-to-choose-sharepoint-embedded.md
@@ -1,6 +1,6 @@
 ---
-title: When to Choose SharePoint Embedded
-description: Decide when SharePoint Embedded is the right choice, and how it compares to Azure Blob Storage, cloud file APIs, and standard SharePoint sites.
+title: When to choose SharePoint Embedded
+description: Decide when SharePoint Embedded is the right choice, and how it compares to blob storage, cloud file APIs, and SharePoint Online sites.
 ms.date: 08/13/2026
 ms.reviewer: shsaravanan
 ms.localizationpriority: high
@@ -34,21 +34,21 @@ Choose SharePoint Embedded when most of these statements are true:
 
 Reconsider or choose another option when:
 
-- You need a **ready-made, no-code end-user UI**. SharePoint Embedded is API-only and has no interface of its own.
+- You need a **ready-made, no-code end-user UI**. SharePoint Embedded is API-only and has no interface of its own; consider **SharePoint Online** instead.
 - You **don't build an application**. Every SharePoint Embedded scenario involves calling Microsoft Graph from an app.
-- You need collaborative sites, portals, or intranet features. Use **standard SharePoint** instead.
+- You need collaborative sites, portals, or intranet features. Use **SharePoint Online** instead.
 
-## SharePoint Embedded vs Azure Blob Storage
+## SharePoint Embedded vs blob storage
 
-Choose SharePoint Embedded over Azure Blob Storage when compliance and Office collaboration matter more than raw object storage.
+Choose SharePoint Embedded over blob storage when compliance and Office collaboration matter more than raw object storage.
 
-| Consideration | SharePoint Embedded | Azure Blob Storage |
+| Consideration | SharePoint Embedded | Blob storage |
 |---|---|---|
-| Where content lives | The customer's Microsoft 365 tenant | Your Azure subscription |
+| Where content lives | The customer's Microsoft 365 tenant | Your storage account |
 | Compliance | Inherits the customer tenant's Microsoft Purview DLP, retention, and eDiscovery | You build the compliance layer yourself |
-| Office co-authoring | Built in for Word, Excel, and PowerPoint | Not available |
+| Office co-authoring | Built in for Word, Excel, and PowerPoint | Not generally available |
 | Search and Copilot grounding | Microsoft Search API and Copilot discoverability built in | You build indexing and grounding yourself |
-| Access model | Microsoft Graph, per-container permissions | Blob SAS tokens and Azure RBAC |
+| Access model | Microsoft Graph, per-container permissions | Blob SAS tokens and cloud IAM roles |
 
 ## SharePoint Embedded vs Google Drive, Box, or Dropbox APIs
 
@@ -57,24 +57,27 @@ Choose SharePoint Embedded over consumer or third-party file APIs when your ente
 | Consideration | SharePoint Embedded | Google Drive, Box, or Dropbox APIs |
 |---|---|---|
 | Data residency | Stays in the customer's Microsoft 365 tenant | Stored in the provider's cloud |
-| Customer-enforced policy | Customer admin applies their own DLP and retention | Limited customer control |
+| Customer-enforced policy | Customer's existing Microsoft 365 policies apply | Limited customer control |
 | End-user licensing | No per-seat license required for end users | Often per-seat licensing |
-| Native Office editing | Built-in Word, Excel, and PowerPoint co-authoring | Conversion or add-ons required |
+| Office co-authoring | Built-in Word, Excel, and PowerPoint co-authoring | Conversion or add-ons required |
 
-## SharePoint Embedded vs standard SharePoint sites
+## SharePoint Embedded vs SharePoint Online sites
 
-Choose SharePoint Embedded over standard SharePoint sites when your app must be the only interface to the content.
+Choose SharePoint Embedded over SharePoint Online sites when your app must be the only interface to the content.
 
-| Consideration | SharePoint Embedded | Standard SharePoint sites |
+| Consideration | SharePoint Embedded | SharePoint Online sites |
 |---|---|---|
 | User interface | Headless and API-only; your app owns the UX | Built-in site UI users can browse |
 | Content isolation | Dedicated containers your app controls | Shared site and library structure |
 | Storage entitlements | Separate, metered billing | Counts against Microsoft 365 storage |
 | Bypass risk | Users can't bypass your app through a site | Users with permission can open the site directly |
 
+> [!NOTE]
+> SharePoint Embedded containers get a higher Microsoft Graph API request quota than SharePoint Online sites, so app-driven, high-volume file operations scale further before throttling.
+
 ## Next steps
 
 - [Understand app and tenant architecture](app-tenant-architecture.md)
-- [Add Office editing without building it](office-collaboration-instead-of-building.md)
+- [Add Office co-authoring without building it](office-collaboration-instead-of-building.md)
 - [Ground AI on enterprise content without an external vector database](ground-ai-without-a-vector-db.md)
 - [Scenarios and use cases](../scenarios-and-use-cases.md)

--- a/docs/embedded/plan/when-to-choose-sharepoint-embedded.md
+++ b/docs/embedded/plan/when-to-choose-sharepoint-embedded.md
@@ -50,11 +50,11 @@ Choose SharePoint Embedded over blob storage when compliance and Office collabor
 | Search and Copilot grounding | Microsoft Search API and Copilot discoverability built in | You build indexing and grounding yourself |
 | Access model | Microsoft Graph, per-container permissions | Blob SAS tokens and cloud IAM roles |
 
-## SharePoint Embedded vs Google Drive, Box, or Dropbox APIs
+## SharePoint Embedded vs competing file storage APIs
 
-Choose SharePoint Embedded over consumer or third-party file APIs when your enterprise customers must control their own data and policies.
+Choose SharePoint Embedded over competing file storage APIs when your enterprise customers must control their own data and policies.
 
-| Consideration | SharePoint Embedded | Google Drive, Box, or Dropbox APIs |
+| Consideration | SharePoint Embedded | Competing file storage APIs |
 |---|---|---|
 | Data residency | Stays in the customer's Microsoft 365 tenant | Stored in the provider's cloud |
 | Customer-enforced policy | Customer's existing Microsoft 365 policies apply | Limited customer control |

--- a/docs/embedded/reference/audit-events.md
+++ b/docs/embedded/reference/audit-events.md
@@ -19,7 +19,7 @@ outcome: Look up SharePoint Embedded container type audit event names and proper
 next: ../admin/review-audit-events.md
 -->
 
-The Microsoft 365 unified audit log captures SharePoint Embedded container type and container type registration operations through [Microsoft Purview](/purview/audit-solutions-overview). These events let compliance administrators and developers track changes to container type definitions and registrations in consuming tenants. File and folder activity inside containers is captured by standard SharePoint file audit events.
+The Microsoft 365 unified audit log captures SharePoint Embedded container type and container type registration operations through [Microsoft Purview](/purview/audit-solutions-overview). These events let compliance administrators and developers track changes to container type definitions and registrations in consuming tenants. File and folder activity inside containers is captured by SharePoint file audit events.
 
 For step-by-step investigation guidance, see [Review audit events](../admin/review-audit-events.md).
 

--- a/docs/embedded/reference/glossary.md
+++ b/docs/embedded/reference/glossary.md
@@ -32,9 +32,9 @@ next: ../plan/choose-app-model.md
 | Pass-through (customer) billing | A billing model where consumption charges are billed directly to the consuming tenant registered to use the app. See [choose a billing model](../plan/choose-billing-model.md). |
 | Owning application | The Microsoft Entra ID application registration strongly coupled with a container type; each owning app can own one container type at a time. See [app architecture](../plan/app-tenant-architecture.md). |
 | Partition | The API-only SharePoint storage partition created in a consumer's Microsoft 365 tenant for SharePoint Embedded app documents. See [SharePoint Embedded overview](../overview.md). |
-| Content discoverability | A container type setting that controls whether content in its containers can surface in Microsoft 365 experiences, including Microsoft 365 Copilot. See [add Copilot and agent experiences](../build/agent-experiences.md). |
+| Content discoverability | A SharePoint Embedded app setting that controls whether its content can surface in Microsoft 365 experiences, including Microsoft 365 Copilot. See [add Copilot and agent experiences](../build/agent-experiences.md). |
 | Recycle bin | Storage for soft-deleted files in a container, so users can restore items before permanent deletion. See [upload, download, and manage files](../build/manage-files.md). |
-| Container restore | Recovery of a deleted container within 93 days of deletion, before permanent removal. See [archive and restore containers](../build/archive-restore-containers.md). |
+| Content restore | Recovery of deleted content within 93 days of deletion, before permanent removal. See [archive and restore containers](../build/archive-restore-containers.md). |
 
 ## Related resources
 

--- a/docs/embedded/reference/glossary.md
+++ b/docs/embedded/reference/glossary.md
@@ -31,7 +31,10 @@ next: ../plan/choose-app-model.md
 | Standard billing | A billing model where consumption charges are billed to the tenant that owns or develops the application. See [choose a billing model](../plan/choose-billing-model.md). |
 | Pass-through (customer) billing | A billing model where consumption charges are billed directly to the consuming tenant registered to use the app. See [choose a billing model](../plan/choose-billing-model.md). |
 | Owning application | The Microsoft Entra ID application registration strongly coupled with a container type; each owning app can own one container type at a time. See [app architecture](../plan/app-tenant-architecture.md). |
-| Partition | The API-only SharePoint storage partition created in a consuming tenant for SharePoint Embedded app documents. See [SharePoint Embedded overview](../overview.md). |
+| Partition | The API-only SharePoint storage partition created in a consumer's Microsoft 365 tenant for SharePoint Embedded app documents. See [SharePoint Embedded overview](../overview.md). |
+| Content discoverability | A container type setting that controls whether content in its containers can surface in Microsoft 365 experiences, including Microsoft 365 Copilot. See [add Copilot and agent experiences](../build/agent-experiences.md). |
+| Recycle bin | Storage for soft-deleted files in a container, so users can restore items before permanent deletion. See [upload, download, and manage files](../build/manage-files.md). |
+| Container restore | Recovery of a deleted container within 93 days of deletion, before permanent removal. See [archive and restore containers](../build/archive-restore-containers.md). |
 
 ## Related resources
 

--- a/docs/embedded/scenarios-and-use-cases.md
+++ b/docs/embedded/scenarios-and-use-cases.md
@@ -31,7 +31,7 @@ You build a multitenant SaaS product, such as contract management for enterprise
 ### Why the usual approaches fall short
 
 - **Your own blob storage** puts customer data outside the customer's tenant, which enterprise IT rejects.
-- **Google Drive, Box, or Dropbox APIs** use per-seat licensing and give the customer's admin little policy control.
+- **Competing file storage APIs** use per-seat licensing and give the customer's admin little policy control.
 
 ### Why SharePoint Embedded
 

--- a/docs/embedded/scenarios-and-use-cases.md
+++ b/docs/embedded/scenarios-and-use-cases.md
@@ -1,12 +1,14 @@
 ---
-title: Scenarios and Use Cases
+title: Scenarios and use cases
 description: Common developer problems that SharePoint Embedded solves, from multitenant SaaS storage to Office co-authoring, AI grounding, and compliant document management.
-ms.date: 08/13/2026
+ms.date: 07/13/2026
 ms.reviewer: shsaravanan
 ms.localizationpriority: high
 ---
 
 # Scenarios and use cases for SharePoint Embedded
+
+**Applies to:** All
 
 <!-- agent:
 task_type: concept
@@ -24,7 +26,7 @@ Use these scenarios to decide whether SharePoint Embedded fits your app. Each on
 
 ### The problem
 
-You build a multitenant SaaS product, such as contract management for enterprise legal teams. Your biggest blocker is file storage. Enterprise customers won't accept their documents living in your storage. Their IT teams want to apply their own data loss prevention (DLP) and retention rules. You still need full control of the files from your app: create, read, organize, permission, and delete, all through APIs.
+You build a multitenant SaaS product, such as contract management for enterprise legal teams. Your biggest blocker is file storage. Enterprise customers won't accept their documents living in your storage. Their IT teams want to apply their own security and compliance policies, like data loss prevention (DLP) and retention rules. You still need full control of the files from your app: create, read, organize, permission, and delete, all through APIs.
 
 ### Why the usual approaches fall short
 
@@ -42,11 +44,11 @@ SharePoint Embedded stores each customer's files inside that customer's own Micr
 
 See [Choose an app model](plan/choose-app-model.md) and [Create and manage containers](build/create-manage-containers.md).
 
-## Scenario: Add Office editing and co-authoring to your app
+## Scenario: Add Office co-authoring to your app
 
 ### The problem
 
-You have a custom app, and your top feature request is "let me edit documents without leaving the app." Today you store files and hand out download links. Users want to open a Word or Excel file and co-author it in real time, with AutoSave and version history, plus sharing with an external person through a link.
+You have a custom app, and your top feature request is "let me edit Office documents the same way I'm used to." Today you store files and hand out download links. Perhaps you even use a Web Application Open Platform Interface (WOPI) host. But your users want to open a Word or Excel file and co-author it in real time, with AutoSave, version history, sharing, and all the features of Office for the web, Office Desktop, and Microsoft 365 for mobile.
 
 ### Why the usual approaches fall short
 
@@ -55,14 +57,16 @@ You have a custom app, and your top feature request is "let me edit documents wi
 
 ### Why SharePoint Embedded
 
-Store the files in a SharePoint Embedded container and open them through Office:
+Store the files in a SharePoint Embedded container and launch them in Office. Your app links to the same Office service Microsoft 365 uses, so you don't build a collaboration engine:
 
 - **Real-time co-authoring** in Office for the web and Office desktop clients.
 - **AutoSave** and **automatic version history** for Word, Excel, and PowerPoint.
-- **Sharing** through email invitations, shareable links, and @mentions.
+- **Sharing** through shareable links, plus @mentions for licensed users.
 - **Scoped access levels**: Anyone, People in your organization, Specific people, and People with existing access.
 
-See [Add Office editing without building it](plan/office-collaboration-instead-of-building.md) and [Open Office files from your app](build/open-office-files.md).
+Editing opens in Office, not inside your app: Office for the web opens in a new browser tab or window, and desktop clients open in their own app. To keep users in your app's UI, embed a read-only [file preview](build/preview-files.md); use Office launch for editing.
+
+See [Add Office co-authoring without building it](plan/office-collaboration-instead-of-building.md) and [Open Office files from your app](build/open-office-files.md).
 
 ## Scenario: Ground an AI agent on enterprise content
 
@@ -80,9 +84,9 @@ You build an internal "ask the knowledge base" agent over thousands of documents
 Store the documents in SharePoint Embedded containers and ground your agent in place:
 
 - Content **stays in the customer's Microsoft 365 tenant**.
-- **Content discoverability is a container-type setting** that controls whether Microsoft 365 Copilot can surface the content.
-- Retrieve content with the **Microsoft Search API**, scoped by `ContainerTypeId`, or a Microsoft Foundry knowledge source.
-- **Microsoft Purview** DLP, retention, and eDiscovery apply, and nothing is exposed to Copilot until you enable discoverability.
+- **Content discoverability is configurable for your app** and controls whether Microsoft 365 Copilot can surface the content.
+- Retrieve content with the **Microsoft Search API** or a Microsoft Foundry knowledge source, scoped to your app's content.
+- **Microsoft Purview** DLP, retention, and eDiscovery apply, and nothing is exposed to Copilot until discoverability is enabled.
 
 See [Ground AI without an external vector database](plan/ground-ai-without-a-vector-db.md) and [Set up SharePoint Embedded as a Foundry knowledge source](build/sharepoint-embedded-knowledge-source.md).
 
@@ -94,7 +98,7 @@ Your app collects documents from customers, inside or outside your organization,
 
 ### Why the usual approaches fall short
 
-- **Standard SharePoint sites** expose an interface users can browse, which you don't want.
+- **SharePoint Online sites** expose an interface users can browse, which you don't want.
 - **Blob storage** leaves you to build recycle bin, restore, search, and compliance yourself.
 
 ### Why SharePoint Embedded
@@ -102,7 +106,7 @@ Your app collects documents from customers, inside or outside your organization,
 SharePoint Embedded gives you an API-only document store with Microsoft 365 capabilities built in:
 
 - **API-only** through Microsoft Graph, with no SharePoint UI to bypass.
-- Full lifecycle: upload and download, folders, versioning, **recycle bin**, and **93-day container restore**.
+- Full lifecycle: upload and download, folders, versioning, **recycle bin**, and **93-day content restore**.
 - Content is searchable through the **Microsoft Search API** and **inherits the tenant's Microsoft Purview** compliance.
 - Your app's end users **don't need a Microsoft 365 license** for basic file operations.
 

--- a/docs/embedded/scenarios-and-use-cases.md
+++ b/docs/embedded/scenarios-and-use-cases.md
@@ -1,88 +1,116 @@
 ---
-title: Scenarios and use cases
-description: Explore scenarios and use cases for SharePoint Embedded.
-ms.date: 07/13/2026
-ms.reviewer: stpuceli
+title: Scenarios and Use Cases
+description: Common developer problems that SharePoint Embedded solves, from multitenant SaaS storage to Office co-authoring, AI grounding, and compliant document management.
+ms.date: 08/13/2026
+ms.reviewer: shsaravanan
 ms.localizationpriority: high
-ai-usage: ai-assisted
 ---
 
 # Scenarios and use cases for SharePoint Embedded
 
-**Applies to:** All
-
-Use these example scenarios to spark ideas for how your custom application can use SharePoint Embedded. Each scenario combines several features to solve a common content-management problem.
-
 <!-- agent:
 task_type: concept
 audience: all
-outcome: Understand common SharePoint Embedded scenarios and when they fit a custom application.
-next: overview.md
+outcome: The reader matches a real-world problem to a SharePoint Embedded scenario and understands why SharePoint Embedded fits better than common alternatives.
+next: plan/when-to-choose-sharepoint-embedded.md
 -->
 
+Use these scenarios to decide whether SharePoint Embedded fits your app. Each one starts with a problem developers actually face, shows why the usual approaches fall short, and explains why SharePoint Embedded is the right choice.
+
 > [!NOTE]
-> This article isn't an exhaustive list of SharePoint Embedded features and scenarios. Each scenario shows one way to combine features in context.
+> This article isn't an exhaustive list. Each scenario shows one way to combine SharePoint Embedded features to solve a common problem.
 
-## Scenario: Structured user experience
+## Scenario: Store files for a multitenant SaaS app
 
-### Description
+### The problem
 
-Choose this pattern when your application needs a guided experience. You want users to work in a structured way rather than in the flexible SharePoint Online interface.
+You build a multitenant SaaS product, such as contract management for enterprise legal teams. Your biggest blocker is file storage. Enterprise customers won't accept their documents living in your storage. Their IT teams want to apply their own data loss prevention (DLP) and retention rules. You still need full control of the files from your app: create, read, organize, permission, and delete, all through APIs.
 
-This pattern also suits business-critical or time-sensitive processes. SharePoint Embedded allocates dedicated resources, so you can manage throttling more easily.
+### Why the usual approaches fall short
 
-### Examples
+- **Your own blob storage** puts customer data outside the customer's tenant, which enterprise IT rejects.
+- **Google Drive, Box, or Dropbox APIs** use per-seat licensing and give the customer's admin little policy control.
 
-- Extended Relationship Management (XRM) applications for tracking external relationships and interactions
-- Engagement-based applications
-- Workflow-based collaboration with defined state
+### Why SharePoint Embedded
 
-### Why use SharePoint Embedded instead of SharePoint Online?
+SharePoint Embedded stores each customer's files inside that customer's own Microsoft 365 tenant, while your app keeps full programmatic control:
 
-- Your application is the only user interface, so you control the entire user experience.
-- Resources sit apart from your Microsoft 365 entitlements, which simplifies resource management.
+- Content lives in the **customer's Microsoft 365 tenant**, not yours.
+- Storage uses **File Storage Containers**, an API-only unit your app controls.
+- The API surface is **Microsoft Graph**; your app owns the entire user experience.
+- Content **inherits the customer tenant's Microsoft Purview** compliance, including DLP and retention.
 
-## Scenario: Highly controlled collaboration
+See [Choose an app model](plan/choose-app-model.md) and [Create and manage containers](build/create-manage-containers.md).
 
-### Description
+## Scenario: Add Office editing and co-authoring to your app
 
-When you build on SharePoint Online directly, a user with permissions can still open the underlying site without awareness from your application. Depending on their permission level, that user might change site settings or take other actions your application didn't intend. Those actions can have unintended consequences for your application or content.
+### The problem
 
-SharePoint Embedded is headless, so your custom application provides the only interface. If your application doesn't expose a way to change content or settings, a user can't bypass it through SharePoint Online. You decide which collaborative features, such as sharing, your application offers.
+You have a custom app, and your top feature request is "let me edit documents without leaving the app." Today you store files and hand out download links. Users want to open a Word or Excel file and co-author it in real time, with AutoSave and version history, plus sharing with an external person through a link.
 
-### Examples
+### Why the usual approaches fall short
 
-- Deal room applications
-- Shared research environments
+- **Building co-authoring yourself** with conflict-free replicated data types takes months and still lacks native Office rendering.
+- **A non-Microsoft collaboration engine** doesn't open `.docx`, `.xlsx`, and `.pptx` with full fidelity.
 
-### Why use SharePoint Embedded instead of SharePoint Online?
+### Why SharePoint Embedded
 
-- You need SharePoint's collaborative capabilities, but only through a highly customized interface.
-- You handle high-value content and want to limit who can discover or alter the repository.
-- Every container in the application can inherit default sharing settings that stay separate from your OneDrive and SharePoint Online settings.
-- Content stays logically separated from your other Microsoft 365 content.
+Store the files in a SharePoint Embedded container and open them through Office:
 
-## Scenario: Customer-facing document upload
+- **Real-time co-authoring** in Office for the web and Office desktop clients.
+- **AutoSave** and **automatic version history** for Word, Excel, and PowerPoint.
+- **Sharing** through email invitations, shareable links, and @mentions.
+- **Scoped access levels**: Anyone, People in your organization, Specific people, and People with existing access.
 
-### Description
+See [Add Office editing without building it](plan/office-collaboration-instead-of-building.md) and [Open Office files from your app](build/open-office-files.md).
 
-Your application serves an end customer, inside or outside your organization, who uploads a file as part of an interaction. You want a simple end-user experience plus the Microsoft 365 capabilities for document storage and compliance.
+## Scenario: Ground an AI agent on enterprise content
 
-SharePoint Embedded supports this scenario. The users of your application don't need access or entitlement to your Microsoft 365 tenant.
+### The problem
 
-### Examples
+You build an internal "ask the knowledge base" agent over thousands of documents spread across file shares and a legacy system. You want to consolidate them, make them searchable, and use them to ground a large language model. Your security team rejects copying everything into an external vector database, and the content must keep its retention and eDiscovery controls.
 
-- Attaching evidence to a mortgage application
-- Verifying an identity document
+### Why the usual approaches fall short
 
-### Why use SharePoint Embedded instead of SharePoint Online?
+- **An external vector database** moves content out of the tenant and breaks the compliance boundary.
+- **Blob storage plus a custom index** forces you to rebuild DLP, retention, and eDiscovery yourself.
 
-- You must segregate this data from the rest of your Microsoft 365 storage, yet keep it in scope for compliance tools like eDiscovery.
-- Users need no Microsoft 365 licensing, and you avoid adding external users to SharePoint Online.
-- Containers give you a simple, flexible unit of data storage.
+### Why SharePoint Embedded
+
+Store the documents in SharePoint Embedded containers and ground your agent in place:
+
+- Content **stays in the customer's Microsoft 365 tenant**.
+- **Content discoverability is a container-type setting** that controls whether Microsoft 365 Copilot can surface the content.
+- Retrieve content with the **Microsoft Search API**, scoped by `ContainerTypeId`, or a Microsoft Foundry knowledge source.
+- **Microsoft Purview** DLP, retention, and eDiscovery apply, and nothing is exposed to Copilot until you enable discoverability.
+
+See [Ground AI without an external vector database](plan/ground-ai-without-a-vector-db.md) and [Set up SharePoint Embedded as a Foundry knowledge source](build/sharepoint-embedded-knowledge-source.md).
+
+## Scenario: Run a compliant, API-only document store
+
+### The problem
+
+Your app collects documents from customers, inside or outside your organization, as part of a workflow. Examples include attaching evidence to a mortgage application or verifying an identity document. You want a simple upload experience plus Microsoft 365 storage and compliance, without giving users access to your tenant.
+
+### Why the usual approaches fall short
+
+- **Standard SharePoint sites** expose an interface users can browse, which you don't want.
+- **Blob storage** leaves you to build recycle bin, restore, search, and compliance yourself.
+
+### Why SharePoint Embedded
+
+SharePoint Embedded gives you an API-only document store with Microsoft 365 capabilities built in:
+
+- **API-only** through Microsoft Graph, with no SharePoint UI to bypass.
+- Full lifecycle: upload and download, folders, versioning, **recycle bin**, and **93-day container restore**.
+- Content is searchable through the **Microsoft Search API** and **inherits the tenant's Microsoft Purview** compliance.
+- Your app's end users **don't need a Microsoft 365 license** for basic file operations.
+
+See [Upload, download, and manage files](build/manage-files.md) and [Archive and restore containers](build/archive-restore-containers.md).
 
 ## Related content
 
 - [What is SharePoint Embedded?](overview.md)
+- [When to choose SharePoint Embedded](plan/when-to-choose-sharepoint-embedded.md)
 - [Understand app and tenant architecture](plan/app-tenant-architecture.md)
-- [Quickstart: build your first app with VS Code](build/quickstart-vscode.md)
+- [Quickstart: Build your first app with VS Code](build/quickstart-vscode.md)

--- a/docs/embedded/scenarios-and-use-cases.md
+++ b/docs/embedded/scenarios-and-use-cases.md
@@ -84,7 +84,7 @@ You build an internal "ask the knowledge base" agent over thousands of documents
 Store the documents in SharePoint Embedded containers and ground your agent in place:
 
 - Content **stays in the customer's Microsoft 365 tenant**.
-- **Content discoverability is a setting on the container type.** It governs whether SharePoint Embedded content surfaces in Microsoft 365 experiences, including Copilot. Tenant governance controls this setting, so an app can't expose content by changing its own configuration.
+- **Content discoverability is a setting on the [container type](plan/container-types-containers.md)** — the template that defines your app's containers. It governs whether SharePoint Embedded content surfaces in Microsoft 365 experiences, including Copilot. Tenant governance controls this setting, so an app can't expose content by changing its own configuration.
 - Retrieve content with the **Microsoft Search API**, scoped by the container type ID (`ContainerTypeId`), or with a Microsoft Foundry knowledge source.
 - **Microsoft Purview** data loss prevention (DLP), retention, and eDiscovery apply. Nothing is exposed to Copilot until discoverability is enabled on the container type.
 

--- a/docs/embedded/scenarios-and-use-cases.md
+++ b/docs/embedded/scenarios-and-use-cases.md
@@ -48,7 +48,7 @@ See [Choose an app model](plan/choose-app-model.md) and [Create and manage conta
 
 ### The problem
 
-You have a custom app, and your top feature request is "let me edit Office documents the same way I'm used to." Today you store files and hand out download links. Perhaps you even use a Web Application Open Platform Interface (WOPI) host. But your users want to open a Word or Excel file and co-author it in real time, with AutoSave, version history, sharing, and all the features of Office for the web, Office Desktop, and Microsoft 365 for mobile.
+You have a custom app, and your top feature request is "let me edit Office documents the same way I'm used to." Today you store files and hand out download links. Perhaps you even use a Web Application Open Platform Interface (WOPI) host. But your users want to open a Word or Excel file and co-author it in real time. They expect AutoSave, version history, and sharing, plus the full experience of Office for the web, Office desktop, and Microsoft 365 for mobile.
 
 ### Why the usual approaches fall short
 
@@ -64,7 +64,7 @@ Store the files in a SharePoint Embedded container and launch them in Office. Yo
 - **Sharing** through shareable links, plus @mentions for licensed users.
 - **Scoped access levels**: Anyone, People in your organization, Specific people, and People with existing access.
 
-Editing opens in Office, not inside your app: Office for the web opens in a new browser tab or window, and desktop clients open in their own app. To keep users in your app's UI, embed a read-only [file preview](build/preview-files.md); use Office launch for editing.
+Editing opens in Office, not inside your app. Office for the web opens in a new browser tab or window, and desktop clients open in their own app. To keep users in your app's UI, embed a read-only [file preview](build/preview-files.md); use Office launch for editing.
 
 See [Add Office co-authoring without building it](plan/office-collaboration-instead-of-building.md) and [Open Office files from your app](build/open-office-files.md).
 
@@ -84,9 +84,9 @@ You build an internal "ask the knowledge base" agent over thousands of documents
 Store the documents in SharePoint Embedded containers and ground your agent in place:
 
 - Content **stays in the customer's Microsoft 365 tenant**.
-- **Content discoverability is configurable for your app** and controls whether Microsoft 365 Copilot can surface the content.
-- Retrieve content with the **Microsoft Search API** or a Microsoft Foundry knowledge source, scoped to your app's content.
-- **Microsoft Purview** DLP, retention, and eDiscovery apply, and nothing is exposed to Copilot until discoverability is enabled.
+- **Content discoverability is a setting on the container type.** It governs whether SharePoint Embedded content surfaces in Microsoft 365 experiences, including Copilot. Tenant governance controls this setting, so an app can't expose content by changing its own configuration.
+- Retrieve content with the **Microsoft Search API**, scoped by the container type ID (`ContainerTypeId`), or with a Microsoft Foundry knowledge source.
+- **Microsoft Purview** data loss prevention (DLP), retention, and eDiscovery apply. Nothing is exposed to Copilot until discoverability is enabled on the container type.
 
 See [Ground AI without an external vector database](plan/ground-ai-without-a-vector-db.md) and [Set up SharePoint Embedded as a Foundry knowledge source](build/sharepoint-embedded-knowledge-source.md).
 
@@ -105,9 +105,11 @@ Your app collects documents from customers, inside or outside your organization,
 
 SharePoint Embedded gives you an API-only document store with Microsoft 365 capabilities built in:
 
-- **API-only** through Microsoft Graph, with no SharePoint UI to bypass.
-- Full lifecycle: upload and download, folders, versioning, **recycle bin**, and **93-day content restore**.
-- Content is searchable through the **Microsoft Search API** and **inherits the tenant's Microsoft Purview** compliance.
+- **API-only through Microsoft Graph**: every file and container operation uses Microsoft Graph, with no SharePoint UI for users to bypass.
+- **Full content lifecycle**: upload and download, folder structure, and versioning.
+- **Two-level soft delete**: deleted items go to a container recycle bin you can restore from, and deleted containers move to a deleted container collection that stays restorable for **93 days** before permanent purge.
+- **Search** through the **Microsoft Search API**, scoped to your app's containers.
+- **Microsoft Purview compliance** inherited from the consuming tenant: DLP, retention policies, sensitivity labels, and eDiscovery.
 - Your app's end users **don't need a Microsoft 365 license** for basic file operations.
 
 See [Upload, download, and manage files](build/manage-files.md) and [Archive and restore containers](build/archive-restore-containers.md).

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -630,7 +630,7 @@
       href: embedded/plan/security-compliance-governance.md
     - name: Understand limits and calling patterns
       href: embedded/plan/limits-calling-patterns.md
-    - name: Add Office editing without building it
+    - name: Add Office co-authoring without building it
       href: embedded/plan/office-collaboration-instead-of-building.md
     - name: Ground AI without an external vector database
       href: embedded/plan/ground-ai-without-a-vector-db.md

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -614,6 +614,8 @@
       href: embedded/whats-new.md
   - name: Plan a SharePoint Embedded solution
     items:
+    - name: When to choose SharePoint Embedded
+      href: embedded/plan/when-to-choose-sharepoint-embedded.md
     - name: Understand app and tenant architecture
       href: embedded/plan/app-tenant-architecture.md
     - name: 'Choose an app model: single-tenant or multitenant'
@@ -628,6 +630,10 @@
       href: embedded/plan/security-compliance-governance.md
     - name: Understand limits and calling patterns
       href: embedded/plan/limits-calling-patterns.md
+    - name: Add Office editing without building it
+      href: embedded/plan/office-collaboration-instead-of-building.md
+    - name: Ground AI without an external vector database
+      href: embedded/plan/ground-ai-without-a-vector-db.md
   - name: Build apps with SharePoint Embedded
     items:
     - name: 'Quickstart: Build your first app with VS Code'


### PR DESCRIPTION
## Summary

These changes lift the **LLM awareness** score (currently **45%, 0 of 4 scenarios pass**; target **90**) measured by the nightly `SPE-Awareness-Evals` suite. That eval asks a model — unaided, with web search — to solve four realistic developer problems that never name SharePoint Embedded (SPE), and scores how often it recommends SPE on its own and states the right facts.

The gap is **positioning at the front door**, not doc quality. This PR reframes the entry content around real problems, adds the missing "when to choose SPE / vs alternatives" content, and states the graded facts on the pages agents land on.

## Changes (8 recommendations)

| # | File | Change |
|---|---|---|
| R1 | `scenarios-and-use-cases.md` | Rewritten as **four problem-first scenarios** (multitenant SaaS storage, Office co-authoring, AI grounding, compliant API-only store), each: problem → why alternatives fall short → why SPE → the facts |
| R2 | `plan/when-to-choose-sharepoint-embedded.md` | **New** decision guide with comparison tables (vs Azure Blob, Google Drive/Box/Dropbox, standard SharePoint sites) |
| R3 | `plan/office-collaboration-instead-of-building.md`, `plan/ground-ai-without-a-vector-db.md` | **New** "don't build it" pages targeting the two weakest scenarios |
| R4 | `overview.md` | "Is SPE right for you?" router, AI/discoverability line, disambiguation note (not sites/SPFx/OneDrive/Blob) |
| R5 | `build/agent-experiences.md`, `build/sharepoint-embedded-knowledge-source.md` | State content-discoverability (container-type setting), Microsoft Search API (`ContainerTypeId`), Purview facts |
| R6 | `build/open-office-files.md` | Co-authoring, AutoSave, versioning, sharing stated up front |
| R7 | `build/manage-files.md`, `reference/glossary.md` | API-only, recycle bin, 93-day restore, no end-user license; new glossary terms |
| R8 | `llms.txt`, `toc.yml` | Value-first routing and TOC entries for the new plan pages |

## How to verify

Dispatch `create-spe-app-eval-daily.yml` (or `RunLocalEvaluation.ps1 -EvalFiles evals/SPE-Awareness-Evals.json`), 5 rounds × all models. Watch each scenario clear **70% (pass)** then **75% (strong)**; target overall **≥ 90, 4/4 pass**.

> Note: because the eval uses live web search, these changes move the score only after the pages are published to the public Learn site. Awareness is also shaped by SPE's broader footprint in model training data.

## Notes for reviewers

- All new and edited content follows the existing conventions: frontmatter, `**Applies to:**`, `<!-- agent: -->` metadata, sentence-case headings, active voice.
- No changes outside `docs/embedded/` and `docs/toc.yml`.
