### PR TITLE
Document how to restrict Office integration for SharePoint Embedded

### DIFF
--- a/docs/embedded/build/open-office-files.md
+++ b/docs/embedded/build/open-office-files.md
@@ -44,7 +44,16 @@ Supported experiences include:
 - Breadcrumbs in Office clients that associate a file with your app.
 
 > [!NOTE]
+> Office integration is enabled by default for SharePoint Embedded container types. Authorized users can open supported files in Office for the web and Office desktop clients, including through Office experiences outside your app's custom user interface. If your app requires file access to remain within app-controlled experiences, you can disable Office integration for the container type.
+
+> [!NOTE]
 > Documents stored in an archived container can't be viewed or accessed. Your app must handle the archived state by showing an appropriate error and guiding users on next steps, such as reactivating the container.
+
+## Control Office integration
+
+Office integration is enabled by default. To disable Office access for a container type, set the `isOfficeRestricted` property in `fileStorageContainerTypeSettings` to `true`. For the property definition and supported API surface, see [fileStorageContainerTypeSettings resource type](/graph/api/resources/filestoragecontainertypesettings?view=graph-rest-beta).
+
+When Office integration is disabled, users can't launch files from affected containers in Office for the web or Office desktop clients. Before enabling this restriction, make sure your app provides or directs users to an appropriate alternative experience for viewing or editing files.
 
 ## Prerequisites
 
@@ -247,6 +256,7 @@ Test each launch path:
 | Mentions don't find a user | Microsoft 365 license and tenant membership limitations. |
 | Breadcrumb doesn't look right | Container properties and Office update channel. |
 | Redirect returns to wrong route | `ApplicationRedirectUrl` and app route handling. |
+| Office for the web or an Office desktop client doesn't open the file | Confirm that Office integration isn't disabled for the container type through `isOfficeRestricted`, and then check the user's file permissions and the existing client-specific launch requirements. |
 
 ## Next steps
 

--- a/docs/embedded/build/open-office-files.md
+++ b/docs/embedded/build/open-office-files.md
@@ -51,7 +51,7 @@ Supported experiences include:
 
 ## Control Office integration
 
-Office integration is enabled by default. To disable Office access for a container type, set the `isOfficeRestricted` property in `fileStorageContainerTypeSettings` to `true`. For the property definition and supported API surface, see [fileStorageContainerTypeSettings resource type](/graph/api/resources/filestoragecontainertypesettings?view=graph-rest-beta).
+Office integration is enabled by default. To disable Office access for a container type, set the `isOfficeRestricted` property in `fileStorageContainerTypeSettings` to `true`. For the property definition and supported API surface, see [fileStorageContainerTypeSettings resource type](/graph/api/resources/filestoragecontainertypesettings?view=graph-rest-beta&preserve-view=true).
 
 When Office integration is disabled, users can't launch files from affected containers in Office for the web or Office desktop clients. Before enabling this restriction, make sure your app provides or directs users to an appropriate alternative experience for viewing or editing files.
 

--- a/docs/embedded/build/open-office-files.md
+++ b/docs/embedded/build/open-office-files.md
@@ -44,14 +44,26 @@ Supported experiences include:
 - Breadcrumbs in Office clients that associate a file with your app.
 
 > [!NOTE]
-> Office integration is enabled by default for SharePoint Embedded container types. Authorized users can open supported files in Office for the web and Office desktop clients, including through Office experiences outside your app's custom user interface. If your app requires file access to remain within app-controlled experiences, you can disable Office integration for the container type.
-
-> [!NOTE]
 > Documents stored in an archived container can't be viewed or accessed. Your app must handle the archived state by showing an appropriate error and guiding users on next steps, such as reactivating the container.
 
 ## Control Office integration
 
-Office integration is enabled by default. To disable Office access for a container type, set the `isOfficeRestricted` property in `fileStorageContainerTypeSettings` to `true`. For the property definition and supported API surface, see [fileStorageContainerTypeSettings resource type](/graph/api/resources/filestoragecontainertypesettings?view=graph-rest-beta&preserve-view=true).
+Office integration is enabled by default for SharePoint Embedded container types. Authorized users can open supported files in Office for the web and Office desktop clients, including through Office experiences outside your app's custom user interface. If your app requires file access to remain within app-controlled experiences, you can disable Office integration for the container type by setting the `isOfficeRestricted` property in `fileStorageContainerTypeSettings` to `true`.
+
+`isOfficeRestricted` is currently available only through the Microsoft Graph beta endpoint. It's not yet available in v1.0. For the property definition, see [fileStorageContainerTypeSettings resource type](/graph/api/resources/filestoragecontainertypesettings?view=graph-rest-beta&preserve-view=true).
+
+Set `settings.isOfficeRestricted` with the Microsoft Graph `PATCH /storage/fileStorage/containerTypes/{containerTypeId}` API against the beta endpoint.
+
+```http
+PATCH https://graph.microsoft.com/beta/storage/fileStorage/containerTypes/{containerTypeId}
+Content-Type: application/json
+
+{
+  "settings": {
+    "isOfficeRestricted": true
+  }
+}
+```
 
 When Office integration is disabled, users can't launch files from affected containers in Office for the web or Office desktop clients. Before enabling this restriction, make sure your app provides or directs users to an appropriate alternative experience for viewing or editing files.
 


### PR DESCRIPTION
## Summary

Updates the SharePoint Embedded Office-launch guidance to state that Office integration is enabled by default and to explain how developers can opt out by using the `isOfficeRestricted` container-type setting.

## Changes

- Clarifies that authorized users can open supported files through Office for the web and Office desktop clients outside an app's custom UI.
- Adds guidance for applications that require file access to remain within app-controlled experiences.
- Links to the beta Microsoft Graph `fileStorageContainerTypeSettings` reference for `isOfficeRestricted`.
- Explains at a high level that restricting Office integration removes Office web and desktop launch experiences.

## Validation

- Verified the public property name and behavior against the current beta Microsoft Graph API documentation.
- Confirmed all links and Learn Markdown formatting.