### PR TITLE
Fix invalid feedback_system value in docfx.json

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -42,7 +42,7 @@
       "ms.author": "vesaj",
       "author": "VesaJuvonen",
       "ms.topic": "article",
-      "feedback_system": "GitHub",
+      "feedback_system": "OpenSource",
       "feedback_github_repo": "SharePoint/sp-dev-docs",
       "feedback_product_url": "https://aka.ms/spdev-uservoice",
       "search.appverid": "MET150"


### PR DESCRIPTION
## Summary
Fixes the recurring OpenPublishing build warning on `docs/docfx.json`:

> Invalid value for `feedback_system`: `GitHub`. The value must be `Standard`, `OpenSource`, or `None`.

`GitHub` is a deprecated value. This repo collects docs feedback through GitHub Issues (`feedback_github_repo` is set to `SharePoint/sp-dev-docs`), so the correct modern value is **`OpenSource`**, which preserves the existing GitHub-Issues feedback behavior while clearing the warning.

## Change
- `docs/docfx.json` line 45: `"feedback_system": "GitHub"` → `"feedback_system": "OpenSource"`

## Not included (intentionally)
The build also reports two `ms.subservice` warnings on `general-development/**` and `spfx/**` (`sharepoint-framework` not valid with `ms.service: sharepoint-online`). Those are unrelated to this change and may be intentional, so I've left them for the SPFx doc owners to decide.

## Testing
Single global-metadata value change; no content or link changes. Feedback widget continues to route to GitHub Issues via the existing `feedback_github_repo`.
