### PR TITLE
Correct 'Edit all mode' behavior description for read-only fields in list forms

### DIFF
--- a/docs/declarative-customization/list-form-configuration.md
+++ b/docs/declarative-customization/list-form-configuration.md
@@ -290,7 +290,7 @@ The custom formatter ensures a consistent user experience:
 
 - New Item form: The read-only field will not be shown.
 - Edit form: The field is displayed without an editable textbox, similar to a Calculated Column.
-- Edit all mode: The field remains visible and uneditable.
+- Edit all mode: The read-only field will not be shown.
 
 The Save button works as expected — no accidental modifications to the read-only fields.
 


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## What's in this Pull Request?

Updated the description of the 'Edit all mode' behavior regarding read-only fields. The read-only field does not remain visible in 'Edit all mode' of the form.