### PR TITLE
Add @latest tag to npx command and update --toVersion value to ensure major.minor.patch semver format

### DIFF
--- a/docs/spfx/release-0.0.0.md.template
+++ b/docs/spfx/release-0.0.0.md.template
@@ -35,7 +35,7 @@ In the project's **package.json** file, identify all SPFx vTODO: {version-previo
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion TODO: {version-release} --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion TODO: {version-release} --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.0.0.md
+++ b/docs/spfx/release-1.0.0.md
@@ -34,7 +34,7 @@ In the project's **package.json** file, identify all SPFx pre-v1 packages. For e
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.0.0 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.0.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.1.0.md
+++ b/docs/spfx/release-1.1.0.md
@@ -34,7 +34,7 @@ In the project's **package.json** file, identify all SPFx v1.0 packages. For eac
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.1 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.1.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.10.0.md
+++ b/docs/spfx/release-1.10.0.md
@@ -34,7 +34,7 @@ In the project's **package.json** file, identify all SPFx v1.9.1 packages. For e
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.10.0 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.10.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.11.0.md
+++ b/docs/spfx/release-1.11.0.md
@@ -39,7 +39,7 @@ In the project's **package.json** file, identify all SPFx v1.10 packages. For ea
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.11.0 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.11.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.12.1.md
+++ b/docs/spfx/release-1.12.1.md
@@ -34,7 +34,7 @@ In the project's **package.json** file, identify all SPFx v1.11.0 packages. For 
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.12.1 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.12.1 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.13.0.md
+++ b/docs/spfx/release-1.13.0.md
@@ -34,7 +34,7 @@ In the project's **package.json** file, identify all SPFx v1.12.1 packages. For 
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.13 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.13.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.13.1.md
+++ b/docs/spfx/release-1.13.1.md
@@ -34,7 +34,7 @@ In the project's **package.json** file, identify all SPFx v1.13 packages. For ea
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.13.1 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.13.1 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.14.0.md
+++ b/docs/spfx/release-1.14.0.md
@@ -34,7 +34,7 @@ In the project's **package.json** file, identify all SPFx v1.13.1 packages. For 
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.14 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.14.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.15.0.md
+++ b/docs/spfx/release-1.15.0.md
@@ -42,7 +42,7 @@ In the project's **package.json** file, identify all SPFx v1.14 packages. For ea
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.15 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.15.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.15.2.md
+++ b/docs/spfx/release-1.15.2.md
@@ -42,7 +42,7 @@ In the project's **package.json** file, identify all SPFx v1.15.0 packages. For 
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.15.2 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.15.2 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.16.0.md
+++ b/docs/spfx/release-1.16.0.md
@@ -42,7 +42,7 @@ In the project's **package.json** file, identify all SPFx v1.15.2 packages. For 
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.16 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.16.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.16.1.md
+++ b/docs/spfx/release-1.16.1.md
@@ -42,7 +42,7 @@ In the project's **package.json** file, identify all SPFx v1.16 packages. For ea
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.16.1 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.16.1 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.17.0.md
+++ b/docs/spfx/release-1.17.0.md
@@ -42,7 +42,7 @@ In the project's **package.json** file, identify all SPFx v1.16.1 packages. For 
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.17 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.17.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.17.1.md
+++ b/docs/spfx/release-1.17.1.md
@@ -45,7 +45,7 @@ In the project's **package.json** file, identify all SPFx v1.17 packages. For ea
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.17.1 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.17.1 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.17.2.md
+++ b/docs/spfx/release-1.17.2.md
@@ -46,7 +46,7 @@ npm install @microsoft/generator-sharepoint@latest --global
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.17.2 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.17.2 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.17.3.md
+++ b/docs/spfx/release-1.17.3.md
@@ -46,7 +46,7 @@ npm install @microsoft/generator-sharepoint@latest --global
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.17.3 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.17.3 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.17.4.md
+++ b/docs/spfx/release-1.17.4.md
@@ -46,7 +46,7 @@ npm install @microsoft/generator-sharepoint@latest --global
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.17.4 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.17.4 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.18.0.md
+++ b/docs/spfx/release-1.18.0.md
@@ -42,7 +42,7 @@ In the project's **package.json** file, identify all SPFx v1.17.x packages. For 
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.18 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.18.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.18.1.md
+++ b/docs/spfx/release-1.18.1.md
@@ -42,7 +42,7 @@ In the project's **package.json** file, identify all SPFx packages. For each SPF
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.18.1 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.18.1 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.18.2.md
+++ b/docs/spfx/release-1.18.2.md
@@ -42,7 +42,7 @@ In the project's **package.json** file, identify all SPFx packages. For each SPF
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.18.2 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.18.2 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.19.0.md
+++ b/docs/spfx/release-1.19.0.md
@@ -42,7 +42,7 @@ In the project's **package.json** file, identify all SPFx v1.18.x packages. For 
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.19 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.19.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.20.0.md
+++ b/docs/spfx/release-1.20.0.md
@@ -42,7 +42,7 @@ In the project's **package.json** file, identify all SPFx v1.19 packages. For ea
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.20 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.20.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.21.0.md
+++ b/docs/spfx/release-1.21.0.md
@@ -45,7 +45,7 @@ In the project's **package.json** file, identify all SPFx v1.20 packages. For ea
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.21 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.21.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.21.1.md
+++ b/docs/spfx/release-1.21.1.md
@@ -45,7 +45,7 @@ In the project's **package.json** file, identify all SPFx v1.21 packages. For ea
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.21.1 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.21.1 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.22.0.md
+++ b/docs/spfx/release-1.22.0.md
@@ -31,7 +31,7 @@ npm install @microsoft/generator-sharepoint@latest --global
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.22.0 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.22.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.22.1.md
+++ b/docs/spfx/release-1.22.1.md
@@ -45,7 +45,7 @@ In the project's **package.json** file, identify all SPFx v1.22 packages. For ea
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.22.1 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.22.1 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.22.2.md
+++ b/docs/spfx/release-1.22.2.md
@@ -45,7 +45,7 @@ In the project's **package.json** file, identify all SPFx v1.22 packages. For ea
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.22.2 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.22.2 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.23.0.md
+++ b/docs/spfx/release-1.23.0.md
@@ -30,7 +30,7 @@ If you are upgrading from older than 1.22 version, please follow the upgrade ste
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.23.0 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.23.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.23.2.md
+++ b/docs/spfx/release-1.23.2.md
@@ -45,7 +45,7 @@ In the project's **package.json** file, identify all SPFx v1.23.0 packages. For 
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.23.2 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.23.2 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.3.0.md
+++ b/docs/spfx/release-1.3.0.md
@@ -34,7 +34,7 @@ In the project's **package.json** file, identify all SPFx v1.1 packages. For eac
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.3 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.3.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.4.0.md
+++ b/docs/spfx/release-1.4.0.md
@@ -32,7 +32,7 @@ In the project's **package.json** file, identify all SPFx v1.3 packages. For eac
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.4 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.4.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.4.1.md
+++ b/docs/spfx/release-1.4.1.md
@@ -32,7 +32,7 @@ In the project's **package.json** file, identify all SPFx v1.4 packages. For eac
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.4.1 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.4.1 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.5.0.md
+++ b/docs/spfx/release-1.5.0.md
@@ -55,7 +55,7 @@ Key changes are around the introduction of the new *plusbeta* model and many oth
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.5 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.5.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.5.1.md
+++ b/docs/spfx/release-1.5.1.md
@@ -34,7 +34,7 @@ In the project's **package.json** file, identify all SPFx v1.5 packages. For eac
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.5.1 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.5.1 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.6.0.md
+++ b/docs/spfx/release-1.6.0.md
@@ -37,7 +37,7 @@ In the project's **package.json** file, identify all SPFx v1.5.1 packages. For e
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.6 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.6.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.7.0.md
+++ b/docs/spfx/release-1.7.0.md
@@ -34,7 +34,7 @@ In the project's **package.json** file, identify all SPFx v1.6 packages. For eac
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.7 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.7.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.7.1.md
+++ b/docs/spfx/release-1.7.1.md
@@ -34,7 +34,7 @@ In the project's **package.json** file, identify all SPFx v1.7 packages. For eac
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.7.1 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.7.1 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.8.0.md
+++ b/docs/spfx/release-1.8.0.md
@@ -57,7 +57,7 @@ We'll release more updated documentation and guidance videos during upcoming day
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.8.0 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.8.0 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.8.1.md
+++ b/docs/spfx/release-1.8.1.md
@@ -34,7 +34,7 @@ In the project's **package.json** file, identify all SPFx v1.8.0 packages. For e
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.8.1 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.8.1 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.8.2.md
+++ b/docs/spfx/release-1.8.2.md
@@ -34,7 +34,7 @@ In the project's **package.json** file, identify all SPFx v1.8.1 packages. For e
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.8.2 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.8.2 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/release-1.9.1.md
+++ b/docs/spfx/release-1.9.1.md
@@ -34,7 +34,7 @@ In the project's **package.json** file, identify all SPFx v1.8.2 packages. For e
 > To upgrade this project, run:
 >
 > ```console
-> npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.9.1 --output md
+> npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.9.1 --output md
 > ```
 >
 > This analyzes your project and outputs all required changes, including a single script to apply them in one go.

--- a/docs/spfx/toolchain/migrate-gulptoolchain-hefttoolchain.md
+++ b/docs/spfx/toolchain/migrate-gulptoolchain-hefttoolchain.md
@@ -54,7 +54,7 @@ All `@microsoft/sp-*` packages in `dependencies` are updated to the target SPFx 
 Run the following command from the root of your project to generate a complete upgrade report:
 
 ```console
-npx -p @pnp/cli-microsoft365 m365 spfx project upgrade --toVersion 1.22.2 --output md
+npx -p @pnp/cli-microsoft365@latest m365 spfx project upgrade --toVersion 1.22.2 --output md
 ```
 
 The report lists every required change and includes a combined script at the end that applies all changes in a single execution. Review the report, then run the script to complete the migration.


### PR DESCRIPTION
## Summary

Pins the CLI for Microsoft 365 package to the `@latest` dist-tag in every documented `spfx project upgrade` command, and updates each release note's `--toVersion` argument to use the full `major.minor.patch` semver format.

## Why

When an agent runs `npx -p @pnp/cli-microsoft365 m365 spfx project upgrade` without a version specifier, npm's engine-based resolution can silently fall back to an old version that predates the current runtime's supported Node range. Adding the explicit `@latest` dist-tag gives npx a defined target instead of leaving it to resolve. See [Your agent just scaffolded a project from 2020](https://developer.microsoft.com/blog/your-agent-just-scaffolded-a-project-from-2020/).

Several release notes also used truncated `--toVersion` values (e.g. `1.14` instead of `1.14.0`). These now use the full semver matching each release.

## Changes

- Added `@latest` to `npx -p @pnp/cli-microsoft365 ...` across all release notes, the release note template, and the toolchain migration guide.
- Normalized `--toVersion` in each release note to full `major.minor.patch` semver.